### PR TITLE
TR3 - Reformat key items JSON

### DIFF
--- a/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
+++ b/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
@@ -1583,10 +1583,6 @@
       "Y": -19200,
       "Z": 48568,
       "Room": 2,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21225
     },
     {
@@ -1594,10 +1590,6 @@
       "Y": -19200,
       "Z": 43500,
       "Room": 2,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21225
     },
     {
@@ -1605,10 +1597,6 @@
       "Y": -19200,
       "Z": 48596,
       "Room": 2,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21225
     },
     {
@@ -1616,10 +1604,6 @@
       "Y": -19200,
       "Z": 54784,
       "Room": 2,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21225
     },
     {
@@ -1627,10 +1611,6 @@
       "Y": -19200,
       "Z": 48640,
       "Room": 2,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21225
     },
     {
@@ -1638,10 +1618,6 @@
       "Y": -19200,
       "Z": 42481,
       "Room": 2,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21225
     },
     {
@@ -1649,10 +1625,6 @@
       "Y": -19200,
       "Z": 42545,
       "Room": 2,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21225
     },
     {
@@ -1660,10 +1632,6 @@
       "Y": -19200,
       "Z": 54749,
       "Room": 2,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21225
     },
     {
@@ -1671,10 +1639,6 @@
       "Y": -19200,
       "Z": 54771,
       "Room": 2,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21225
     },
     {
@@ -1682,10 +1646,6 @@
       "Y": -13312,
       "Z": 55808,
       "Room": 140,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21225
     },
     {
@@ -1693,10 +1653,6 @@
       "Y": -18176,
       "Z": 41452,
       "Room": 106,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21225
     },
     {
@@ -1704,10 +1660,6 @@
       "Y": -18176,
       "Z": 38432,
       "Room": 106,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21225
     },
     {
@@ -1715,10 +1667,6 @@
       "Y": -20224,
       "Z": 34307,
       "Room": 112,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21225
     },
     {
@@ -1726,10 +1674,6 @@
       "Y": -19200,
       "Z": 35310,
       "Room": 112,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21225
     },
     {
@@ -1737,10 +1681,6 @@
       "Y": -19200,
       "Z": 35366,
       "Room": 112,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21225
     },
     {
@@ -1748,10 +1688,6 @@
       "Y": -15104,
       "Z": 41472,
       "Room": 108,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21225
     },
     {
@@ -1759,10 +1695,6 @@
       "Y": -19200,
       "Z": 26179,
       "Room": 112,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21225
     },
     {
@@ -1770,10 +1702,6 @@
       "Y": -15104,
       "Z": 53760,
       "Room": 158,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21396
     },
     {
@@ -1781,10 +1709,6 @@
       "Y": -15104,
       "Z": 53760,
       "Room": 158,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21396
     },
     {
@@ -1792,10 +1716,6 @@
       "Y": -8704,
       "Z": 47616,
       "Room": 174,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21396
     },
     {
@@ -1803,10 +1723,6 @@
       "Y": -8704,
       "Z": 50688,
       "Room": 174,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21396
     },
     {
@@ -1814,10 +1730,6 @@
       "Y": -12032,
       "Z": 50688,
       "Room": 173,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21396
     },
     {
@@ -1825,10 +1737,6 @@
       "Y": -8704,
       "Z": 47616,
       "Room": 174,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21396
     },
     {
@@ -1836,10 +1744,6 @@
       "Y": -13824,
       "Z": 46592,
       "Room": 156,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21396
     },
     {
@@ -1847,10 +1751,6 @@
       "Y": -13824,
       "Z": 46592,
       "Room": 156,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21396
     },
     {
@@ -1858,10 +1758,6 @@
       "Y": -14848,
       "Z": 45568,
       "Room": 95,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21396
     },
     {
@@ -1869,10 +1765,6 @@
       "Y": -12288,
       "Z": 45541,
       "Room": 96,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21396
     },
     {
@@ -1880,10 +1772,6 @@
       "Y": -13568,
       "Z": 41486,
       "Room": 96,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21396
     },
     {
@@ -1891,10 +1779,6 @@
       "Y": -13568,
       "Z": 41496,
       "Room": 96,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21396
     },
     {
@@ -1902,10 +1786,6 @@
       "Y": -17792,
       "Z": 45568,
       "Room": 86,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21396
     },
     {
@@ -1913,10 +1793,6 @@
       "Y": -16384,
       "Z": 41387,
       "Room": 86,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21396
     },
     {
@@ -1924,10 +1800,6 @@
       "Y": -16520,
       "Z": 42493,
       "Room": 86,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21396
     },
     {
@@ -1935,10 +1807,6 @@
       "Y": -17926,
       "Z": 45591,
       "Room": 86,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 21396
     }
   ],

--- a/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
+++ b/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
@@ -956,10 +956,6 @@
       "Y": 3119,
       "Z": 93791,
       "Room": 130,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17222
     },
     {
@@ -967,10 +963,6 @@
       "Y": 2560,
       "Z": 91662,
       "Room": 164,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17222
     },
     {
@@ -978,10 +970,6 @@
       "Y": 2432,
       "Z": 93696,
       "Room": 53,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17222
     },
     {
@@ -989,10 +977,6 @@
       "Y": -1024,
       "Z": 89647,
       "Room": 120,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17222
     },
     {
@@ -1000,10 +984,6 @@
       "Y": -1024,
       "Z": 89553,
       "Room": 121,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17222
     },
     {
@@ -1011,10 +991,6 @@
       "Y": -2304,
       "Z": 94720,
       "Room": 127,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17222
     },
     {
@@ -1022,10 +998,6 @@
       "Y": -2560,
       "Z": 91648,
       "Room": 134,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17222
     },
     {
@@ -1033,10 +1005,6 @@
       "Y": -768,
       "Z": 91133,
       "Room": 121,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17222
     },
     {
@@ -1044,10 +1012,6 @@
       "Y": -773,
       "Z": 90655,
       "Room": 120,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17222
     },
     {
@@ -1055,10 +1019,6 @@
       "Y": 1789,
       "Z": 91735,
       "Room": 135,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17222
     },
     {
@@ -1066,10 +1026,6 @@
       "Y": -4096,
       "Z": 87525,
       "Room": 121,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17326
     },
     {
@@ -1077,10 +1033,6 @@
       "Y": -5616,
       "Z": 87583,
       "Room": 120,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17326
     },
     {
@@ -1088,10 +1040,6 @@
       "Y": -4352,
       "Z": 88496,
       "Room": 120,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17326
     },
     {
@@ -1099,10 +1047,6 @@
       "Y": -4217,
       "Z": 87576,
       "Room": 121,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17326
     },
     {
@@ -1110,10 +1054,6 @@
       "Y": -6400,
       "Z": 86528,
       "Room": 123,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17326
     },
     {
@@ -1121,10 +1061,6 @@
       "Y": -7424,
       "Z": 84480,
       "Room": 178,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17326
     },
     {
@@ -1132,10 +1068,6 @@
       "Y": -2048,
       "Z": 89600,
       "Room": 119,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17326
     },
     {
@@ -1143,10 +1075,6 @@
       "Y": -1020,
       "Z": 92691,
       "Room": 119,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17326
     },
     {
@@ -1154,10 +1082,6 @@
       "Y": -384,
       "Z": 78336,
       "Room": 14,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17326
     },
     {
@@ -1165,10 +1089,6 @@
       "Y": -6866,
       "Z": 86505,
       "Room": 122,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17329
     },
     {
@@ -1176,10 +1096,6 @@
       "Y": -6019,
       "Z": 85516,
       "Room": 122,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17329
     },
     {
@@ -1187,10 +1103,6 @@
       "Y": -5888,
       "Z": 88511,
       "Room": 122,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17329
     },
     {
@@ -1198,10 +1110,6 @@
       "Y": -5888,
       "Z": 88620,
       "Room": 122,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17329
     },
     {
@@ -1209,10 +1117,6 @@
       "Y": -5888,
       "Z": 90422,
       "Room": 122,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17329
     },
     {
@@ -1220,10 +1124,6 @@
       "Y": -6784,
       "Z": 92672,
       "Room": 123,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17329
     },
     {
@@ -1231,10 +1131,6 @@
       "Y": -256,
       "Z": 79425,
       "Room": 14,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17329
     },
     {
@@ -1242,10 +1138,6 @@
       "Y": -256,
       "Z": 79586,
       "Room": 14,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17329
     },
     {
@@ -1253,10 +1145,6 @@
       "Y": -1024,
       "Z": 81705,
       "Room": 14,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17329
     },
     {
@@ -1264,10 +1152,6 @@
       "Y": -1792,
       "Z": 80384,
       "Room": 14,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17329
     },
     {
@@ -1275,10 +1159,6 @@
       "Y": 1666,
       "Z": 17914,
       "Room": 7,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17231
     },
     {
@@ -1286,10 +1166,6 @@
       "Y": -1280,
       "Z": 26112,
       "Room": 3,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17231
     },
     {
@@ -1297,10 +1173,6 @@
       "Y": -128,
       "Z": 25090,
       "Room": 3,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17231
     },
     {
@@ -1308,10 +1180,6 @@
       "Y": 3318,
       "Z": 29658,
       "Room": 7,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17231
     },
     {
@@ -1319,10 +1187,6 @@
       "Y": 2048,
       "Z": 30190,
       "Room": 7,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17231
     },
     {
@@ -1330,10 +1194,6 @@
       "Y": -249,
       "Z": 36837,
       "Room": 173,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17231
     },
     {
@@ -1341,10 +1201,6 @@
       "Y": -201,
       "Z": 36065,
       "Room": 0,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17231
     },
     {
@@ -1352,10 +1208,6 @@
       "Y": -428,
       "Z": 43902,
       "Room": 173,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17231
     },
     {
@@ -1363,10 +1215,6 @@
       "Y": -450,
       "Z": 45834,
       "Room": 2,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17231
     },
     {
@@ -1374,10 +1222,6 @@
       "Y": -436,
       "Z": 46801,
       "Room": 2,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17231
     },
     {
@@ -1385,10 +1229,6 @@
       "Y": -179,
       "Z": 45274,
       "Room": 2,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17231
     },
     {
@@ -1396,10 +1236,6 @@
       "Y": 645,
       "Z": 41524,
       "Room": 5,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17231
     },
     {
@@ -1407,10 +1243,6 @@
       "Y": 2304,
       "Z": 36839,
       "Room": 5,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17231
     },
     {
@@ -1418,10 +1250,6 @@
       "Y": -555,
       "Z": 38393,
       "Room": 2,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 17231
     }
   ],

