### PR TITLE
Amend Enemy Exclusions

### DIFF
--- a/TRRandomizerCore/Randomizers/TR1/TR1EnemyRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/TR1EnemyRandomizer.cs
@@ -196,8 +196,10 @@ namespace TRRandomizerCore.Randomizers
             }
             List<TREntities> newEntities = new List<TREntities>(enemyCount);
 
-            // Do we need at least one water creature?
-            bool waterEnemyRequired = TR1EntityUtilities.GetWaterEnemies().Any(e => oldEntities.Contains(e));
+            // TR1 doesn't kill land creatures when underwater, so if "no restrictions" is
+            // enabled, don't enforce any by default.
+            bool waterEnemyRequired = difficulty == RandoDifficulty.Default
+                && TR1EntityUtilities.GetWaterEnemies().Any(oldEntities.Contains);
 
             // Let's try to populate the list. Start by adding a water enemy if needed.
             if (waterEnemyRequired)
@@ -515,7 +517,7 @@ namespace TRRandomizerCore.Randomizers
                 }
 
                 List<TREntities> enemyPool;
-                if (IsEnemyInOrAboveWater(currentEntity, level.Data, floorData))
+                if (difficulty == RandoDifficulty.Default && IsEnemyInOrAboveWater(currentEntity, level.Data, floorData))
                 {
                     // Make sure we replace with another water enemy
                     enemyPool = enemies.Water;

--- a/TRRandomizerCore/Randomizers/TR2/TR2EnemyRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR2/TR2EnemyRandomizer.cs
@@ -236,7 +236,8 @@ namespace TRRandomizerCore.Randomizers
                 }
 
                 // Get all other candidate supported enemies
-                List<TR2Entities> allEnemies = TR2EntityUtilities.GetCandidateCrossLevelEnemies().FindAll(e => TR2EnemyUtilities.IsEnemySupported(level.Name, e, difficulty));
+                List<TR2Entities> allEnemies = TR2EntityUtilities.GetCandidateCrossLevelEnemies()
+                    .FindAll(e => TR2EnemyUtilities.IsEnemySupported(level.Name, e, difficulty, Settings.ProtectMonks));
                 if (Settings.OneEnemyMode || Settings.IncludedEnemies.Count < newEntities.Capacity || Settings.DragonSpawnType == DragonSpawnType.Minimum)
                 {
                     // Marco isn't excludable in his own right because supporting a dragon-only game is impossible.
@@ -263,7 +264,7 @@ namespace TRRandomizerCore.Randomizers
                     // Try to enforce Marco's appearance, but only if this isn't the final packing attempt
                     if (Settings.DragonSpawnType == DragonSpawnType.Maximum
                         && !newEntities.Contains(TR2Entities.MarcoBartoli)
-                        && TR2EnemyUtilities.IsEnemySupported(level.Name, TR2Entities.MarcoBartoli, difficulty)
+                        && TR2EnemyUtilities.IsEnemySupported(level.Name, TR2Entities.MarcoBartoli, difficulty, Settings.ProtectMonks)
                         && reduceEnemyCountBy == 0)
                     {
                         entity = TR2Entities.MarcoBartoli;
@@ -378,7 +379,7 @@ namespace TRRandomizerCore.Randomizers
                     }
                     while ((_excludedEnemies.Contains(fallbackEnemy) && pool.Any(e => !_excludedEnemies.Contains(e))) 
                     || newEntities.Contains(fallbackEnemy) 
-                    || !TR2EnemyUtilities.IsEnemySupported(level.Name, fallbackEnemy, difficulty));
+                    || !TR2EnemyUtilities.IsEnemySupported(level.Name, fallbackEnemy, difficulty, Settings.ProtectMonks));
                     newEntities.Add(fallbackEnemy);
                 }
                 while (newEntities.All(e => restrictedRoomEnemies.ContainsKey(e)));
@@ -415,7 +416,7 @@ namespace TRRandomizerCore.Randomizers
 
         private TR2Entities SelectRequiredEnemy(List<TR2Entities> pool, TR2CombinedLevel level, RandoDifficulty difficulty)
         {
-            pool.RemoveAll(e => !TR2EnemyUtilities.IsEnemySupported(level.Name, e, difficulty));
+            pool.RemoveAll(e => !TR2EnemyUtilities.IsEnemySupported(level.Name, e, difficulty, Settings.ProtectMonks));
 
             TR2Entities entity;
             if (pool.All(_excludedEnemies.Contains))

--- a/TRRandomizerCore/Utilities/TR2EnemyUtilities.cs
+++ b/TRRandomizerCore/Utilities/TR2EnemyUtilities.cs
@@ -95,8 +95,15 @@ namespace TRRandomizerCore.Utilities
             return false;
         }
 
-        public static bool IsEnemySupported(string lvlName, TR2Entities entity, RandoDifficulty difficulty)
+        public static bool IsEnemySupported(string lvlName, TR2Entities entity, RandoDifficulty difficulty, bool protectMonks)
         {
+            if (lvlName == TR2LevelNames.HOME && TR2EntityUtilities.IsMonk(entity))
+            {
+                // Monks are excluded from HSH by default unless the player is happy
+                // with having to kill them.
+                return !protectMonks;
+            }
+
             bool isEnemyTechnicallySupported = IsEnemySupported(lvlName, entity, _unsupportedEnemiesTechnical);
             bool isEnemySupported = isEnemyTechnicallySupported;
 


### PR DESCRIPTION
This allows land enemies to appear underwater in `No Restrictions` mode in TR1; this was always intended but the logic was forcing water creatures to always be selected if originally present. TR1 doesn't kill land creatures underwater, unlike TR2 onwards.

This also fixes monks only appearing in HSH alongside other enemies. If all enemies except monks are excluded and the option to protect monks is disabled, they will now appear on their own in HSH.

Resolves #451.