### PR TITLE
#434 Fix WindowsAPICodePack References

### DIFF
--- a/TRRandomizerView/TRRandomizerView.csproj
+++ b/TRRandomizerView/TRRandomizerView.csproj
@@ -54,12 +54,10 @@
     <Reference Include="TRGE.Core">
       <HintPath>..\Deps\TRGE.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAPICodePack, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAPICodePack-Core.1.1.1\lib\Microsoft.WindowsAPICodePack.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.WindowsAPICodePack.Shell, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAPICodePack-Shell.1.1.1\lib\Microsoft.WindowsAPICodePack.Shell.dll</HintPath>
-    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="WindowsAPICodePack-Core" version="1.1.1" />
+    <PackageReference Include="WindowsAPICodePack-Shell" version="1.1.1" />
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Resources\arrows.png" />
@@ -95,6 +93,6 @@
     <Exec Command="rmdir /S /Q $(TargetDir)\Lib" />
   </Target>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="mkdir $(TargetDir)\Lib&#xD;&#xA;move /Y $(TargetDir)\*.dll $(TargetDir)\Lib&#xD;&#xA;move /Y $(TargetDir)\*.xml $(TargetDir)\Lib" />
+    <Exec Command="mkdir $(TargetDir)\Lib&#xD;&#xA;move /Y $(TargetDir)\*.dll $(TargetDir)\Lib" />
   </Target>
 </Project>

--- a/TRRandomizerView/packages.config
+++ b/TRRandomizerView/packages.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
-  <package id="WindowsAPICodePack-Core" version="1.1.1" targetFramework="net472" />
-  <package id="WindowsAPICodePack-Shell" version="1.1.1" targetFramework="net472" />
-</packages>


### PR DESCRIPTION
Ensures the WindowsAPICodePack are restored properly and not relying on local copies. Removes the redundant packages config file too.
Resolves #434.