### PR TITLE
Fix Lara texture corruption

### DIFF
--- a/TRRandomizerCore/Levels/TR1CombinedLevel.cs
+++ b/TRRandomizerCore/Levels/TR1CombinedLevel.cs
@@ -6,6 +6,8 @@ namespace TRRandomizerCore.Levels
 {
     public class TR1CombinedLevel
     {
+        private const string _steamPyramidChecksum = "2205228f27e5ff5eb9912d8ec0f001ef";
+
         /// <summary>
         /// The main level data stored in the corresponding .PHD file.
         /// </summary>
@@ -15,6 +17,11 @@ namespace TRRandomizerCore.Levels
         /// The scripting information for the level stored in Tomb1Main_gameflow.json5.
         /// </summary>
         public TR1ScriptedLevel Script { get; set; }
+
+        /// <summary>
+        /// The checksum of the backed up level file.
+        /// </summary>
+        public string Checksum { get; set; }
 
         /// <summary>
         /// The uppercase base file name of the level e.g. LEVEL1.PHD
@@ -54,5 +61,15 @@ namespace TRRandomizerCore.Levels
         /// Checks if the current level is the assault course.
         /// </summary>
         public bool IsAssault => Is(TRLevelNames.ASSAULT);
+
+        /// <summary>
+        /// Tests if this level is the Steam/GoG version of Great Pyramid.
+        /// </summary>
+        public bool IsSteamPyramid => Is(TRLevelNames.PYRAMID) && Checksum == _steamPyramidChecksum;
+
+        /// <summary>
+        /// Returns {Name}-Steam if IsSteamPyramid, otherwise just {Name}.
+        /// </summary>
+        public string JsonID => IsSteamPyramid ? Name + "-Steam" : Name;
     }
 }

--- a/TRRandomizerCore/Levels/TR2CombinedLevel.cs
+++ b/TRRandomizerCore/Levels/TR2CombinedLevel.cs
@@ -21,6 +21,11 @@ namespace TRRandomizerCore.Levels
         public TR2ScriptedLevel Script { get; set; }
 
         /// <summary>
+        /// The checksum of the backed up level file.
+        /// </summary>
+        public string Checksum { get; set; }
+
+        /// <summary>
         /// The uppercase base file name of the level e.g. KEEL.TR2
         /// </summary>
         public string Name => Script.LevelFileBaseName.ToUpper();

--- a/TRRandomizerCore/Levels/TR3CombinedLevel.cs
+++ b/TRRandomizerCore/Levels/TR3CombinedLevel.cs
@@ -20,6 +20,11 @@ namespace TRRandomizerCore.Levels
         public TR3ScriptedLevel Script { get; set; }
 
         /// <summary>
+        /// The checksum of the backed up level file.
+        /// </summary>
+        public string Checksum { get; set; }
+
+        /// <summary>
         /// The uppercase base file name of the level e.g. KEEL.TR2
         /// </summary>
         public string Name => Script.LevelFileBaseName.ToUpper();

--- a/TRRandomizerCore/Processors/AbstractLevelProcessor.cs
+++ b/TRRandomizerCore/Processors/AbstractLevelProcessor.cs
@@ -117,5 +117,11 @@ namespace TRRandomizerCore.Processors
         {
             return File.ReadAllText(GetResourcePath(filePath));
         }
+
+        public string GetBackupChecksum(string filePath)
+        {
+            string fullPath = Path.Combine(BackupPath, filePath);
+            return new FileInfo(fullPath).Checksum();
+        }
     }
 }

--- a/TRRandomizerCore/Processors/TR1/TR1LevelProcessor.cs
+++ b/TRRandomizerCore/Processors/TR1/TR1LevelProcessor.cs
@@ -22,7 +22,8 @@ namespace TRRandomizerCore.Processors
             TR1CombinedLevel level = new TR1CombinedLevel
             {
                 Data = LoadLevelData(scriptedLevel.LevelFileBaseName),
-                Script = scriptedLevel
+                Script = scriptedLevel,
+                Checksum = GetBackupChecksum(scriptedLevel.LevelFileBaseName)
             };
 
             if (scriptedLevel.HasCutScene)

--- a/TRRandomizerCore/Processors/TR2/TR2LevelProcessor.cs
+++ b/TRRandomizerCore/Processors/TR2/TR2LevelProcessor.cs
@@ -22,7 +22,8 @@ namespace TRRandomizerCore.Processors
             TR2CombinedLevel level = new TR2CombinedLevel
             {
                 Data = LoadLevelData(scriptedLevel.LevelFileBaseName),
-                Script = scriptedLevel
+                Script = scriptedLevel,
+                Checksum = GetBackupChecksum(scriptedLevel.LevelFileBaseName)
             };
 
             if (scriptedLevel.HasCutScene)

