### PR TITLE
#436 Create Build Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Build the solution
         run: |
           dotnet restore
+          dotnet test --filter 'FullyQualifiedName!~TRLevelReaderUnitTests'
           dotnet build TRRandomizerView -c Release -o build -a x86
           
       - name: Package the build
@@ -51,6 +52,7 @@ jobs:
       - name: Build the solution
         run: |
           dotnet restore
+          dotnet test --filter 'FullyQualifiedName!~TRLevelReaderUnitTests'
           dotnet build TRRandomizerView -c Release -o build -a x64
           
       - name: Package the build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  buildx86:
+    name: Build x86
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '6.0'
+          
+      - name: Build the solution
+        run: |
+          dotnet restore
+          dotnet build TRRandomizerView -c Release -o build -a x86
+          
+      - name: Package the build
+        run: |
+          cd build
+          dir
+          Compress-Archive -Path (Get-ChildItem -Exclude *.pdb) -DestinationPath TRRando-x86.zip
+          
+      - name: Upload the package
+        uses: actions/upload-artifact@v3
+        with:
+          name: TRRando-x86
+          path: build/TRRando-x86.zip
+          
+  buildx64:
+    name: Build x64
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '6.0'
+          
+      - name: Build the solution
+        run: |
+          dotnet restore
+          dotnet build TRRandomizerView -c Release -o build -a x64
+          
+      - name: Package the build
+        run: |
+          cd build
+          dir
+          Compress-Archive -Path (Get-ChildItem -Exclude *.pdb) -DestinationPath TRRando-x64.zip
+          
+      - name: Upload the package
+        uses: actions/upload-artifact@v3
+        with:
+          name: TRRando-x64
+          path: build/TRRando-x64.zip

--- a/TRRandomizerCore/Randomizers/TR2/TR2ItemRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR2/TR2ItemRandomizer.cs
@@ -148,8 +148,6 @@ namespace TRRandomizerCore.Randomizers
             {
                 TR2ScriptedLevel theDeck = Levels.Find(l => l.Is(TR2LevelNames.DECK));
 
-                Location loc = null;
-
                 // if The deck is included in levels I check if its after monastery 
                 if (theDeck != null)
                 {

--- a/TRRandomizerView/TRRandomizerView.csproj
+++ b/TRRandomizerView/TRRandomizerView.csproj
@@ -90,9 +90,9 @@
     <Resource Include="Resources\up.png" />
   </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-    <Exec Command="rmdir /S /Q $(TargetDir)\Lib" />
+    <Exec Command="rmdir /S /Q &quot;$(TargetDir)\Lib&quot;" />
   </Target>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="mkdir $(TargetDir)\Lib&#xD;&#xA;move /Y $(TargetDir)\*.dll $(TargetDir)\Lib" />
+    <Exec Command="mkdir &quot;$(TargetDir)\Lib&quot;&#xD;&#xA;move /Y &quot;$(TargetDir)\*.dll&quot; &quot;$(TargetDir)\Lib&quot;" />
   </Target>
 </Project>


### PR DESCRIPTION
The proof will be in the pudding with this one, but I've tested it on a private repository and it looks OK. I'll leave the issue open in case any tweaks are needed after it runs.

The change in `TR2ItemRandomizer` gets rid of a compiler warning (unused var, seems to have been introduced [here](https://github.com/LostArtefacts/TR-Rando/commit/d007cc93f1e162f29de8ad043ecf29d7ef68db94)) so the output should be clean, and the post build update is a guard in case `$(TargetDir)` contains spaces.

I also realised with the SDK update recently that we switched to x64 builds so I think going forward we should release both as it's been x86 up until now.

One issue I think is that the packages will be double-zipped, but when releasing we can stick to manual uploads for now. The main purpose of this is for easier QA testing.
https://github.com/actions/upload-artifact#zipped-artifact-downloads