--- a/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
+++ b/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
@@ -2632,10 +2632,6 @@
       "Y": -3328,
       "Z": 61952,
       "Room": 78,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14294
     },
     {
@@ -2643,10 +2639,6 @@
       "Y": -3200,
       "Z": 61952,
       "Room": 43,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14294
     },
     {
@@ -2654,10 +2646,6 @@
       "Y": -3328,
       "Z": 57931,
       "Room": 47,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14294
     },
     {
@@ -2665,10 +2653,6 @@
       "Y": -3328,
       "Z": 53760,
       "Room": 48,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14294
     },
     {
@@ -2676,10 +2660,6 @@
       "Y": -3328,
       "Z": 62998,
       "Room": 130,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14294
     },
     {
@@ -2687,10 +2667,6 @@
       "Y": -3328,
       "Z": 50686,
       "Room": 48,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14294
     },
     {
@@ -2698,10 +2674,6 @@
       "Y": -3200,
       "Z": 46437,
       "Room": 41,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14294
     },
     {
@@ -2709,10 +2681,6 @@
       "Y": -3200,
       "Z": 43519,
       "Room": 41,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14294
     },
     {
@@ -2720,10 +2688,6 @@
       "Y": -3328,
       "Z": 42548,
       "Room": 37,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14294
     },
     {
@@ -2731,10 +2695,6 @@
       "Y": -8704,
       "Z": 74221,
       "Room": 107,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14294
     },
     {
@@ -2742,10 +2702,6 @@
       "Y": -10240,
       "Z": 76258,
       "Room": 65,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14294
     },
     {
@@ -2753,10 +2709,6 @@
       "Y": -10240,
       "Z": 73167,
       "Room": 65,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14294
     },
     {
@@ -2764,10 +2716,6 @@
       "Y": -9728,
       "Z": 78370,
       "Room": 65,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14294
     },
     {
@@ -2775,10 +2723,6 @@
       "Y": -9728,
       "Z": 74240,
       "Room": 65,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14294
     },
     {
@@ -2786,10 +2730,6 @@
       "Y": -9728,
       "Z": 68136,
       "Room": 65,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14294
     },
     {
@@ -2797,10 +2737,6 @@
       "Y": -12800,
       "Z": 86511,
       "Room": 119,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14294
     },
     {
@@ -2808,10 +2744,6 @@
       "Y": -6695,
       "Z": 56875,
       "Room": 179,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14294
     },
     {
@@ -2819,10 +2751,6 @@
       "Y": -5376,
       "Z": 78332,
       "Room": 111,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14294
     },
     {
@@ -2830,10 +2758,6 @@
       "Y": -3199,
       "Z": 42495,
       "Room": 30,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14294
     },
     {
@@ -2841,10 +2765,6 @@
       "Y": -3840,
       "Z": 43520,
       "Room": 30,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14294
     },
     {
@@ -2852,10 +2772,6 @@
       "Y": -4096,
       "Z": 44544,
       "Room": 35,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14294
     },
     {
@@ -2863,10 +2779,6 @@
       "Y": 2304,
       "Z": 51712,
       "Room": 33,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14294
     },
     {
@@ -2874,10 +2786,6 @@
       "Y": 7936,
       "Z": 43520,
       "Room": 31,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14294
     },
     {
@@ -2885,10 +2793,6 @@
       "Y": 8704,
       "Z": 42496,
       "Room": 40,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14294
     },
     {
@@ -2896,10 +2800,6 @@
       "Y": 9472,
       "Z": 39424,
       "Room": 40,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14294
     },
     {
@@ -2907,10 +2807,6 @@
       "Y": -128,
       "Z": 60928,
       "Room": 174,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14294
     },
     {
@@ -2918,10 +2814,6 @@
       "Y": -5888,
       "Z": 79358,
       "Room": 154,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14378
     },
     {
@@ -2929,10 +2821,6 @@
       "Y": -5888,
       "Z": 74265,
       "Room": 154,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14378
     },
     {
@@ -2940,10 +2828,6 @@
       "Y": -2816,
       "Z": 80362,
       "Room": 151,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14378
     },
     {
@@ -2951,10 +2835,6 @@
       "Y": -2943,
       "Z": 71168,
       "Room": 149,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14378
     },
     {
@@ -2962,10 +2842,6 @@
       "Y": -2816,
       "Z": 68096,
       "Room": 115,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14378
     },
     {
@@ -2973,10 +2849,6 @@
       "Y": -2816,
       "Z": 62976,
       "Room": 114,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14378
     },
     {
@@ -2984,10 +2856,6 @@
       "Y": -2935,
       "Z": 63967,
       "Room": 114,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14378
     },
     {
@@ -2995,10 +2863,6 @@
       "Y": -3072,
       "Z": 65041,
       "Room": 113,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14378
     },
     {
@@ -3006,10 +2870,6 @@
       "Y": -3072,
       "Z": 65031,
       "Room": 113,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14378
     },
     {
@@ -3017,10 +2877,6 @@
       "Y": -3072,
       "Z": 66048,
       "Room": 113,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14378
     },
     {
@@ -3028,10 +2884,6 @@
       "Y": -3072,
       "Z": 69120,
       "Room": 113,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14378
     },
     {
@@ -3039,10 +2891,6 @@
       "Y": -3072,
       "Z": 77312,
       "Room": 156,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14378
     },
     {
@@ -3050,10 +2898,6 @@
       "Y": -2816,
       "Z": 73239,
       "Room": 152,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14378
     },
     {
@@ -3061,10 +2905,6 @@
       "Y": 0,
       "Z": 69120,
       "Room": 148,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14378
     },
     {
@@ -3072,10 +2912,6 @@
       "Y": 0,
       "Z": 68096,
       "Room": 148,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14378
     },
     {
@@ -3083,10 +2919,6 @@
       "Y": 0,
       "Z": 78323,
       "Room": 144,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14378
     },
     {
@@ -3094,10 +2926,6 @@
       "Y": 0,
       "Z": 77133,
       "Room": 144,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14378
     },
     {
@@ -3105,10 +2933,6 @@
       "Y": -2816,
       "Z": 56832,
       "Room": 116,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 14378
     }
   ],

--- a/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
+++ b/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
@@ -3574,10 +3574,6 @@
       "Y": 3584,
       "Z": 62965,
       "Room": 49,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16257
     },
     {
@@ -3585,10 +3581,6 @@
       "Y": 3588,
       "Z": 62937,
       "Room": 49,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16257
     },
     {
@@ -3596,10 +3588,6 @@
       "Y": 4864,
       "Z": 54812,
       "Room": 75,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16257
     },
     {
@@ -3607,10 +3595,6 @@
       "Y": 7424,
       "Z": 57842,
       "Room": 72,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16257
     },
     {
@@ -3618,10 +3602,6 @@
       "Y": 3584,
       "Z": 55808,
       "Room": 74,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16257
     },
     {
@@ -3629,10 +3609,6 @@
       "Y": 2816,
       "Z": 49638,
       "Room": 76,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16257
     },
     {
@@ -3640,10 +3616,6 @@
       "Y": 2816,
       "Z": 50657,
       "Room": 55,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16257
     },
     {
@@ -3651,10 +3623,6 @@
       "Y": 6912,
       "Z": 49619,
       "Room": 80,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16257
     },
     {
@@ -3662,10 +3630,6 @@
       "Y": 4864,
       "Z": 56845,
       "Room": 75,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16257
     },
     {
@@ -3673,10 +3637,6 @@
       "Y": 2816,
       "Z": 72242,
       "Room": 56,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16257
     },
     {
@@ -3684,10 +3644,6 @@
       "Y": 5888,
       "Z": 70148,
       "Room": 59,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16257
     },
     {
@@ -3695,10 +3651,6 @@
       "Y": -4724,
       "Z": 45521,
       "Room": 129,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16233
     },
     {
@@ -3706,10 +3658,6 @@
       "Y": -4864,
       "Z": 46089,
       "Room": 127,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16233
     },
     {
@@ -3717,10 +3665,6 @@
       "Y": -7936,
       "Z": 47616,
       "Room": 150,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16233
     },
     {
@@ -3728,10 +3672,6 @@
       "Y": -4864,
       "Z": 50688,
       "Room": 127,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16233
     },
     {
@@ -3739,10 +3679,6 @@
       "Y": -3840,
       "Z": 54270,
       "Room": 130,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16233
     },
     {
@@ -3750,10 +3686,6 @@
       "Y": -2816,
       "Z": 62976,
       "Room": 50,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16233
     },
     {
@@ -3761,10 +3693,6 @@
       "Y": -2304,
       "Z": 65530,
       "Room": 125,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16233
     },
     {
@@ -3772,10 +3700,6 @@
       "Y": -2304,
       "Z": 58863,
       "Room": 45,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16233
     },
     {
@@ -3783,10 +3707,6 @@
       "Y": -2816,
       "Z": 62959,
       "Room": 50,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16233
     },
     {
@@ -3794,10 +3714,6 @@
       "Y": -512,
       "Z": 62976,
       "Room": 53,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16233
     },
     {
@@ -3805,10 +3721,6 @@
       "Y": -2048,
       "Z": 32256,
       "Room": 99,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16322
     },
     {
@@ -3816,10 +3728,6 @@
       "Y": -2048,
       "Z": 31220,
       "Room": 99,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16322
     },
     {
@@ -3827,10 +3735,6 @@
       "Y": -2048,
       "Z": 31225,
       "Room": 99,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16322
     },
     {
@@ -3838,10 +3742,6 @@
       "Y": -2048,
       "Z": 40454,
       "Room": 99,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16322
     },
     {
@@ -3849,10 +3749,6 @@
       "Y": -2048,
       "Z": 38911,
       "Room": 99,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16322
     },
     {
@@ -3860,10 +3756,6 @@
       "Y": -2048,
       "Z": 41987,
       "Room": 103,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16322
     },
     {
@@ -3871,10 +3763,6 @@
       "Y": -2304,
       "Z": 47616,
       "Room": 120,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16322
     },
     {
@@ -3882,10 +3770,6 @@
       "Y": -2048,
       "Z": 47616,
       "Room": 96,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16322
     },
     {
@@ -3893,10 +3777,6 @@
       "Y": -2304,
       "Z": 47616,
       "Room": 123,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16322
     },
     {
@@ -3904,10 +3784,6 @@
       "Y": -2304,
       "Z": 47616,
       "Room": 123,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16322
     },
     {
@@ -3915,10 +3791,6 @@
       "Y": -3328,
       "Z": 48630,
       "Room": 96,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16322
     },
     {
@@ -3926,10 +3798,6 @@
       "Y": -3328,
       "Z": 65025,
       "Room": 3,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16322
     },
     {
@@ -3937,10 +3805,6 @@
       "Y": -3328,
       "Z": 55867,
       "Room": 3,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16322
     },
     {
@@ -3948,10 +3812,6 @@
       "Y": -3328,
       "Z": 59904,
       "Room": 3,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16322
     },
     {
@@ -3959,10 +3819,6 @@
       "Y": -4352,
       "Z": 44525,
       "Room": 97,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16322
     },
     {
@@ -3970,10 +3826,6 @@
       "Y": -4352,
       "Z": 44544,
       "Room": 97,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16322
     },
     {
@@ -3981,10 +3833,6 @@
       "Y": 1536,
       "Z": 56844,
       "Room": 78,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16286
     },
     {
@@ -3992,10 +3840,6 @@
       "Y": 1536,
       "Z": 54797,
       "Room": 78,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16286
     },
     {
@@ -4003,10 +3847,6 @@
       "Y": 1536,
       "Z": 49649,
       "Room": 78,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16286
     },
     {
@@ -4014,10 +3854,6 @@
       "Y": 1536,
       "Z": 52741,
       "Room": 78,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16286
     },
     {
@@ -4025,10 +3861,6 @@
       "Y": 6912,
       "Z": 49658,
       "Room": 80,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16286
     },
     {
@@ -4036,10 +3868,6 @@
       "Y": 4864,
       "Z": 53760,
       "Room": 75,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16286
     },
     {
@@ -4047,10 +3875,6 @@
       "Y": 3584,
       "Z": 55808,
       "Room": 74,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16286
     },
     {
@@ -4058,10 +3882,6 @@
       "Y": 1536,
       "Z": 66048,
       "Room": 51,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16286
     },
     {
@@ -4069,10 +3889,6 @@
       "Y": 1536,
       "Z": 59925,
       "Room": 61,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 16286
     }
   ],

--- a/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
+++ b/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
@@ -758,10 +758,6 @@
       "Y": -2816,
       "Z": 35318,
       "Room": 55,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 12323
     },
     {
@@ -769,10 +765,6 @@
       "Y": -2304,
       "Z": 35328,
       "Room": 99,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 12323
     },
     {
@@ -780,10 +772,6 @@
       "Y": -2560,
       "Z": 40448,
       "Room": 98,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 12323
     },
     {
@@ -791,10 +779,6 @@
       "Y": -2560,
       "Z": 41472,
       "Room": 98,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 12323
     },
     {
@@ -802,10 +786,6 @@
       "Y": -2560,
       "Z": 45559,
       "Room": 98,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 12323
     },
     {
@@ -813,10 +793,6 @@
       "Y": -2560,
       "Z": 42453,
       "Room": 91,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 12323
     },
     {
@@ -824,10 +800,6 @@
       "Y": -2560,
       "Z": 44469,
       "Room": 91,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 12323
     },
     {
@@ -835,10 +807,6 @@
       "Y": -1024,
       "Z": 47673,
       "Room": 89,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 12323
     },
     {
@@ -846,10 +814,6 @@
       "Y": 768,
       "Z": 55834,
       "Room": 30,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 12323
     },
     {
@@ -857,10 +821,6 @@
       "Y": -2304,
       "Z": 44561,
       "Room": 87,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 12323
     },
     {
@@ -868,10 +828,6 @@
       "Y": -2560,
       "Z": 41486,
       "Room": 87,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 12323
     },
     {
@@ -879,10 +835,6 @@
       "Y": -2560,
       "Z": 37376,
       "Room": 86,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 12323
     },
     {
@@ -890,10 +842,6 @@
       "Y": -768,
       "Z": 37357,
       "Room": 85,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 12323
     },
     {
@@ -901,10 +849,6 @@
       "Y": -768,
       "Z": 36358,
       "Room": 88,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 12323
     },
     {
@@ -912,10 +856,6 @@
       "Y": -2816,
       "Z": 44491,
       "Room": 87,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 12323
     },
     {
@@ -923,10 +863,6 @@
       "Y": 256,
       "Z": 34304,
       "Room": 72,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 12239
     },
     {
@@ -934,10 +870,6 @@
       "Y": -643,
       "Z": 33264,
       "Room": 72,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 12239
     },
     {
@@ -945,10 +877,6 @@
       "Y": -768,
       "Z": 33280,
       "Room": 59,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 12239
     },
     {
@@ -956,10 +884,6 @@
       "Y": 512,
       "Z": 29184,
       "Room": 60,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 12239
     },
     {
@@ -967,10 +891,6 @@
       "Y": 512,
       "Z": 30208,
       "Room": 60,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 12239
     },
     {
@@ -978,10 +898,6 @@
       "Y": 768,
       "Z": 41523,
       "Room": 63,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 12239
     },
     {
@@ -989,10 +905,6 @@
       "Y": 256,
       "Z": 36352,
       "Room": 78,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 12239
     },
     {
@@ -1000,10 +912,6 @@
       "Y": 1536,
       "Z": 41472,
       "Room": 79,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 12239
     },
     {
@@ -1011,10 +919,6 @@
       "Y": 1536,
       "Z": 43627,
       "Room": 79,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 12239
     },
     {
@@ -1022,10 +926,6 @@
       "Y": 512,
       "Z": 42424,
       "Room": 80,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 12239
     },
     {
@@ -1033,10 +933,6 @@
       "Y": 512,
       "Z": 45537,
       "Room": 80,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 12239
     },
     {
@@ -1044,10 +940,6 @@
       "Y": 3072,
       "Z": 30208,
       "Room": 75,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 12239
     },
     {
@@ -1055,10 +947,6 @@
       "Y": 512,
       "Z": 26118,
       "Room": 58,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 12239
     }
   ],

