### PR TITLE
Fix Pyramid secret

### DIFF
--- a/TRRandomizerCore/Resources/TR1/Environment/LEVEL10C.PHD-Environment.json
+++ b/TRRandomizerCore/Resources/TR1/Environment/LEVEL10C.PHD-Environment.json
@@ -1,5 +1,21 @@
 {
-  "All": [],
+  "All": [
+    {
+      "Comments": "Fix the final secret if secret randomization is not enabled (if the trigger isn't there, nothing is done).",
+      "EMType": 66,
+      "Locations": [
+        {
+          "X": 69120,
+          "Z": 51712,
+          "Room": 64
+        }
+      ],
+      "Action": {
+        "Action": 10,
+        "Parameter": 2
+      }
+    }
+  ],
   "NonPurist": [
     {
       "Comments": "Fix the out of place texture in room 2.",


### PR DESCRIPTION
T1M used to fix this issue with a gameflow sequence, but was [changed recently](https://github.com/LostArtefacts/Tomb1Main/pull/790) to use an injection instead. This injection also fixes other FD issues in the game, so the rando ignores this injection file to avoid conflicts with environment changes. Other FD issues are handled in `All` or `NonPurist` in the environment mods anyway, but this secret was missed.

One side effect of this is that we can't place a rando secret on this particular tile (well we could, but it would likely break the secret index); I don't think it's an issue as it'd be in plain sight.

Resolves #495.