--- a/TRRandomizerCore/Processors/TR3/TR3LevelProcessor.cs
+++ b/TRRandomizerCore/Processors/TR3/TR3LevelProcessor.cs
@@ -27,7 +27,8 @@ namespace TRRandomizerCore.Processors
             TR3CombinedLevel level = new TR3CombinedLevel
             {
                 Data = LoadLevelData(scriptedLevel.LevelFileBaseName),
-                Script = scriptedLevel
+                Script = scriptedLevel,
+                Checksum = GetBackupChecksum(scriptedLevel.LevelFileBaseName)
             };
 
             if (scriptedLevel.HasCutScene)

--- a/TRRandomizerCore/Randomizers/TR1/TR1TextureRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/TR1TextureRandomizer.cs
@@ -224,7 +224,7 @@ namespace TRRandomizerCore.Randomizers
                 return TR1TextureMapping.Get
                 (
                     level.Data,
-                    level.Name,
+                    level.JsonID,
                     _textureDatabase,
                     TextureMonitor.GetLevelMapping(level.Name),
                     TextureMonitor.GetIgnoredEntities(level.Name),

--- a/TRRandomizerCore/Resources/TR1/Textures/Mapping/LEVEL10C.PHD-Steam-Textures.json
+++ b/TRRandomizerCore/Resources/TR1/Textures/Mapping/LEVEL10C.PHD-Steam-Textures.json
@@ -1,0 +1,128 @@
+{
+  "Landmarks": {
+    "Landmarks.apel_": {
+      "0": [
+        {
+          "RectangleIndices": [ 152 ],
+          "BackgroundIndex": 2,
+          "RoomNumber": 49
+        }
+      ]
+    }
+  },
+
+  "Static": {
+    "Lara.Bobble": [
+      {
+        "Segment": 0,
+        "Tile": 9,
+        "X": 32,
+        "Y": 208
+      },
+      {
+        "Segment": 1,
+        "Tile": 9,
+        "X": 176,
+        "Y": 208
+      },
+      {
+        "Segment": 2,
+        "Tile": 9,
+        "X": 192,
+        "Y": 208
+      },
+      {
+        "Segment": 3,
+        "Tile": 9,
+        "X": 160,
+        "Y": 208
+      },
+      {
+        "Segment": 4,
+        "Tile": 9,
+        "X": 48,
+        "Y": 208
+      },
+      {
+        "Segment": 5,
+        "Tile": 9,
+        "X": 144,
+        "Y": 208
+      }
+    ],
+    "Lara.Top": [
+      {
+        "Segment": 0,
+        "Tile": 7,
+        "X": 184,
+        "Y": 200
+      },
+      {
+        "Segment": 1,
+        "Tile": 8,
+        "X": 152,
+        "Y": 72
+      },
+      {
+        "Segment": 1,
+        "Tile": 8,
+        "X": 80,
+        "Y": 80
+      },
+      {
+        "Segment": 2,
+        "Tile": 9,
+        "X": 32,
+        "Y": 0
+      },
+      {
+        "Segment": 2,
+        "Tile": 9,
+        "X": 96,
+        "Y": 0
+      },
+      {
+        "Segment": 3,
+        "Tile": 7,
+        "X": 184,
+        "Y": 232
+      },
+      {
+        "Segment": 4,
+        "Tile": 8,
+        "X": 216,
+        "Y": 240
+      },
+      {
+        "Segment": 5,
+        "Tile": 8,
+        "X": 80,
+        "Y": 112
+      },
+      {
+        "Segment": 7,
+        "Tile": 9,
+        "X": 72,
+        "Y": 0
+      },
+      {
+        "Segment": 8,
+        "Tile": 6,
+        "X": 72,
+        "Y": 248
+      },
+      {
+        "Segment": 9,
+        "Tile": 9,
+        "X": 16,
+        "Y": 208
+      },
+      {
+        "Segment": 10,
+        "Tile": 8,
+        "X": 48,
+        "Y": 144
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Until we rework the texture system, this will use different manual mapping for Lara's outfit for the Steam/GOG version of Great Pyramid. Added the checksum property to all levels in case needed elsewhere.
Resolves #476.