--- a/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
+++ b/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
@@ -266,10 +266,6 @@
       "Y": 3328,
       "Z": 57856,
       "Room": 211,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11435
     },
     {
@@ -277,10 +273,6 @@
       "Y": 4352,
       "Z": 57856,
       "Room": 211,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11435
     },
     {
@@ -288,10 +280,6 @@
       "Y": 5376,
       "Z": 62972,
       "Room": 213,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11435
     },
     {
@@ -299,10 +287,6 @@
       "Y": 3328,
       "Z": 61980,
       "Room": 209,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11435
     },
     {
@@ -310,10 +294,6 @@
       "Y": 5120,
       "Z": 58802,
       "Room": 208,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11435
     },
     {
@@ -321,10 +301,6 @@
       "Y": 4352,
       "Z": 53705,
       "Room": 211,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11435
     },
     {
@@ -332,10 +308,6 @@
       "Y": 4352,
       "Z": 62998,
       "Room": 211,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11435
     },
     {
@@ -343,10 +315,6 @@
       "Y": 4096,
       "Z": 65027,
       "Room": 212,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11435
     },
     {
@@ -354,10 +322,6 @@
       "Y": 4096,
       "Z": 69140,
       "Room": 212,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11435
     },
     {
@@ -365,10 +329,6 @@
       "Y": 7168,
       "Z": 69090,
       "Room": 220,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11444
     },
     {
@@ -376,10 +336,6 @@
       "Y": 7168,
       "Z": 69075,
       "Room": 220,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11444
     },
     {
@@ -387,10 +343,6 @@
       "Y": 7168,
       "Z": 62949,
       "Room": 220,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11444
     },
     {
@@ -398,10 +350,6 @@
       "Y": 7168,
       "Z": 63997,
       "Room": 220,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11444
     },
     {
@@ -409,10 +357,6 @@
       "Y": 7168,
       "Z": 63038,
       "Room": 220,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11444
     },
     {
@@ -420,10 +364,6 @@
       "Y": 4096,
       "Z": 65046,
       "Room": 212,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11444
     },
     {
@@ -431,10 +371,6 @@
       "Y": 4096,
       "Z": 69232,
       "Room": 212,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11444
     },
     {
@@ -442,10 +378,6 @@
       "Y": 5888,
       "Z": 46592,
       "Room": 189,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11416
     },
     {
@@ -453,10 +385,6 @@
       "Y": 5888,
       "Z": 45568,
       "Room": 190,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11416
     },
     {
@@ -464,10 +392,6 @@
       "Y": 7168,
       "Z": 61952,
       "Room": 81,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11416
     },
     {
@@ -475,10 +399,6 @@
       "Y": 7168,
       "Z": 54752,
       "Room": 82,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11416
     },
     {
@@ -486,10 +406,6 @@
       "Y": 6656,
       "Z": 37383,
       "Room": 170,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11416
     },
     {
@@ -497,10 +413,6 @@
       "Y": 6656,
       "Z": 37377,
       "Room": 170,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11416
     },
     {
@@ -508,10 +420,6 @@
       "Y": 8192,
       "Z": 62951,
       "Room": 88,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11416
     },
     {
@@ -519,10 +427,6 @@
       "Y": 7936,
       "Z": 69120,
       "Room": 88,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11416
     },
     {
@@ -530,10 +434,6 @@
       "Y": 8960,
       "Z": 18946,
       "Room": 173,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11416
     },
     {
@@ -541,10 +441,6 @@
       "Y": 1792,
       "Z": 17920,
       "Room": 177,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11416
     },
     {
@@ -552,10 +448,6 @@
       "Y": 4608,
       "Z": 22996,
       "Room": 175,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11416
     },
     {
@@ -563,10 +455,6 @@
       "Y": 1419,
       "Z": 22033,
       "Room": 176,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11416
     },
     {
@@ -574,10 +462,6 @@
       "Y": 1024,
       "Z": 18944,
       "Room": 176,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11416
     },
     {
@@ -585,10 +469,6 @@
       "Y": 3840,
       "Z": 14848,
       "Room": 184,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11416
     },
     {
@@ -596,10 +476,6 @@
       "Y": 768,
       "Z": 27186,
       "Room": 200,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11416
     },
     {
@@ -607,10 +483,6 @@
       "Y": 2560,
       "Z": 26154,
       "Room": 201,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11416
     },
     {
@@ -618,10 +490,6 @@
       "Y": 2689,
       "Z": 26152,
       "Room": 201,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11416
     },
     {
@@ -629,10 +497,6 @@
       "Y": 4352,
       "Z": 46546,
       "Room": 215,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11446
     },
     {
@@ -640,10 +504,6 @@
       "Y": 4352,
       "Z": 47639,
       "Room": 215,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11446
     },
     {
@@ -651,10 +511,6 @@
       "Y": 4352,
       "Z": 57856,
       "Room": 211,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11446
     },
     {
@@ -662,10 +518,6 @@
       "Y": 4352,
       "Z": 64035,
       "Room": 211,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11446
     },
     {
@@ -673,10 +525,6 @@
       "Y": 5376,
       "Z": 58858,
       "Room": 213,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11446
     },
     {
@@ -684,10 +532,6 @@
       "Y": 5888,
       "Z": 52732,
       "Room": 221,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11446
     },
     {
@@ -695,10 +539,6 @@
       "Y": 4096,
       "Z": 69150,
       "Room": 212,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11446
     },
     {
@@ -706,10 +546,6 @@
       "Y": 5236,
       "Z": 70121,
       "Room": 98,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11371
     },
     {
@@ -717,10 +553,6 @@
       "Y": 4864,
       "Z": 74240,
       "Room": 101,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11371
     },
     {
@@ -728,10 +560,6 @@
       "Y": 3584,
       "Z": 91685,
       "Room": 118,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11371
     },
     {
@@ -739,10 +567,6 @@
       "Y": 3840,
       "Z": 94720,
       "Room": 111,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11371
     },
     {
@@ -750,10 +574,6 @@
       "Y": 3840,
       "Z": 93696,
       "Room": 110,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11371
     },
     {
@@ -761,10 +581,6 @@
       "Y": 3840,
       "Z": 96731,
       "Room": 112,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11371
     },
     {
@@ -772,10 +588,6 @@
       "Y": 1280,
       "Z": 92739,
       "Room": 126,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11371
     },
     {
@@ -783,10 +595,6 @@
       "Y": -1536,
       "Z": 94720,
       "Room": 14,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11371
     },
     {
@@ -794,10 +602,6 @@
       "Y": 7168,
       "Z": 92720,
       "Room": 137,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11371
     },
     {
@@ -805,10 +609,6 @@
       "Y": 7168,
       "Z": 95812,
       "Room": 138,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11371
     },
     {
@@ -816,10 +616,6 @@
       "Y": 7168,
       "Z": 93669,
       "Room": 129,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11371
     },
     {
@@ -827,10 +623,6 @@
       "Y": 4608,
       "Z": 92631,
       "Room": 134,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11371
     },
     {
@@ -838,10 +630,6 @@
       "Y": 5120,
       "Z": 93656,
       "Room": 141,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11371
     },
     {
@@ -849,10 +637,6 @@
       "Y": 5120,
       "Z": 97818,
       "Room": 140,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11371
     },
     {
@@ -860,10 +644,6 @@
       "Y": 4864,
       "Z": 87552,
       "Room": 147,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11371
     },
     {
@@ -871,10 +651,6 @@
       "Y": 7168,
       "Z": 90624,
       "Room": 143,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11371
     },
     {
@@ -882,10 +658,6 @@
       "Y": 7168,
       "Z": 97820,
       "Room": 142,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11371
     },
     {
@@ -893,10 +665,6 @@
       "Y": 2816,
       "Z": 53703,
       "Room": 206,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11411
     },
     {
@@ -904,10 +672,6 @@
       "Y": 1536,
       "Z": 56832,
       "Room": 207,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11411
     },
     {
@@ -915,10 +679,6 @@
       "Y": 3584,
       "Z": 53740,
       "Room": 204,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11411
     },
     {
@@ -926,10 +686,6 @@
       "Y": 4608,
       "Z": 57844,
       "Room": 219,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11411
     },
     {
@@ -937,10 +693,6 @@
       "Y": 3328,
       "Z": 54784,
       "Room": 195,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11411
     },
     {
@@ -948,10 +700,6 @@
       "Y": 1536,
       "Z": 59901,
       "Room": 207,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11410
     },
     {
@@ -959,10 +707,6 @@
       "Y": 2816,
       "Z": 62983,
       "Room": 206,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11410
     },
     {
@@ -970,10 +714,6 @@
       "Y": 3584,
       "Z": 63049,
       "Room": 204,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11410
     },
     {
@@ -981,10 +721,6 @@
       "Y": 4608,
       "Z": 58880,
       "Room": 219,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11410
     },
     {
@@ -992,10 +728,6 @@
       "Y": 3328,
       "Z": 60928,
       "Room": 195,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11410
     },
     {
@@ -1003,10 +735,6 @@
       "Y": -512,
       "Z": 53760,
       "Room": 197,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11410
     },
     {
@@ -1014,10 +742,6 @@
       "Y": -512,
       "Z": 62976,
       "Room": 197,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11410
     },
     {
@@ -1025,10 +749,6 @@
       "Y": 256,
       "Z": 72192,
       "Room": 166,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 11410
     }
   ],

