### PR TITLE
Fix Ice Palace softlock

### DIFF
--- a/TRRandomizerCore/Randomizers/Shared/EnvironmentPicker.cs
+++ b/TRRandomizerCore/Randomizers/Shared/EnvironmentPicker.cs
@@ -18,7 +18,8 @@ namespace TRRandomizerCore.Randomizers
         {
             Options = new EMOptions
             {
-                EnableHardMode = hardMode
+                EnableHardMode = hardMode,
+                ExcludedTags = new List<EMTag>()
             };
         }
 
@@ -53,6 +54,16 @@ namespace TRRandomizerCore.Randomizers
                 : EMTag.CommunityPatchOnly);
 
             Options.ExcludedTags = excludedTags;
+        }
+
+        public void ResetTags(bool isCommunityPatch)
+        {
+            Options.ExcludedTags = new List<EMTag>
+            {
+                isCommunityPatch
+                ? EMTag.NonCommunityPatchOnly
+                : EMTag.CommunityPatchOnly
+            };
         }
 
         public List<EMEditorSet> GetRandomAny(EMEditorMapping mapping)

--- a/TRRandomizerCore/Randomizers/TR1/TR1EnvironmentRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/TR1EnvironmentRandomizer.cs
@@ -180,6 +180,7 @@ namespace TRRandomizerCore.Randomizers
             // or may not apply. Process these last so that conditions based on other
             // mods can be used.
             picker.Options.ExclusionMode = EMExclusionMode.Individual;
+            picker.ResetTags(ScriptEditor.Edition.IsCommunityPatch);
             foreach (EMConditionalSingleEditorSet mod in mapping.ConditionalAll)
             {
                 mod.ApplyToLevel(level.Data, picker.Options);

--- a/TRRandomizerCore/Randomizers/TR2/TR2EnvironmentRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR2/TR2EnvironmentRandomizer.cs
@@ -141,6 +141,7 @@ namespace TRRandomizerCore.Randomizers
             // or may not apply. Process these last so that conditions based on other
             // mods can be used.
             picker.Options.ExclusionMode = EMExclusionMode.Individual;
+            picker.ResetTags(ScriptEditor.Edition.IsCommunityPatch);
             foreach (EMConditionalSingleEditorSet mod in mapping.ConditionalAll)
             {
                 mod.ApplyToLevel(level.Data, picker.Options);

--- a/TRRandomizerCore/Randomizers/TR3/TR3EnvironmentRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/TR3EnvironmentRandomizer.cs
@@ -182,6 +182,7 @@ namespace TRRandomizerCore.Randomizers
             // or may not apply. Process these last so that conditions based on other
             // mods can be used.
             picker.Options.ExclusionMode = EMExclusionMode.Individual;
+            picker.ResetTags(ScriptEditor.Edition.IsCommunityPatch);
             foreach (EMConditionalSingleEditorSet mod in mapping.ConditionalAll)
             {
                 mod.ApplyToLevel(level.Data, picker.Options);

--- a/TRRandomizerCore/Resources/TR2/Environment/ICECAVE.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR2/Environment/ICECAVE.TR2-Environment.json
@@ -1697,9 +1697,6 @@
         {
           "Comments": "A ladder to get to the new room.",
           "EMType": 0,
-          "Tags": [
-            3
-          ],
           "TextureMap": {
             "1387": {
               "138": {


### PR DESCRIPTION
Ensures tags are reset before running `ConditionalAll` as these run regardless of whether or not environment rando is enabled. The actual fix is in the JSON file for this issue, but the code change ensures this shouldn't happen again.
Resolves #497.