### PR TITLE
TR3 Fix Monkey Vehicle Crash

### DIFF
--- a/TRLevelReader/Helpers/TR3EntityUtilities.cs
+++ b/TRLevelReader/Helpers/TR3EntityUtilities.cs
@@ -364,6 +364,7 @@ namespace TRLevelReader.Helpers
             return entityType == TR3Entities.Quad
                 || entityType == TR3Entities.Kayak
                 || entityType == TR3Entities.UPV
+                || entityType == TR3Entities.Boat
                 || entityType == TR3Entities.MineCart;
         }
 

--- a/TRLevelReader/Helpers/TR3EntityUtilities.cs
+++ b/TRLevelReader/Helpers/TR3EntityUtilities.cs
@@ -359,6 +359,14 @@ namespace TRLevelReader.Helpers
                 || IsArtefactPickup(entity);
         }
 
+        public static bool IsVehicleType(TR3Entities entityType)
+        {
+            return entityType == TR3Entities.Quad
+                || entityType == TR3Entities.Kayak
+                || entityType == TR3Entities.UPV
+                || entityType == TR3Entities.MineCart;
+        }
+
         public static List<TR3Entities> GetCandidateCrossLevelEnemies()
         {
             return new List<TR3Entities>

--- a/TRRandomizerCore/Levels/TR3CombinedLevel.cs
+++ b/TRRandomizerCore/Levels/TR3CombinedLevel.cs
@@ -1,6 +1,9 @@
-﻿using TRGE.Core;
+﻿using System.Collections.Generic;
+using System.Linq;
+using TRGE.Core;
 using TRLevelReader.Helpers;
 using TRLevelReader.Model;
+using TRLevelReader.Model.Enums;
 
 namespace TRRandomizerCore.Levels
 {
@@ -87,6 +90,8 @@ namespace TRRandomizerCore.Levels
         /// </summary>
         public bool HasSecrets => Script.NumSecrets > 0;
 
+        public bool HasVehicle => Data.Entities.Any(e => TR3EntityUtilities.IsVehicleType((TR3Entities)e.TypeID));
+
         /// <summary>
         /// Get the adventure based on this level's name.
         /// </summary>
@@ -112,6 +117,17 @@ namespace TRRandomizerCore.Levels
                 }
 
                 return TR3Adventure.India;
+            }
+        }
+
+        public void RemoveModel(TR3Entities type)
+        {
+            List<TRModel> models = Data.Models.ToList();
+            if (models.Find(m => m.ID == (uint)type) is TRModel model)
+            {
+                models.Remove(model);
+                Data.Models = models.ToArray();
+                Data.NumModels--;
             }
         }
     }

--- a/TRRandomizerCore/Processors/TR3/TR3SequenceProcessor.cs
+++ b/TRRandomizerCore/Processors/TR3/TR3SequenceProcessor.cs
@@ -191,6 +191,18 @@ namespace TRRandomizerCore.Processors
             {
                 quad.TypeID = (short)TR3Entities.UPV;
             }
+
+            // If we're not randomizing enemies, we have to perform the monkey/tiger/vehicle crash
+            // test here for the likes of Jungle.
+            if (!Settings.RandomizeEnemies
+                && level.Data.Entities.Any(e => e.TypeID == (short)TR3Entities.Monkey)
+                && level.Data.Models.Any(m => m.ID == (uint)TR3Entities.Tiger))
+            {
+                level.RemoveModel(TR3Entities.Tiger);
+                level.Data.Entities.Where(e => e.TypeID == (short)TR3Entities.Tiger)
+                    .ToList()
+                    .ForEach(e => e.TypeID = (short)TR3Entities.Monkey);
+            }
         }
 
         private void AmendAntarctica(TR3CombinedLevel level)


### PR DESCRIPTION
Various monkey-tiger-vehicle crash workarounds.

Cross-level enemy rando:
- If monkeys are picked first in the enemy pool and a vehicle is present, tigers will never be picked
- If tigers are picked first in the enemy pool and a vehicle is present, monkeys will never be picked

Native enemy rando:
- If a vehicle and the monkey and tiger models are present, either the monkey or tiger model will be banished (only Jungle affected essentially)

No enemy rando:
- If a UPV has been added to cold water levels (if sequencing or weather is being randomized), an additional check will ensure tigers are removed where monkeys exist (so again, only Jungle affected)

Resolves #466.