--- a/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
+++ b/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
@@ -1259,10 +1259,6 @@
       "Y": 2048,
       "Z": 59890,
       "Room": 46,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18270
     },
     {
@@ -1270,10 +1266,6 @@
       "Y": 2048,
       "Z": 63990,
       "Room": 46,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18270
     },
     {
@@ -1281,10 +1273,6 @@
       "Y": 2048,
       "Z": 66583,
       "Room": 46,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18270
     },
     {
@@ -1292,10 +1280,6 @@
       "Y": 1794,
       "Z": 62455,
       "Room": 47,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18270
     },
     {
@@ -1303,10 +1287,6 @@
       "Y": 1792,
       "Z": 68096,
       "Room": 47,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18270
     },
     {
@@ -1314,10 +1294,6 @@
       "Y": 1024,
       "Z": 50688,
       "Room": 45,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18270
     },
     {
@@ -1325,10 +1301,6 @@
       "Y": 2048,
       "Z": 45568,
       "Room": 45,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18270
     },
     {
@@ -1336,10 +1308,6 @@
       "Y": 2048,
       "Z": 47616,
       "Room": 45,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18270
     },
     {
@@ -1347,10 +1315,6 @@
       "Y": 2048,
       "Z": 51712,
       "Room": 45,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18270
     },
     {
@@ -1358,10 +1322,6 @@
       "Y": 2048,
       "Z": 51712,
       "Room": 45,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18270
     },
     {
@@ -1369,10 +1329,6 @@
       "Y": -512,
       "Z": 45552,
       "Room": 48,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18270
     },
     {
@@ -1380,10 +1336,6 @@
       "Y": -512,
       "Z": 55775,
       "Room": 48,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18270
     },
     {
@@ -1391,10 +1343,6 @@
       "Y": -1664,
       "Z": 53760,
       "Room": 53,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18270
     },
     {
@@ -1402,10 +1350,6 @@
       "Y": -512,
       "Z": 47616,
       "Room": 48,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18270
     },
     {
@@ -1413,10 +1357,6 @@
       "Y": -3072,
       "Z": 49802,
       "Room": 2,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18270
     },
     {
@@ -1424,10 +1364,6 @@
       "Y": -252,
       "Z": 44001,
       "Room": 78,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18270
     },
     {
@@ -1435,10 +1371,6 @@
       "Y": -764,
       "Z": 44024,
       "Room": 78,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18270
     },
     {
@@ -1446,10 +1378,6 @@
       "Y": -2304,
       "Z": 57853,
       "Room": 6,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18270
     },
     {
@@ -1457,10 +1385,6 @@
       "Y": -768,
       "Z": 61943,
       "Room": 23,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18270
     },
     {
@@ -1468,10 +1392,6 @@
       "Y": -2304,
       "Z": 59957,
       "Room": 23,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18270
     },
     {
@@ -1479,10 +1399,6 @@
       "Y": -2048,
       "Z": 62976,
       "Room": 25,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18270
     },
     {
@@ -1490,10 +1406,6 @@
       "Y": 0,
       "Z": 15872,
       "Room": 72,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18255
     },
     {
@@ -1501,10 +1413,6 @@
       "Y": 0,
       "Z": 18944,
       "Room": 72,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18255
     },
     {
@@ -1512,10 +1420,6 @@
       "Y": 256,
       "Z": 18944,
       "Room": 72,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18255
     },
     {
@@ -1523,10 +1427,6 @@
       "Y": 256,
       "Z": 19968,
       "Room": 72,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18255
     },
     {
@@ -1534,10 +1434,6 @@
       "Y": 0,
       "Z": 20992,
       "Room": 72,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18255
     },
     {
@@ -1545,10 +1441,6 @@
       "Y": -270,
       "Z": 22975,
       "Room": 57,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18255
     },
     {
@@ -1556,10 +1448,6 @@
       "Y": 2560,
       "Z": 29181,
       "Room": 61,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18255
     },
     {
@@ -1567,10 +1455,6 @@
       "Y": 2560,
       "Z": 26149,
       "Room": 61,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18255
     },
     {
@@ -1578,10 +1462,6 @@
       "Y": 2560,
       "Z": 26184,
       "Room": 61,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18255
     },
     {
@@ -1589,10 +1469,6 @@
       "Y": 0,
       "Z": 30208,
       "Room": 57,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18255
     },
     {
@@ -1600,10 +1476,6 @@
       "Y": -4608,
       "Z": 31232,
       "Room": 59,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18255
     },
     {
@@ -1611,10 +1483,6 @@
       "Y": -6144,
       "Z": 27136,
       "Room": 60,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18255
     },
     {
@@ -1622,10 +1490,6 @@
       "Y": -6144,
       "Z": 30208,
       "Room": 60,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18255
     },
     {
@@ -1633,10 +1497,6 @@
       "Y": -8576,
       "Z": 25088,
       "Room": 62,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18255
     },
     {
@@ -1644,10 +1504,6 @@
       "Y": -6144,
       "Z": 24022,
       "Room": 60,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18255
     },
     {
@@ -1655,10 +1511,6 @@
       "Y": 0,
       "Z": 58792,
       "Room": 1,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18255
     },
     {
@@ -1666,10 +1518,6 @@
       "Y": 0,
       "Z": 56824,
       "Room": 1,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18255
     },
     {
@@ -1677,10 +1525,6 @@
       "Y": 0,
       "Z": 44551,
       "Room": 1,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18255
     },
     {
@@ -1688,10 +1532,6 @@
       "Y": 1024,
       "Z": 39424,
       "Room": 29,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18255
     },
     {
@@ -1699,10 +1539,6 @@
       "Y": 1024,
       "Z": 36352,
       "Room": 29,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18255
     },
     {
@@ -1710,10 +1546,6 @@
       "Y": 1024,
       "Z": 33280,
       "Room": 29,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18255
     },
     {
@@ -1721,10 +1553,6 @@
       "Y": 1024,
       "Z": 30208,
       "Room": 29,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18255
     },
     {
@@ -1732,10 +1560,6 @@
       "Y": 1024,
       "Z": 30208,
       "Room": 29,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18255
     },
     {
@@ -1743,10 +1567,6 @@
       "Y": 1024,
       "Z": 33280,
       "Room": 29,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18255
     },
     {
@@ -1754,10 +1574,6 @@
       "Y": 1024,
       "Z": 36352,
       "Room": 29,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 18255
     }
   ],

--- a/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
+++ b/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
@@ -2942,10 +2942,6 @@
       "Y": -4864,
       "Z": 82426,
       "Room": 74,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15279
     },
     {
@@ -2953,10 +2949,6 @@
       "Y": -4864,
       "Z": 72180,
       "Room": 74,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15279
     },
     {
@@ -2964,10 +2956,6 @@
       "Y": -6656,
       "Z": 80414,
       "Room": 76,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15279
     },
     {
@@ -2975,10 +2963,6 @@
       "Y": -1792,
       "Z": 75252,
       "Room": 39,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15279
     },
     {
@@ -2986,10 +2970,6 @@
       "Y": -1536,
       "Z": 77328,
       "Room": 39,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15279
     },
     {
@@ -2997,10 +2977,6 @@
       "Y": 1280,
       "Z": 53740,
       "Room": 65,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15279
     },
     {
@@ -3008,10 +2984,6 @@
       "Y": 1023,
       "Z": 58897,
       "Room": 66,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15279
     },
     {
@@ -3019,10 +2991,6 @@
       "Y": 1024,
       "Z": 56860,
       "Room": 65,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15279
     },
     {
@@ -3030,10 +2998,6 @@
       "Y": 1280,
       "Z": 53796,
       "Room": 65,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15279
     },
     {
@@ -3041,10 +3005,6 @@
       "Y": -3584,
       "Z": 60966,
       "Room": 33,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15239
     },
     {
@@ -3052,10 +3012,6 @@
       "Y": -3584,
       "Z": 53788,
       "Room": 33,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15239
     },
     {
@@ -3063,10 +3019,6 @@
       "Y": -3584,
       "Z": 53771,
       "Room": 33,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15239
     },
     {
@@ -3074,10 +3026,6 @@
       "Y": -3584,
       "Z": 60924,
       "Room": 33,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15239
     },
     {
@@ -3085,10 +3033,6 @@
       "Y": -3840,
       "Z": 56835,
       "Room": 33,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15239
     },
     {
@@ -3096,10 +3040,6 @@
       "Y": -2048,
       "Z": 60960,
       "Room": 34,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15239
     },
     {
@@ -3107,10 +3047,6 @@
       "Y": -2048,
       "Z": 60908,
       "Room": 34,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15239
     },
     {
@@ -3118,10 +3054,6 @@
       "Y": -2048,
       "Z": 53760,
       "Room": 34,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15239
     },
     {
@@ -3129,10 +3061,6 @@
       "Y": 512,
       "Z": 49713,
       "Room": 168,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15239
     },
     {
@@ -3140,10 +3068,6 @@
       "Y": 6144,
       "Z": 48643,
       "Room": 154,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15239
     },
     {
@@ -3151,10 +3075,6 @@
       "Y": 9472,
       "Z": 49596,
       "Room": 83,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15239
     },
     {
@@ -3162,10 +3082,6 @@
       "Y": 4334,
       "Z": 55842,
       "Room": 153,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15239
     },
     {
@@ -3173,10 +3089,6 @@
       "Y": -256,
       "Z": 56812,
       "Room": 61,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15239
     },
     {
@@ -3184,10 +3096,6 @@
       "Y": -256,
       "Z": 23035,
       "Room": 1,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15234
     },
     {
@@ -3195,10 +3103,6 @@
       "Y": -256,
       "Z": 23047,
       "Room": 0,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15234
     },
     {
@@ -3206,10 +3110,6 @@
       "Y": -256,
       "Z": 23078,
       "Room": 113,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15234
     },
     {
@@ -3217,10 +3117,6 @@
       "Y": -256,
       "Z": 38387,
       "Room": 3,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15234
     },
     {
@@ -3228,10 +3124,6 @@
       "Y": -256,
       "Z": 38420,
       "Room": 4,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15234
     },
     {
@@ -3239,10 +3131,6 @@
       "Y": -256,
       "Z": 38402,
       "Room": 5,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15234
     },
     {
@@ -3250,10 +3138,6 @@
       "Y": -256,
       "Z": 38354,
       "Room": 6,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15234
     },
     {
@@ -3261,10 +3145,6 @@
       "Y": 0,
       "Z": 31244,
       "Room": 117,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15234
     },
     {
@@ -3272,10 +3152,6 @@
       "Y": 256,
       "Z": 26086,
       "Room": 58,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15234
     },
     {
@@ -3283,10 +3159,6 @@
       "Y": 2048,
       "Z": 29187,
       "Room": 49,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15234
     },
     {
@@ -3294,10 +3166,6 @@
       "Y": 2048,
       "Z": 26103,
       "Room": 50,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15234
     },
     {
@@ -3305,10 +3173,6 @@
       "Y": 2048,
       "Z": 17900,
       "Room": 32,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15234
     },
     {
@@ -3316,10 +3180,6 @@
       "Y": -2816,
       "Z": 38421,
       "Room": 63,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15234
     },
     {
@@ -3327,10 +3187,6 @@
       "Y": -9472,
       "Z": 50590,
       "Room": 101,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15355
     },
     {
@@ -3338,10 +3194,6 @@
       "Y": -2304,
       "Z": 50683,
       "Room": 87,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15355
     },
     {
@@ -3349,10 +3201,6 @@
       "Y": -8704,
       "Z": 45556,
       "Room": 130,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15355
     },
     {
@@ -3360,10 +3208,6 @@
       "Y": -8704,
       "Z": 43578,
       "Room": 130,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15355
     },
     {
@@ -3371,10 +3215,6 @@
       "Y": -9728,
       "Z": 46303,
       "Room": 130,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15355
     },
     {
@@ -3382,10 +3222,6 @@
       "Y": -8960,
       "Z": 36330,
       "Room": 138,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15355
     },
     {
@@ -3393,10 +3229,6 @@
       "Y": -8960,
       "Z": 34323,
       "Room": 138,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15355
     },
     {
@@ -3404,10 +3236,6 @@
       "Y": -4864,
       "Z": 33307,
       "Room": 159,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15355
     },
     {
@@ -3415,10 +3243,6 @@
       "Y": -4864,
       "Z": 20037,
       "Room": 160,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15355
     },
     {
@@ -3426,10 +3250,6 @@
       "Y": -4864,
       "Z": 22016,
       "Room": 160,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15355
     },
     {
@@ -3437,10 +3257,6 @@
       "Y": -3840,
       "Z": 34316,
       "Room": 106,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15355
     },
     {
@@ -3448,10 +3264,6 @@
       "Y": -3840,
       "Z": 29157,
       "Room": 108,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15355
     },
     {
@@ -3459,10 +3271,6 @@
       "Y": -3584,
       "Z": 27158,
       "Room": 105,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15355
     },
     {
@@ -3470,10 +3278,6 @@
       "Y": -4864,
       "Z": 17898,
       "Room": 160,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15366
     },
     {
@@ -3481,10 +3285,6 @@
       "Y": -4864,
       "Z": 21955,
       "Room": 160,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15366
     },
     {
@@ -3492,10 +3292,6 @@
       "Y": -4864,
       "Z": 12777,
       "Room": 160,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15366
     },
     {
@@ -3503,10 +3299,6 @@
       "Y": -4608,
       "Z": 13280,
       "Room": 160,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15366
     },
     {
@@ -3514,10 +3306,6 @@
       "Y": -4608,
       "Z": 16409,
       "Room": 160,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15366
     },
     {
@@ -3525,10 +3313,6 @@
       "Y": -4864,
       "Z": 26109,
       "Room": 160,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15366
     },
     {
@@ -3536,10 +3320,6 @@
       "Y": -4864,
       "Z": 30227,
       "Room": 160,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15366
     },
     {
@@ -3547,10 +3327,6 @@
       "Y": -9216,
       "Z": 39442,
       "Room": 138,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15366
     },
     {
@@ -3558,10 +3334,6 @@
       "Y": -3584,
       "Z": 33273,
       "Room": 106,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15366
     },
     {
@@ -3569,10 +3341,6 @@
       "Y": -3584,
       "Z": 31242,
       "Room": 108,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15366
     },
     {
@@ -3580,10 +3348,6 @@
       "Y": -7936,
       "Z": 37068,
       "Room": 145,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15366
     },
     {
@@ -3591,10 +3355,6 @@
       "Y": -10240,
       "Z": 40450,
       "Room": 130,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15366
     },
     {
@@ -3602,10 +3362,6 @@
       "Y": -10496,
       "Z": 43520,
       "Room": 149,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15366
     },
     {
@@ -3613,10 +3369,6 @@
       "Y": -256,
       "Z": 7666,
       "Room": 129,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15350
     },
     {
@@ -3624,10 +3376,6 @@
       "Y": 5120,
       "Z": 17944,
       "Room": 41,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15350
     },
     {
@@ -3635,10 +3383,6 @@
       "Y": 5120,
       "Z": 18014,
       "Room": 41,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15350
     },
     {
@@ -3646,10 +3390,6 @@
       "Y": 5120,
       "Z": 24065,
       "Room": 41,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15350
     },
     {
@@ -3657,10 +3397,6 @@
       "Y": 4864,
       "Z": 24039,
       "Room": 41,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15350
     },
     {
@@ -3668,10 +3404,6 @@
       "Y": 8960,
       "Z": 23089,
       "Room": 124,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15350
     },
     {
@@ -3679,10 +3411,6 @@
       "Y": 8704,
       "Z": 19945,
       "Room": 142,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15350
     },
     {
@@ -3690,10 +3418,6 @@
       "Y": 8704,
       "Z": 31229,
       "Room": 144,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15350
     },
     {
@@ -3701,10 +3425,6 @@
       "Y": 8960,
       "Z": 28160,
       "Room": 162,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15350
     },
     {
@@ -3712,10 +3432,6 @@
       "Y": 8960,
       "Z": 20972,
       "Room": 162,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15350
     },
     {
@@ -3723,10 +3439,6 @@
       "Y": 14592,
       "Z": 17874,
       "Room": 183,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15350
     },
     {
@@ -3734,10 +3446,6 @@
       "Y": 14592,
       "Z": 24025,
       "Room": 161,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15350
     },
     {
@@ -3745,10 +3453,6 @@
       "Y": 14592,
       "Z": 24065,
       "Room": 161,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15350
     },
     {
@@ -3756,10 +3460,6 @@
       "Y": 14592,
       "Z": 17901,
       "Room": 161,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15350
     },
     {
@@ -3767,10 +3467,6 @@
       "Y": 8704,
       "Z": 17931,
       "Room": 118,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15350
     },
     {
@@ -3778,10 +3474,6 @@
       "Y": 8960,
       "Z": 19985,
       "Room": 118,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15350
     },
     {
@@ -3789,10 +3481,6 @@
       "Y": -256,
       "Z": 5638,
       "Room": 177,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15335
     },
     {
@@ -3800,10 +3488,6 @@
       "Y": -256,
       "Z": 7680,
       "Room": 125,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15335
     },
     {
@@ -3811,10 +3495,6 @@
       "Y": 4834,
       "Z": 19909,
       "Room": 41,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15335
     },
     {
@@ -3822,10 +3502,6 @@
       "Y": 4853,
       "Z": 22036,
       "Room": 41,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15335
     },
     {
@@ -3833,10 +3509,6 @@
       "Y": 4847,
       "Z": 20965,
       "Room": 41,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15335
     },
     {
@@ -3844,10 +3516,6 @@
       "Y": 4835,
       "Z": 21019,
       "Room": 41,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15335
     },
     {
@@ -3855,10 +3523,6 @@
       "Y": -1024,
       "Z": 19935,
       "Room": 46,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15335
     },
     {
@@ -3866,10 +3530,6 @@
       "Y": -1280,
       "Z": 23022,
       "Room": 46,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15335
     },
     {
@@ -3877,10 +3537,6 @@
       "Y": -1280,
       "Z": 22010,
       "Room": 43,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15335
     },
     {
@@ -3888,10 +3544,6 @@
       "Y": -255,
       "Z": 21002,
       "Room": 43,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15335
     },
     {
@@ -3899,10 +3551,6 @@
       "Y": -256,
       "Z": 17931,
       "Room": 43,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15335
     },
     {
@@ -3910,10 +3558,6 @@
       "Y": -3840,
       "Z": 18979,
       "Room": 44,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15335
     },
     {
@@ -3921,10 +3565,6 @@
       "Y": 8704,
       "Z": 19928,
       "Room": 142,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 15335
     }
   ],

