### PR TITLE
TR1 Pushblock save/load issues

### DIFF
--- a/TRRandomizerCore/Resources/TR1/Environment/LEVEL3B.PHD-Environment.json
+++ b/TRRandomizerCore/Resources/TR1/Environment/LEVEL3B.PHD-Environment.json
@@ -2502,6 +2502,32 @@
       ],
       [
         {
+          "Comments": "Create a pushblock buffer room.",
+          "EMType": 126,
+          "Location": {
+            "X": 51200,
+            "Y": -512,
+            "Z": 37888
+          },
+          "LinkedLocation": {
+            "X": 49664,
+            "Y": 6656,
+            "Z": 43520,
+            "Room": 37
+          },
+          "Textures": {
+            "WallAlignment": 4
+          },
+          "AmbientLighting": 7487,
+          "DefaultVertex": {
+            "Lighting": 7616
+          },
+          "Lights": [],
+          "Height": 4,
+          "Width": 3,
+          "Depth": 3
+        },
+        {
           "Comments": "Make a trap/puzzle room off room 37.",
           "EMType": 126,
           "Tags": [
@@ -3479,6 +3505,21 @@
           }
         },
         {
+          "EMType": 83,
+          "Ceiling": {
+            "X": 52736,
+            "Y": -512,
+            "Z": 39424,
+            "Room": -3
+          },
+          "Floor": {
+            "X": 52736,
+            "Y": 512,
+            "Z": 39424,
+            "Room": -1
+          }
+        },
+        {
           "Comments": "Make visibility portals.",
           "EMType": 81,
           "Portals": [
@@ -4038,9 +4079,9 @@
           "Intensity": -1,
           "Location": {
             "X": 52736,
-            "Y": -512,
+            "Y": -1536,
             "Z": 39424,
-            "Room": -1
+            "Room": -3
           }
         },
         {

--- a/TRRandomizerCore/Resources/TR1/Environment/LEVEL7B.PHD-Environment.json
+++ b/TRRandomizerCore/Resources/TR1/Environment/LEVEL7B.PHD-Environment.json
@@ -3989,6 +3989,32 @@
       ],
       [
         {
+          "Comments": "Create a pushblock buffer room.",
+          "EMType": 126,
+          "Location": {
+            "X": 56320,
+            "Y": -20480,
+            "Z": 5120
+          },
+          "LinkedLocation": {
+            "X": 57856,
+            "Y": -3328,
+            "Z": 1536,
+            "Room": 19
+          },
+          "Textures": {
+            "WallAlignment": 4
+          },
+          "AmbientLighting": 7168,
+          "DefaultVertex": {
+            "Lighting": 7680
+          },
+          "Lights": [],
+          "Height": 4,
+          "Width": 3,
+          "Depth": 3
+        },
+        {
           "Comments": "Another variant of above.",
           "EMType": 126,
           "Tags": [
@@ -4392,6 +4418,21 @@
           }
         },
         {
+          "EMType": 83,
+          "Ceiling": {
+            "X": 57856,
+            "Y": -20480,
+            "Z": 6656,
+            "Room": -4
+          },
+          "Floor": {
+            "X": 57856,
+            "Y": -19456,
+            "Z": 6656,
+            "Room": -2
+          }
+        },
+        {
           "Comments": "Rotate some floor faces.",
           "EMType": 23,
           "Rotations": [
@@ -4558,9 +4599,9 @@
           "Intensity": -1,
           "Location": {
             "X": 57856,
-            "Y": -20480,
+            "Y": -21504,
             "Z": 6656,
-            "Room": -2
+            "Room": -4
           }
         },
         {


### PR DESCRIPTION
This fixes save/load floor height issues with pushblocks that drop from the air. There needs to be a buffer room for these cases in order to workaround the game changing the floor heights. This type of puzzle is only used in ToQ and ToT.

Resolves #445.