--- a/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
+++ b/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
@@ -4264,10 +4264,6 @@
       "Y": 5888,
       "Z": 41497,
       "Room": 106,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26312
     },
     {
@@ -4275,10 +4271,6 @@
       "Y": 3840,
       "Z": 51712,
       "Room": 72,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26312
     },
     {
@@ -4286,10 +4278,6 @@
       "Y": 3840,
       "Z": 47595,
       "Room": 72,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26312
     },
     {
@@ -4297,10 +4285,6 @@
       "Y": 3840,
       "Z": 45536,
       "Room": 72,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26312
     },
     {
@@ -4308,10 +4292,6 @@
       "Y": 2048,
       "Z": 51576,
       "Room": 75,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26312
     },
     {
@@ -4319,10 +4299,6 @@
       "Y": 5888,
       "Z": 41435,
       "Room": 70,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26312
     },
     {
@@ -4330,10 +4306,6 @@
       "Y": 6272,
       "Z": 35328,
       "Room": 67,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26312
     },
     {
@@ -4341,10 +4313,6 @@
       "Y": 6272,
       "Z": 35328,
       "Room": 67,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26312
     },
     {
@@ -4352,10 +4320,6 @@
       "Y": 7936,
       "Z": 41473,
       "Room": 69,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26312
     },
     {
@@ -4363,10 +4327,6 @@
       "Y": 5888,
       "Z": 44596,
       "Room": 70,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26312
     },
     {
@@ -4374,10 +4334,6 @@
       "Y": 3840,
       "Z": 50688,
       "Room": 64,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26312
     },
     {
@@ -4385,10 +4341,6 @@
       "Y": 4864,
       "Z": 42496,
       "Room": 2,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26312
     },
     {
@@ -4396,10 +4348,6 @@
       "Y": -7936,
       "Z": 29160,
       "Room": 32,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26312
     },
     {
@@ -4407,10 +4355,6 @@
       "Y": -8960,
       "Z": 27136,
       "Room": 32,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26312
     },
     {
@@ -4418,10 +4362,6 @@
       "Y": -8333,
       "Z": 28106,
       "Room": 32,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26312
     },
     {
@@ -4429,10 +4369,6 @@
       "Y": -1536,
       "Z": 28129,
       "Room": 23,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26312
     },
     {
@@ -4440,10 +4376,6 @@
       "Y": 7936,
       "Z": 70144,
       "Room": 80,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26365
     },
     {
@@ -4451,10 +4383,6 @@
       "Y": 8065,
       "Z": 70128,
       "Room": 56,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26365
     },
     {
@@ -4462,10 +4390,6 @@
       "Y": 7936,
       "Z": 58880,
       "Room": 77,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26365
     },
     {
@@ -4473,10 +4397,6 @@
       "Y": 7936,
       "Z": 68096,
       "Room": 14,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26365
     },
     {
@@ -4484,10 +4404,6 @@
       "Y": 8192,
       "Z": 65022,
       "Room": 18,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26365
     },
     {
@@ -4495,10 +4411,6 @@
       "Y": 17152,
       "Z": 74240,
       "Room": 151,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26365
     },
     {
@@ -4506,10 +4418,6 @@
       "Y": 16929,
       "Z": 73304,
       "Room": 151,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26365
     },
     {
@@ -4517,10 +4425,6 @@
       "Y": 29696,
       "Z": 72192,
       "Room": 170,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26365
     },
     {
@@ -4528,10 +4432,6 @@
       "Y": 24576,
       "Z": 62976,
       "Room": 153,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26365
     },
     {
@@ -4539,10 +4439,6 @@
       "Y": 26624,
       "Z": 66048,
       "Room": 164,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26365
     },
     {
@@ -4550,10 +4446,6 @@
       "Y": 26496,
       "Z": 56832,
       "Room": 160,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26365
     },
     {
@@ -4561,10 +4453,6 @@
       "Y": 26624,
       "Z": 67072,
       "Room": 160,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26365
     },
     {
@@ -4572,10 +4460,6 @@
       "Y": 25088,
       "Z": 67422,
       "Room": 160,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26365
     },
     {
@@ -4583,10 +4467,6 @@
       "Y": 24811,
       "Z": 65019,
       "Room": 160,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26365
     },
     {
@@ -4594,10 +4474,6 @@
       "Y": 25344,
       "Z": 57924,
       "Room": 160,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26365
     },
     {
@@ -4605,10 +4481,6 @@
       "Y": 17920,
       "Z": 70171,
       "Room": 165,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26365
     },
     {
@@ -4616,10 +4488,6 @@
       "Y": 14594,
       "Z": 71121,
       "Room": 166,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26365
     },
     {
@@ -4627,10 +4495,6 @@
       "Y": 12301,
       "Z": 72240,
       "Room": 166,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26365
     },
     {
@@ -4638,10 +4502,6 @@
       "Y": 2560,
       "Z": 67072,
       "Room": 167,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26365
     },
     {
@@ -4649,10 +4509,6 @@
       "Y": 7424,
       "Z": 60928,
       "Room": 124,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26333
     },
     {
@@ -4660,10 +4516,6 @@
       "Y": 7424,
       "Z": 62976,
       "Room": 124,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26333
     },
     {
@@ -4671,10 +4523,6 @@
       "Y": 6912,
       "Z": 60928,
       "Room": 118,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26333
     },
     {
@@ -4682,10 +4530,6 @@
       "Y": 6912,
       "Z": 63557,
       "Room": 122,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26333
     },
     {
@@ -4693,10 +4537,6 @@
       "Y": 6912,
       "Z": 64064,
       "Room": 123,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26333
     },
     {
@@ -4704,10 +4544,6 @@
       "Y": 10752,
       "Z": 55812,
       "Room": 13,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26333
     },
     {
@@ -4715,10 +4551,6 @@
       "Y": 8192,
       "Z": 53757,
       "Room": 11,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26333
     },
     {
@@ -4726,10 +4558,6 @@
       "Y": 14848,
       "Z": 57856,
       "Room": 87,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26333
     },
     {
@@ -4737,10 +4565,6 @@
       "Y": 14848,
       "Z": 58828,
       "Room": 89,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26333
     },
     {
@@ -4748,10 +4572,6 @@
       "Y": 14976,
       "Z": 60928,
       "Room": 91,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26333
     },
     {
@@ -4759,10 +4579,6 @@
       "Y": 15360,
       "Z": 58777,
       "Room": 159,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26333
     },
     {
@@ -4770,10 +4586,6 @@
       "Y": 6912,
       "Z": 59892,
       "Room": 117,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 26333
     }
   ],

--- a/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
+++ b/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
@@ -2364,10 +2364,6 @@
       "Y": -4352,
       "Z": 28120,
       "Room": 69,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23293
     },
     {
@@ -2375,10 +2371,6 @@
       "Y": -4096,
       "Z": 29195,
       "Room": 69,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23293
     },
     {
@@ -2386,10 +2378,6 @@
       "Y": -5632,
       "Z": 30227,
       "Room": 69,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23293
     },
     {
@@ -2397,10 +2385,6 @@
       "Y": -4409,
       "Z": 33287,
       "Room": 69,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23293
     },
     {
@@ -2408,10 +2392,6 @@
       "Y": -3840,
       "Z": 28158,
       "Room": 69,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23293
     },
     {
@@ -2419,10 +2399,6 @@
       "Y": -4352,
       "Z": 26131,
       "Room": 69,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23293
     },
     {
@@ -2430,10 +2406,6 @@
       "Y": -5376,
       "Z": 25106,
       "Room": 69,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23293
     },
     {
@@ -2441,10 +2413,6 @@
       "Y": -7936,
       "Z": 26133,
       "Room": 69,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23293
     },
     {
@@ -2452,10 +2420,6 @@
       "Y": -8730,
       "Z": 31232,
       "Room": 72,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23293
     },
     {
@@ -2463,10 +2427,6 @@
       "Y": -5888,
       "Z": 27141,
       "Room": 69,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23293
     },
     {
@@ -2474,10 +2434,6 @@
       "Y": -5245,
       "Z": 25063,
       "Room": 69,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23293
     },
     {
@@ -2485,10 +2441,6 @@
       "Y": -5376,
       "Z": 31266,
       "Room": 69,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23293
     },
     {
@@ -2496,10 +2448,6 @@
       "Y": -4225,
       "Z": 31237,
       "Room": 69,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23293
     },
     {
@@ -2507,10 +2455,6 @@
       "Y": -6656,
       "Z": 35306,
       "Room": 69,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23293
     },
     {
@@ -2518,10 +2462,6 @@
       "Y": -4483,
       "Z": 37369,
       "Room": 69,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23293
     },
     {
@@ -2529,10 +2469,6 @@
       "Y": -4352,
       "Z": 35379,
       "Room": 69,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23293
     },
     {
@@ -2540,10 +2476,6 @@
       "Y": -1280,
       "Z": 33259,
       "Room": 134,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23293
     },
     {
@@ -2551,10 +2483,6 @@
       "Y": -2304,
       "Z": 37337,
       "Room": 134,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23293
     },
     {
@@ -2562,10 +2490,6 @@
       "Y": -1280,
       "Z": 40448,
       "Room": 134,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23293
     },
     {
@@ -2573,10 +2497,6 @@
       "Y": -1536,
       "Z": 37376,
       "Room": 47,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23293
     },
     {
@@ -2584,10 +2504,6 @@
       "Y": -5462,
       "Z": 35160,
       "Room": 69,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23293
     },
     {
@@ -2595,10 +2511,6 @@
       "Y": -2304,
       "Z": 20962,
       "Room": 25,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23293
     },
     {
@@ -2606,10 +2518,6 @@
       "Y": -30464,
       "Z": 34304,
       "Room": 147,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23283
     },
     {
@@ -2617,10 +2525,6 @@
       "Y": -30464,
       "Z": 29184,
       "Room": 152,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23283
     },
     {
@@ -2628,10 +2532,6 @@
       "Y": -30464,
       "Z": 28160,
       "Room": 164,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23283
     },
     {
@@ -2639,10 +2539,6 @@
       "Y": -28928,
       "Z": 27136,
       "Room": 173,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23283
     },
     {
@@ -2650,10 +2546,6 @@
       "Y": -27007,
       "Z": 26112,
       "Room": 56,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23283
     },
     {
@@ -2661,10 +2553,6 @@
       "Y": -22784,
       "Z": 31244,
       "Room": 15,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23283
     },
     {
@@ -2672,10 +2560,6 @@
       "Y": -20480,
       "Z": 27111,
       "Room": 18,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23283
     },
     {
@@ -2683,10 +2567,6 @@
       "Y": -23592,
       "Z": 28185,
       "Room": 15,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23283
     },
     {
@@ -2694,10 +2574,6 @@
       "Y": -14336,
       "Z": 27163,
       "Room": 35,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23283
     },
     {
@@ -2705,10 +2581,6 @@
       "Y": -18688,
       "Z": 30236,
       "Room": 18,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23283
     },
     {
@@ -2716,10 +2588,6 @@
       "Y": -13824,
       "Z": 31232,
       "Room": 73,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23283
     },
     {
@@ -2727,10 +2595,6 @@
       "Y": -13881,
       "Z": 31262,
       "Room": 77,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23283
     },
     {
@@ -2738,10 +2602,6 @@
       "Y": -14592,
       "Z": 25088,
       "Room": 20,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23283
     },
     {
@@ -2749,10 +2609,6 @@
       "Y": -15360,
       "Z": 26143,
       "Room": 174,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23283
     },
     {
@@ -2760,10 +2616,6 @@
       "Y": -15360,
       "Z": 22970,
       "Room": 174,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23283
     },
     {
@@ -2771,10 +2623,6 @@
       "Y": -18432,
       "Z": 25088,
       "Room": 54,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 23283
     }
   ],

--- a/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
+++ b/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
@@ -4595,10 +4595,6 @@
       "Y": -8192,
       "Z": 77312,
       "Room": 120,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27325
     },
     {
@@ -4606,10 +4602,6 @@
       "Y": 512,
       "Z": 80384,
       "Room": 119,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27324
     },
     {
@@ -4617,10 +4609,6 @@
       "Y": 5120,
       "Z": 48640,
       "Room": 209,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4628,10 +4616,6 @@
       "Y": 6144,
       "Z": 54824,
       "Room": 219,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4639,10 +4623,6 @@
       "Y": 6144,
       "Z": 49633,
       "Room": 219,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4650,10 +4630,6 @@
       "Y": 5376,
       "Z": 56756,
       "Room": 220,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4661,10 +4637,6 @@
       "Y": 5120,
       "Z": 56784,
       "Room": 212,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4672,10 +4644,6 @@
       "Y": 3840,
       "Z": 49648,
       "Room": 210,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4683,10 +4651,6 @@
       "Y": 5120,
       "Z": 38400,
       "Room": 211,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4694,10 +4658,6 @@
       "Y": 5375,
       "Z": 38446,
       "Room": 216,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4705,10 +4665,6 @@
       "Y": 5376,
       "Z": 44688,
       "Room": 213,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4716,10 +4672,6 @@
       "Y": 5120,
       "Z": 47671,
       "Room": 210,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4727,10 +4679,6 @@
       "Y": 5120,
       "Z": 55815,
       "Room": 212,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4738,10 +4686,6 @@
       "Y": 5120,
       "Z": 55786,
       "Room": 212,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4749,10 +4693,6 @@
       "Y": -3328,
       "Z": 38418,
       "Room": 90,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4760,10 +4700,6 @@
       "Y": -3327,
       "Z": 44521,
       "Room": 231,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4771,10 +4707,6 @@
       "Y": -3328,
       "Z": 46597,
       "Room": 232,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4782,10 +4714,6 @@
       "Y": -3328,
       "Z": 55744,
       "Room": 89,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4793,10 +4721,6 @@
       "Y": -3328,
       "Z": 53649,
       "Room": 90,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4804,10 +4728,6 @@
       "Y": -3328,
       "Z": 52685,
       "Room": 93,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4815,10 +4735,6 @@
       "Y": -3328,
       "Z": 50472,
       "Room": 91,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4826,10 +4742,6 @@
       "Y": -3328,
       "Z": 41594,
       "Room": 91,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4837,10 +4749,6 @@
       "Y": -3328,
       "Z": 36408,
       "Room": 35,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4848,10 +4756,6 @@
       "Y": -8192,
       "Z": 46552,
       "Room": 100,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4859,10 +4763,6 @@
       "Y": -7680,
       "Z": 65024,
       "Room": 147,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4870,10 +4770,6 @@
       "Y": -3840,
       "Z": 74121,
       "Room": 153,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4881,10 +4777,6 @@
       "Y": -4608,
       "Z": 76288,
       "Room": 204,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4892,10 +4784,6 @@
       "Y": -7424,
       "Z": 68073,
       "Room": 150,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4903,10 +4791,6 @@
       "Y": -4352,
       "Z": 65932,
       "Room": 102,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4914,10 +4798,6 @@
       "Y": -2816,
       "Z": 62962,
       "Room": 104,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4925,10 +4805,6 @@
       "Y": -2048,
       "Z": 63957,
       "Room": 104,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4936,10 +4812,6 @@
       "Y": -3072,
       "Z": 72124,
       "Room": 103,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4947,10 +4819,6 @@
       "Y": 1280,
       "Z": 80460,
       "Room": 115,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4958,10 +4826,6 @@
       "Y": 1280,
       "Z": 80367,
       "Room": 115,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4969,10 +4833,6 @@
       "Y": 1280,
       "Z": 80253,
       "Room": 115,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4980,10 +4840,6 @@
       "Y": 1024,
       "Z": 81388,
       "Room": 119,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -4991,10 +4847,6 @@
       "Y": 1024,
       "Z": 79369,
       "Room": 119,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -5002,10 +4854,6 @@
       "Y": 1280,
       "Z": 76263,
       "Room": 126,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -5013,10 +4861,6 @@
       "Y": 1280,
       "Z": 76365,
       "Room": 126,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -5024,10 +4868,6 @@
       "Y": 7424,
       "Z": 75094,
       "Room": 131,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -5035,10 +4875,6 @@
       "Y": 5376,
       "Z": 75239,
       "Room": 133,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -5046,10 +4882,6 @@
       "Y": -768,
       "Z": 69091,
       "Room": 142,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -5057,10 +4889,6 @@
       "Y": -2560,
       "Z": 72162,
       "Room": 141,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -5068,10 +4896,6 @@
       "Y": -2560,
       "Z": 77282,
       "Room": 141,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -5079,10 +4903,6 @@
       "Y": -2048,
       "Z": 89894,
       "Room": 94,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27435
     },
     {
@@ -5090,10 +4910,6 @@
       "Y": -3840,
       "Z": 58867,
       "Room": 23,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27251
     },
     {
@@ -5101,10 +4917,6 @@
       "Y": -2559,
       "Z": 61949,
       "Room": 13,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27251
     },
     {
@@ -5112,10 +4924,6 @@
       "Y": -1024,
       "Z": 59894,
       "Room": 0,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27251
     },
     {
@@ -5123,10 +4931,6 @@
       "Y": -255,
       "Z": 63979,
       "Room": 6,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27251
     },
     {
@@ -5134,10 +4938,6 @@
       "Y": -256,
       "Z": 72233,
       "Room": 4,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27251
     },
     {
@@ -5145,10 +4945,6 @@
       "Y": -256,
       "Z": 76305,
       "Room": 15,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27251
     },
     {
@@ -5156,10 +4952,6 @@
       "Y": -2816,
       "Z": 66048,
       "Room": 17,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27251
     },
     {
@@ -5167,10 +4959,6 @@
       "Y": -2699,
       "Z": 67063,
       "Room": 17,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27251
     },
     {
@@ -5178,10 +4966,6 @@
       "Y": -3840,
       "Z": 65018,
       "Room": 11,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27251
     },
     {
@@ -5189,10 +4973,6 @@
       "Y": -3840,
       "Z": 67069,
       "Room": 12,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27251
     },
     {
@@ -5200,10 +4980,6 @@
       "Y": -3840,
       "Z": 70130,
       "Room": 12,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27251
     },
     {
@@ -5211,10 +4987,6 @@
       "Y": -4608,
       "Z": 61968,
       "Room": 25,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27251
     },
     {
@@ -5222,10 +4994,6 @@
       "Y": 0,
       "Z": 54757,
       "Room": 31,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27251
     },
     {
@@ -5233,10 +5001,6 @@
       "Y": -256,
       "Z": 69114,
       "Room": 9,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27251
     },
     {
@@ -5244,10 +5008,6 @@
       "Y": -2560,
       "Z": 89600,
       "Room": 94,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27299
     },
     {
@@ -5255,10 +5015,6 @@
       "Y": -12032,
       "Z": 54784,
       "Room": 97,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 27302
     }
   ],

--- a/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
+++ b/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
@@ -5024,10 +5024,6 @@
       "Y": -3840,
       "Z": 55808,
       "Room": 47,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 29242
     },
     {
@@ -5035,10 +5031,6 @@
       "Y": -3072,
       "Z": 63963,
       "Room": 44,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 29242
     },
     {
@@ -5046,10 +5038,6 @@
       "Y": 1280,
       "Z": 53767,
       "Room": 57,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 29242
     },
     {
@@ -5057,10 +5045,6 @@
       "Y": 1279,
       "Z": 53743,
       "Room": 42,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 29242
     },
     {
@@ -5068,10 +5052,6 @@
       "Y": -2048,
       "Z": 54757,
       "Room": 44,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 29242
     },
     {
@@ -5079,10 +5059,6 @@
       "Y": -2048,
       "Z": 54784,
       "Room": 44,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 29242
     },
     {
@@ -5090,10 +5066,6 @@
       "Y": -2304,
       "Z": 58807,
       "Room": 44,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 29242
     },
     {
@@ -5101,10 +5073,6 @@
       "Y": -4990,
       "Z": 65029,
       "Room": 56,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 29242
     },
     {
@@ -5112,10 +5080,6 @@
       "Y": -2816,
       "Z": 64000,
       "Room": 44,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 29242
     },
     {
@@ -5123,10 +5087,6 @@
       "Y": 2048,
       "Z": 69161,
       "Room": 26,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 29242
     },
     {
@@ -5134,10 +5094,6 @@
       "Y": 7168,
       "Z": 60932,
       "Room": 60,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 29242
     },
     {
@@ -5145,10 +5101,6 @@
       "Y": 5632,
       "Z": 64031,
       "Room": 58,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 29242
     },
     {
@@ -5156,10 +5108,6 @@
       "Y": 5632,
       "Z": 59893,
       "Room": 43,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 29242
     },
     {
@@ -5167,10 +5115,6 @@
       "Y": 5632,
       "Z": 57856,
       "Room": 41,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 29242
     }
   ]

--- a/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
+++ b/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
@@ -1577,18 +1577,6 @@
       "KeyItemGroupID": 18255
     }
   ],
-  "RAPIDS.TR2": [
-    {
-      "X": 0,
-      "Z": 0,
-      "Y": 0,
-      "Room": 0,
-      "RequiresGlitch": false,
-      "Difficulty": 0,
-      "IsInRoomSpace": false,
-      "IsItem": true
-    }
-  ],
   "TRIBOSS.TR2": [
     {
       "X": 0,

--- a/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
+++ b/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
@@ -950,18 +950,6 @@
       "KeyItemGroupID": 12239
     }
   ],
-  "TONYBOSS.TR2": [
-    {
-      "X": 0,
-      "Z": 0,
-      "Y": 0,
-      "Room": 0,
-      "RequiresGlitch": false,
-      "Difficulty": 0,
-      "IsInRoomSpace": false,
-      "IsItem": true
-    }
-  ],
   "SHORE.TR2": [
     {
       "X": 32294,

--- a/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
+++ b/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
@@ -1816,10 +1816,6 @@
       "Y": -8704,
       "Z": 84520,
       "Room": 110,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22262
     },
     {
@@ -1827,10 +1823,6 @@
       "Y": -8704,
       "Z": 88659,
       "Room": 110,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22262
     },
     {
@@ -1838,10 +1830,6 @@
       "Y": -8704,
       "Z": 88594,
       "Room": 110,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22262
     },
     {
@@ -1849,10 +1837,6 @@
       "Y": -8704,
       "Z": 84514,
       "Room": 110,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22262
     },
     {
@@ -1860,10 +1844,6 @@
       "Y": -5888,
       "Z": 89615,
       "Room": 37,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22262
     },
     {
@@ -1871,10 +1851,6 @@
       "Y": -5888,
       "Z": 89594,
       "Room": 37,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22262
     },
     {
@@ -1882,10 +1858,6 @@
       "Y": -5888,
       "Z": 89616,
       "Room": 37,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22262
     },
     {
@@ -1893,10 +1865,6 @@
       "Y": -7424,
       "Z": 85547,
       "Room": 37,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22262
     },
     {
@@ -1904,10 +1872,6 @@
       "Y": -7424,
       "Z": 85542,
       "Room": 37,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22262
     },
     {
@@ -1915,10 +1879,6 @@
       "Y": -5888,
       "Z": 79384,
       "Room": 37,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22262
     },
     {
@@ -1926,10 +1886,6 @@
       "Y": -5888,
       "Z": 79348,
       "Room": 37,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22262
     },
     {
@@ -1937,10 +1893,6 @@
       "Y": -5888,
       "Z": 79365,
       "Room": 37,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22262
     },
     {
@@ -1948,10 +1900,6 @@
       "Y": -5888,
       "Z": 79289,
       "Room": 37,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22262
     },
     {
@@ -1959,10 +1907,6 @@
       "Y": -8704,
       "Z": 82432,
       "Room": 110,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22262
     },
     {
@@ -1970,10 +1914,6 @@
       "Y": 1023,
       "Z": 24071,
       "Room": 1,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22334
     },
     {
@@ -1981,10 +1921,6 @@
       "Y": 1024,
       "Z": 25082,
       "Room": 1,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22334
     },
     {
@@ -1992,10 +1928,6 @@
       "Y": 1024,
       "Z": 23043,
       "Room": 1,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22334
     },
     {
@@ -2003,10 +1935,6 @@
       "Y": 1024,
       "Z": 22003,
       "Room": 1,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22334
     },
     {
@@ -2014,10 +1942,6 @@
       "Y": 1024,
       "Z": 19893,
       "Room": 1,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22334
     },
     {
@@ -2025,10 +1949,6 @@
       "Y": 1024,
       "Z": 25099,
       "Room": 1,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22334
     },
     {
@@ -2036,10 +1956,6 @@
       "Y": 1024,
       "Z": 23060,
       "Room": 1,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22334
     },
     {
@@ -2047,10 +1963,6 @@
       "Y": 1024,
       "Z": 22013,
       "Room": 1,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22334
     },
     {
@@ -2058,10 +1970,6 @@
       "Y": 768,
       "Z": 56904,
       "Room": 42,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22247
     },
     {
@@ -2069,10 +1977,6 @@
       "Y": 768,
       "Z": 56956,
       "Room": 42,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22247
     },
     {
@@ -2080,10 +1984,6 @@
       "Y": 2287,
       "Z": 55793,
       "Room": 51,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22247
     },
     {
@@ -2091,10 +1991,6 @@
       "Y": 2302,
       "Z": 54935,
       "Room": 51,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22247
     },
     {
@@ -2102,10 +1998,6 @@
       "Y": 3054,
       "Z": 55830,
       "Room": 148,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22247
     },
     {
@@ -2113,10 +2005,6 @@
       "Y": 3035,
       "Z": 54711,
       "Room": 148,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22247
     },
     {
@@ -2124,10 +2012,6 @@
       "Y": 1536,
       "Z": 55316,
       "Room": 42,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22247
     },
     {
@@ -2135,10 +2019,6 @@
       "Y": 768,
       "Z": 59399,
       "Room": 41,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22247
     },
     {
@@ -2146,10 +2026,6 @@
       "Y": 768,
       "Z": 59438,
       "Room": 41,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22247
     },
     {
@@ -2157,10 +2033,6 @@
       "Y": 766,
       "Z": 59398,
       "Room": 41,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22247
     },
     {
@@ -2168,10 +2040,6 @@
       "Y": 768,
       "Z": 60941,
       "Room": 41,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22247
     },
     {
@@ -2179,10 +2047,6 @@
       "Y": 768,
       "Z": 62993,
       "Room": 41,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22247
     },
     {
@@ -2190,10 +2054,6 @@
       "Y": 768,
       "Z": 56832,
       "Room": 42,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22247
     },
     {
@@ -2201,10 +2061,6 @@
       "Y": 768,
       "Z": 57856,
       "Room": 42,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22247
     },
     {
@@ -2212,10 +2068,6 @@
       "Y": 256,
       "Z": 58855,
       "Room": 41,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22247
     },
     {
@@ -2223,10 +2075,6 @@
       "Y": 768,
       "Z": 60928,
       "Room": 41,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22247
     },
     {
@@ -2234,10 +2082,6 @@
       "Y": -4096,
       "Z": 84471,
       "Room": 89,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22301
     },
     {
@@ -2245,10 +2089,6 @@
       "Y": -2816,
       "Z": 88453,
       "Room": 77,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22301
     },
     {
@@ -2256,10 +2096,6 @@
       "Y": -2304,
       "Z": 85565,
       "Room": 77,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22301
     },
     {
@@ -2267,10 +2103,6 @@
       "Y": -5888,
       "Z": 89591,
       "Room": 82,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22301
     },
     {
@@ -2278,10 +2110,6 @@
       "Y": -6912,
       "Z": 86540,
       "Room": 92,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22301
     },
     {
@@ -2289,10 +2117,6 @@
       "Y": -4096,
       "Z": 78339,
       "Room": 67,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22301
     },
     {
@@ -2300,10 +2124,6 @@
       "Y": -4096,
       "Z": 81413,
       "Room": 60,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22301
     },
     {
@@ -2311,10 +2131,6 @@
       "Y": -2560,
       "Z": 91650,
       "Room": 131,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22301
     },
     {
@@ -2322,10 +2138,6 @@
       "Y": -2048,
       "Z": 91634,
       "Room": 129,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22301
     },
     {
@@ -2333,10 +2145,6 @@
       "Y": -3840,
       "Z": 64034,
       "Room": 55,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22301
     },
     {
@@ -2344,10 +2152,6 @@
       "Y": -3328,
       "Z": 73241,
       "Room": 55,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22301
     },
     {
@@ -2355,10 +2159,6 @@
       "Y": -2048,
       "Z": 71165,
       "Room": 118,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22301
     },
     {
@@ -2366,10 +2166,6 @@
       "Y": -3328,
       "Z": 68076,
       "Room": 55,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22301
     },
     {
@@ -2377,10 +2173,6 @@
       "Y": -2304,
       "Z": 62970,
       "Room": 69,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22235
     },
     {
@@ -2388,10 +2180,6 @@
       "Y": -2048,
       "Z": 61935,
       "Room": 69,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22235
     },
     {
@@ -2399,10 +2187,6 @@
       "Y": -2304,
       "Z": 62976,
       "Room": 69,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22235
     },
     {
@@ -2410,10 +2194,6 @@
       "Y": -2304,
       "Z": 61940,
       "Room": 69,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22235
     },
     {
@@ -2421,10 +2201,6 @@
       "Y": 512,
       "Z": 67083,
       "Room": 58,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22235
     },
     {
@@ -2432,10 +2208,6 @@
       "Y": 2557,
       "Z": 65019,
       "Room": 102,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22235
     },
     {
@@ -2443,10 +2215,6 @@
       "Y": 5120,
       "Z": 66041,
       "Room": 50,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22235
     },
     {
@@ -2454,10 +2222,6 @@
       "Y": 9472,
       "Z": 66052,
       "Room": 64,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22235
     },
     {
@@ -2465,10 +2229,6 @@
       "Y": 9728,
       "Z": 66027,
       "Room": 64,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22235
     },
     {
@@ -2476,10 +2236,6 @@
       "Y": 12800,
       "Z": 65015,
       "Room": 6,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22235
     },
     {
@@ -2487,10 +2243,6 @@
       "Y": 13568,
       "Z": 66030,
       "Room": 65,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22235
     },
     {
@@ -2498,10 +2250,6 @@
       "Y": -5888,
       "Z": 85479,
       "Room": 37,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22243
     },
     {
@@ -2509,10 +2257,6 @@
       "Y": -5888,
       "Z": 85491,
       "Room": 37,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22243
     },
     {
@@ -2520,10 +2264,6 @@
       "Y": -5888,
       "Z": 85454,
       "Room": 37,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22243
     },
     {
@@ -2531,10 +2271,6 @@
       "Y": -5888,
       "Z": 85488,
       "Room": 37,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22243
     },
     {
@@ -2542,10 +2278,6 @@
       "Y": -1280,
       "Z": 66563,
       "Room": 40,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22243
     },
     {
@@ -2553,10 +2285,6 @@
       "Y": -5888,
       "Z": 77817,
       "Room": 37,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22243
     },
     {
@@ -2564,10 +2292,6 @@
       "Y": -5888,
       "Z": 77818,
       "Room": 37,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22243
     },
     {
@@ -2575,10 +2299,6 @@
       "Y": 255,
       "Z": 63755,
       "Room": 39,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22243
     },
     {
@@ -2586,10 +2306,6 @@
       "Y": -4608,
       "Z": 34303,
       "Room": 62,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22325
     },
     {
@@ -2597,10 +2313,6 @@
       "Y": -4608,
       "Z": 34308,
       "Room": 62,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22325
     },
     {
@@ -2608,10 +2320,6 @@
       "Y": -376,
       "Z": 48669,
       "Room": 43,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22325
     },
     {
@@ -2619,10 +2327,6 @@
       "Y": 672,
       "Z": 51589,
       "Room": 53,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22325
     },
     {
@@ -2630,10 +2334,6 @@
       "Y": 768,
       "Z": 50688,
       "Room": 43,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22325
     },
     {
@@ -2641,10 +2341,6 @@
       "Y": 768,
       "Z": 51698,
       "Room": 53,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22325
     },
     {
@@ -2652,10 +2348,6 @@
       "Y": -256,
       "Z": 50688,
       "Room": 18,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22325
     },
     {
@@ -2663,10 +2355,6 @@
       "Y": -768,
       "Z": 57856,
       "Room": 45,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 22325
     }
   ],

--- a/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
+++ b/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
@@ -2626,18 +2626,6 @@
       "KeyItemGroupID": 23283
     }
   ],
-  "OFFICE.TR2": [
-    {
-      "X": 0,
-      "Z": 0,
-      "Y": 0,
-      "Room": 0,
-      "RequiresGlitch": false,
-      "Difficulty": 0,
-      "IsInRoomSpace": false,
-      "IsItem": true
-    }
-  ],
   "NEVADA.TR2": [
     {
       "X": 5632,

--- a/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
+++ b/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
@@ -5018,18 +5018,6 @@
       "KeyItemGroupID": 27302
     }
   ],
-  "CHAMBER.TR2": [
-    {
-      "X": 0,
-      "Z": 0,
-      "Y": 0,
-      "Room": 0,
-      "RequiresGlitch": false,
-      "Difficulty": 0,
-      "IsInRoomSpace": false,
-      "IsItem": true
-    }
-  ],
   "STPAUL.TR2": [
     {
       "X": 49664,

--- a/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
+++ b/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
@@ -5,10 +5,6 @@
       "Y": 24064,
       "Z": 61980,
       "Room": 26,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -16,10 +12,6 @@
       "Y": 27136,
       "Z": 71168,
       "Room": 147,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -27,10 +19,6 @@
       "Y": 26378,
       "Z": 80360,
       "Room": 31,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -38,10 +26,6 @@
       "Y": 27136,
       "Z": 76279,
       "Room": 83,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -49,10 +33,6 @@
       "Y": 24064,
       "Z": 70140,
       "Room": 163,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -60,10 +40,6 @@
       "Y": 24064,
       "Z": 75262,
       "Room": 85,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -71,10 +47,6 @@
       "Y": 26493,
       "Z": 76297,
       "Room": 84,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -82,10 +54,6 @@
       "Y": 27136,
       "Z": 77312,
       "Room": 151,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -93,10 +61,6 @@
       "Y": 28160,
       "Z": 76321,
       "Room": 62,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -104,10 +68,6 @@
       "Y": 25600,
       "Z": 63939,
       "Room": 50,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -115,10 +75,6 @@
       "Y": 26880,
       "Z": 65016,
       "Room": 99,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -126,10 +82,6 @@
       "Y": 21504,
       "Z": 62914,
       "Room": 14,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -137,10 +89,6 @@
       "Y": 23808,
       "Z": 63986,
       "Room": 162,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -148,10 +96,6 @@
       "Y": 19712,
       "Z": 62963,
       "Room": 75,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -159,10 +103,6 @@
       "Y": 17152,
       "Z": 70138,
       "Room": 143,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -170,10 +110,6 @@
       "Y": 24064,
       "Z": 53671,
       "Room": 72,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -181,10 +117,6 @@
       "Y": 25611,
       "Z": 53758,
       "Room": 70,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -192,10 +124,6 @@
       "Y": 27392,
       "Z": 54775,
       "Room": 88,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -203,10 +131,6 @@
       "Y": 25735,
       "Z": 51659,
       "Room": 54,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -214,10 +138,6 @@
       "Y": 24576,
       "Z": 61030,
       "Room": 28,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -225,10 +145,6 @@
       "Y": 24832,
       "Z": 61995,
       "Room": 28,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -236,10 +152,6 @@
       "Y": 27799,
       "Z": 65088,
       "Room": 43,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -247,10 +159,6 @@
       "Y": 27264,
       "Z": 61952,
       "Room": 43,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -258,10 +166,6 @@
       "Y": 25856,
       "Z": 59941,
       "Room": 30,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -269,10 +173,6 @@
       "Y": 27136,
       "Z": 60962,
       "Room": 146,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -280,10 +180,6 @@
       "Y": 25088,
       "Z": 54760,
       "Room": 141,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -291,10 +187,6 @@
       "Y": 27136,
       "Z": 59942,
       "Room": 134,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -302,10 +194,6 @@
       "Y": 26112,
       "Z": 73234,
       "Room": 122,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -313,10 +201,6 @@
       "Y": 30578,
       "Z": 77380,
       "Room": 118,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -324,10 +208,6 @@
       "Y": 29952,
       "Z": 91648,
       "Room": 113,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -335,10 +215,6 @@
       "Y": 28160,
       "Z": 81408,
       "Room": 113,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -346,10 +222,6 @@
       "Y": 25856,
       "Z": 80357,
       "Room": 98,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -357,10 +229,6 @@
       "Y": 24069,
       "Z": 86501,
       "Room": 97,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -368,10 +236,6 @@
       "Y": 24320,
       "Z": 91625,
       "Room": 97,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -379,10 +243,6 @@
       "Y": 27904,
       "Z": 90652,
       "Room": 106,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -390,10 +250,6 @@
       "Y": 27904,
       "Z": 87532,
       "Room": 106,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     },
     {
@@ -401,10 +257,6 @@
       "Y": 27904,
       "Z": 90617,
       "Room": 103,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 10359
     }
   ],

--- a/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
+++ b/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
@@ -1577,18 +1577,6 @@
       "KeyItemGroupID": 18255
     }
   ],
-  "TRIBOSS.TR2": [
-    {
-      "X": 0,
-      "Z": 0,
-      "Y": 0,
-      "Room": 0,
-      "RequiresGlitch": false,
-      "Difficulty": 0,
-      "IsInRoomSpace": false,
-      "IsItem": true
-    }
-  ],
   "ROOFS.TR2": [
     {
       "X": 63054,

--- a/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
+++ b/TRRandomizerCore/Resources/TR3/Locations/item_locations.json
@@ -3898,10 +3898,6 @@
       "Y": -4864,
       "Z": 31293,
       "Room": 86,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25292
     },
     {
@@ -3909,10 +3905,6 @@
       "Y": -3584,
       "Z": 27156,
       "Room": 87,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25292
     },
     {
@@ -3920,10 +3912,6 @@
       "Y": -3328,
       "Z": 27118,
       "Room": 87,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25292
     },
     {
@@ -3931,10 +3919,6 @@
       "Y": -3353,
       "Z": 38358,
       "Room": 89,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25292
     },
     {
@@ -3942,10 +3926,6 @@
       "Y": -4608,
       "Z": 38385,
       "Room": 89,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25292
     },
     {
@@ -3953,10 +3933,6 @@
       "Y": -4608,
       "Z": 39431,
       "Room": 89,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25292
     },
     {
@@ -3964,10 +3940,6 @@
       "Y": 0,
       "Z": 35318,
       "Room": 101,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25292
     },
     {
@@ -3975,10 +3947,6 @@
       "Y": -512,
       "Z": 38416,
       "Room": 101,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25292
     },
     {
@@ -3986,10 +3954,6 @@
       "Y": -3328,
       "Z": 42490,
       "Room": 166,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25292
     },
     {
@@ -3997,10 +3961,6 @@
       "Y": -6144,
       "Z": 52765,
       "Room": 98,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25298
     },
     {
@@ -4008,10 +3968,6 @@
       "Y": -6144,
       "Z": 53683,
       "Room": 98,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25298
     },
     {
@@ -4019,10 +3975,6 @@
       "Y": -6144,
       "Z": 53742,
       "Room": 97,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25298
     },
     {
@@ -4030,10 +3982,6 @@
       "Y": -6144,
       "Z": 50720,
       "Room": 97,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25298
     },
     {
@@ -4041,10 +3989,6 @@
       "Y": -6400,
       "Z": 44626,
       "Room": 95,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25298
     },
     {
@@ -4052,10 +3996,6 @@
       "Y": -2816,
       "Z": 47587,
       "Room": 91,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25298
     },
     {
@@ -4063,10 +4003,6 @@
       "Y": -3328,
       "Z": 51701,
       "Room": 108,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25298
     },
     {
@@ -4074,10 +4010,6 @@
       "Y": -2927,
       "Z": 51647,
       "Room": 105,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25298
     },
     {
@@ -4085,10 +4017,6 @@
       "Y": -3584,
       "Z": 47557,
       "Room": 112,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25298
     },
     {
@@ -4096,10 +4024,6 @@
       "Y": -4608,
       "Z": 73230,
       "Room": 134,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25339
     },
     {
@@ -4107,10 +4031,6 @@
       "Y": -4608,
       "Z": 71168,
       "Room": 134,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25339
     },
     {
@@ -4118,10 +4038,6 @@
       "Y": -4608,
       "Z": 65024,
       "Room": 27,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25339
     },
     {
@@ -4129,10 +4045,6 @@
       "Y": -4608,
       "Z": 61952,
       "Room": 27,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25339
     },
     {
@@ -4140,10 +4052,6 @@
       "Y": -5120,
       "Z": 64031,
       "Room": 27,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25339
     },
     {
@@ -4151,10 +4059,6 @@
       "Y": -4608,
       "Z": 70160,
       "Room": 191,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25339
     },
     {
@@ -4162,10 +4066,6 @@
       "Y": -4608,
       "Z": 73245,
       "Room": 134,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25339
     },
     {
@@ -4173,10 +4073,6 @@
       "Y": -2816,
       "Z": 72192,
       "Room": 133,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25339
     },
     {
@@ -4184,10 +4080,6 @@
       "Y": -2944,
       "Z": 69120,
       "Room": 187,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25339
     },
     {
@@ -4195,10 +4087,6 @@
       "Y": -2816,
       "Z": 75279,
       "Room": 133,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25339
     },
     {
@@ -4206,10 +4094,6 @@
       "Y": -2816,
       "Z": 61913,
       "Room": 187,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25339
     },
     {
@@ -4217,10 +4101,6 @@
       "Y": -4608,
       "Z": 65024,
       "Room": 27,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25339
     },
     {
@@ -4228,10 +4108,6 @@
       "Y": -2816,
       "Z": 62976,
       "Room": 187,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25339
     },
     {
@@ -4239,10 +4115,6 @@
       "Y": -3072,
       "Z": 81408,
       "Room": 115,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25321
     },
     {
@@ -4250,10 +4122,6 @@
       "Y": -3072,
       "Z": 82457,
       "Room": 115,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25321
     },
     {
@@ -4261,10 +4129,6 @@
       "Y": -3071,
       "Z": 79338,
       "Room": 115,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25321
     },
     {
@@ -4272,10 +4136,6 @@
       "Y": -2816,
       "Z": 75264,
       "Room": 77,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25321
     },
     {
@@ -4283,10 +4143,6 @@
       "Y": -2688,
       "Z": 78336,
       "Room": 78,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25321
     },
     {
@@ -4294,10 +4150,6 @@
       "Y": -2816,
       "Z": 80377,
       "Room": 78,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25321
     },
     {
@@ -4305,10 +4157,6 @@
       "Y": -2816,
       "Z": 77277,
       "Room": 78,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25321
     },
     {
@@ -4316,10 +4164,6 @@
       "Y": -2944,
       "Z": 73216,
       "Room": 77,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25321
     },
     {
@@ -4327,10 +4171,6 @@
       "Y": -2815,
       "Z": 72974,
       "Room": 77,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25321
     },
     {
@@ -4338,10 +4178,6 @@
       "Y": -3072,
       "Z": 79922,
       "Room": 115,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25321
     },
     {
@@ -4349,10 +4185,6 @@
       "Y": -512,
       "Z": 36349,
       "Room": 186,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25375
     },
     {
@@ -4360,10 +4192,6 @@
       "Y": -1024,
       "Z": 42515,
       "Room": 157,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25375
     },
     {
@@ -4371,10 +4199,6 @@
       "Y": -1811,
       "Z": 44327,
       "Room": 75,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25375
     },
     {
@@ -4382,10 +4206,6 @@
       "Y": -1280,
       "Z": 52656,
       "Room": 76,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25375
     },
     {
@@ -4393,10 +4213,6 @@
       "Y": -1931,
       "Z": 53807,
       "Room": 202,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25375
     },
     {
@@ -4404,10 +4220,6 @@
       "Y": -3864,
       "Z": 50636,
       "Room": 71,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25375
     },
     {
@@ -4415,10 +4227,6 @@
       "Y": -3591,
       "Z": 40425,
       "Room": 70,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25375
     },
     {
@@ -4426,10 +4234,6 @@
       "Y": -3712,
       "Z": 35328,
       "Room": 203,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25375
     },
     {
@@ -4437,10 +4241,6 @@
       "Y": -1280,
       "Z": 38216,
       "Room": 103,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25375
     },
     {
@@ -4448,10 +4248,6 @@
       "Y": -1280,
       "Z": 29692,
       "Room": 102,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25375
     },
     {
@@ -4459,10 +4255,6 @@
       "Y": -1906,
       "Z": 26109,
       "Room": 46,
-      "Difficulty": "Easy",
-      "IsInRoomSpace": false,
-      "IsItem": false,
-      "RequiresGlitch": false,
       "KeyItemGroupID": 25375
     }
   ],


### PR DESCRIPTION
Removed all redundant variables from TR3 key item locations. Also changed the logic to skip over levels that don't have key items (or don't move them) and removed the placeholder locations for these (Kaliya, Madubu, Puna, City, Cavern).
Doing this ahead of #465, which will require some location updates.
Resolves #471.