### PR TITLE
Secret Pack Mode

### DIFF
--- a/TRRandomizerCore/Editors/RandomizerSettings.cs
+++ b/TRRandomizerCore/Editors/RandomizerSettings.cs
@@ -83,8 +83,8 @@ namespace TRRandomizerCore.Editors
         public TRSecretCountMode SecretCountMode { get; set; }
         public uint MinSecretCount { get; set; }
         public uint MaxSecretCount { get; set; }
-        public bool UseAuthoredSecrets { get; set; }
-        public string SecretAuthor { get; set; }
+        public bool UseSecretPack { get; set; }
+        public string SecretPack { get; set; }
         public bool PersistOutfits { get; set; }
         public bool RemoveRobeDagger { get; set; }
         public uint HaircutLevelCount { get; set; }
@@ -186,8 +186,8 @@ namespace TRRandomizerCore.Editors
             SecretCountMode = (TRSecretCountMode)config.GetEnum(nameof(SecretCountMode), typeof(TRSecretCountMode), TRSecretCountMode.Default);
             MinSecretCount = config.GetUInt(nameof(MinSecretCount), 1);
             MaxSecretCount = config.GetUInt(nameof(MaxSecretCount), 5);
-            UseAuthoredSecrets = config.GetBool(nameof(UseAuthoredSecrets));
-            SecretAuthor = config.GetString(nameof(SecretAuthor));
+            UseSecretPack = config.GetBool(nameof(UseSecretPack));
+            SecretPack = config.GetString(nameof(SecretPack));
 
             RandomizeItems = config.GetBool(nameof(RandomizeItems));
             ItemSeed = config.GetInt(nameof(ItemSeed), defaultSeed);
@@ -338,8 +338,8 @@ namespace TRRandomizerCore.Editors
             config[nameof(SecretCountMode)] = SecretCountMode;
             config[nameof(MinSecretCount)] = MinSecretCount;
             config[nameof(MaxSecretCount)] = MaxSecretCount;
-            config[nameof(UseAuthoredSecrets)] = UseAuthoredSecrets;
-            config[nameof(SecretAuthor)] = SecretAuthor;
+            config[nameof(UseSecretPack)] = UseSecretPack;
+            config[nameof(SecretPack)] = SecretPack;
 
             config[nameof(RandomizeItems)] = RandomizeItems;
             config[nameof(ItemSeed)] = ItemSeed;

--- a/TRRandomizerCore/Editors/RandomizerSettings.cs
+++ b/TRRandomizerCore/Editors/RandomizerSettings.cs
@@ -83,6 +83,8 @@ namespace TRRandomizerCore.Editors
         public TRSecretCountMode SecretCountMode { get; set; }
         public uint MinSecretCount { get; set; }
         public uint MaxSecretCount { get; set; }
+        public bool UseAuthoredSecrets { get; set; }
+        public string SecretAuthor { get; set; }
         public bool PersistOutfits { get; set; }
         public bool RemoveRobeDagger { get; set; }
         public uint HaircutLevelCount { get; set; }
@@ -184,6 +186,8 @@ namespace TRRandomizerCore.Editors
             SecretCountMode = (TRSecretCountMode)config.GetEnum(nameof(SecretCountMode), typeof(TRSecretCountMode), TRSecretCountMode.Default);
             MinSecretCount = config.GetUInt(nameof(MinSecretCount), 1);
             MaxSecretCount = config.GetUInt(nameof(MaxSecretCount), 5);
+            UseAuthoredSecrets = config.GetBool(nameof(UseAuthoredSecrets));
+            SecretAuthor = config.GetString(nameof(SecretAuthor));
 
             RandomizeItems = config.GetBool(nameof(RandomizeItems));
             ItemSeed = config.GetInt(nameof(ItemSeed), defaultSeed);
@@ -334,6 +338,8 @@ namespace TRRandomizerCore.Editors
             config[nameof(SecretCountMode)] = SecretCountMode;
             config[nameof(MinSecretCount)] = MinSecretCount;
             config[nameof(MaxSecretCount)] = MaxSecretCount;
+            config[nameof(UseAuthoredSecrets)] = UseAuthoredSecrets;
+            config[nameof(SecretAuthor)] = SecretAuthor;
 
             config[nameof(RandomizeItems)] = RandomizeItems;
             config[nameof(ItemSeed)] = ItemSeed;

--- a/TRRandomizerCore/Editors/TR1RandoEditor.cs
+++ b/TRRandomizerCore/Editors/TR1RandoEditor.cs
@@ -147,6 +147,7 @@ namespace TRRandomizerCore.Editors
                 Settings = Settings,
                 TextureMonitor = textureMonitor
             };
+            environmentRandomizer.AllocateMirroredLevels(Settings.EnvironmentSeed);
 
             using (textureMonitor)
             {
@@ -203,7 +204,7 @@ namespace TRRandomizerCore.Editors
                         SaveMonitor = monitor,
                         Settings = Settings,
                         ItemFactory = itemFactory,
-                        MirrorLevels = environmentRandomizer.AllocateMirroredLevels(Settings.EnvironmentSeed)
+                        Mirrorer = environmentRandomizer
                     }.Randomize(Settings.SecretSeed);
                 }
 

--- a/TRRandomizerCore/Editors/TR2RandoEditor.cs
+++ b/TRRandomizerCore/Editors/TR2RandoEditor.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using TRGE.Coord;
 using TRGE.Core;
 using TRLevelControl.Helpers;
+using TRRandomizerCore.Helpers;
 using TRRandomizerCore.Processors;
 using TRRandomizerCore.Randomizers;
 using TRRandomizerCore.Textures;
@@ -70,6 +71,7 @@ namespace TRRandomizerCore.Editors
                 scriptEditor.SaveScript();
             }
 
+            ItemFactory itemFactory = new();
             TR2TextureMonitorBroker textureMonitor = new();
             TR2EnvironmentRandomizer environmentRandomizer = new()
             {
@@ -141,7 +143,8 @@ namespace TRRandomizerCore.Editors
                         BackupPath = backupDirectory,
                         SaveMonitor = monitor,
                         Settings = Settings,
-                        Mirrorer = environmentRandomizer
+                        Mirrorer = environmentRandomizer,
+                        ItemFactory = itemFactory,
                     }.Randomize(Settings.SecretSeed);
                 }
 
@@ -157,7 +160,8 @@ namespace TRRandomizerCore.Editors
                         BackupPath = backupDirectory,
                         SaveMonitor = monitor,
                         Settings = Settings,
-                        TextureMonitor = textureMonitor
+                        TextureMonitor = textureMonitor,
+                        ItemFactory = itemFactory,
                     }).Randomize(Settings.ItemSeed);
                 }
 

--- a/TRRandomizerCore/Editors/TR2RandoEditor.cs
+++ b/TRRandomizerCore/Editors/TR2RandoEditor.cs
@@ -70,9 +70,22 @@ namespace TRRandomizerCore.Editors
                 scriptEditor.SaveScript();
             }
 
+            TR2TextureMonitorBroker textureMonitor = new();
+            TR2EnvironmentRandomizer environmentRandomizer = new()
+            {
+                ScriptEditor = tr23ScriptEditor,
+                Levels = levels,
+                BasePath = wipDirectory,
+                BackupPath = backupDirectory,
+                SaveMonitor = monitor,
+                Settings = Settings,
+                TextureMonitor = textureMonitor
+            };
+            environmentRandomizer.AllocateMirroredLevels(Settings.EnvironmentSeed);
+
             // Texture monitoring is needed between enemy and texture randomization
             // to track where imported enemies are placed.
-            using (TR2TextureMonitorBroker textureMonitor = new TR2TextureMonitorBroker())
+            using (textureMonitor)
             {
                 if (!monitor.IsCancelled && Settings.RandomizeEnemies)
                 {
@@ -127,7 +140,8 @@ namespace TRRandomizerCore.Editors
                         BasePath = wipDirectory,
                         BackupPath = backupDirectory,
                         SaveMonitor = monitor,
-                        Settings = Settings
+                        Settings = Settings,
+                        Mirrorer = environmentRandomizer
                     }.Randomize(Settings.SecretSeed);
                 }
 
@@ -201,16 +215,7 @@ namespace TRRandomizerCore.Editors
                 if (!monitor.IsCancelled)
                 {
                     monitor.FireSaveStateBeginning(TRSaveCategory.Custom, Settings.RandomizeEnvironment ? "Randomizing environment" : "Applying default environment packs");
-                    new TR2EnvironmentRandomizer
-                    {
-                        ScriptEditor = tr23ScriptEditor,
-                        Levels = levels,
-                        BasePath = wipDirectory,
-                        BackupPath = backupDirectory,
-                        SaveMonitor = monitor,
-                        Settings = Settings,
-                        TextureMonitor = textureMonitor
-                    }.Randomize(Settings.EnvironmentSeed);
+                    environmentRandomizer.Randomize(Settings.EnvironmentSeed);
                 }
 
                 if (!monitor.IsCancelled && Settings.RandomizeAudio)

--- a/TRRandomizerCore/Editors/TR3RandoEditor.cs
+++ b/TRRandomizerCore/Editors/TR3RandoEditor.cs
@@ -190,6 +190,7 @@ namespace TRRandomizerCore.Editors
                     Settings = Settings,
                     TextureMonitor = textureMonitor
                 };
+                environmentRandomizer.AllocateMirroredLevels(Settings.EnvironmentSeed);
 
                 if (!monitor.IsCancelled && Settings.RandomizeSecrets)
                 {
@@ -204,7 +205,7 @@ namespace TRRandomizerCore.Editors
                         Settings = Settings,
                         TextureMonitor = textureMonitor,
                         ItemFactory = itemFactory,
-                        MirrorLevels = environmentRandomizer.AllocateMirroredLevels(Settings.EnvironmentSeed)
+                        Mirrorer = environmentRandomizer
                     }.Randomize(Settings.SecretSeed);
                 }
 

--- a/TRRandomizerCore/Helpers/ItemFactory.cs
+++ b/TRRandomizerCore/Helpers/ItemFactory.cs
@@ -1,7 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.IO;
 using TRLevelControl.Model;
 
 namespace TRRandomizerCore.Helpers
@@ -12,11 +9,15 @@ namespace TRRandomizerCore.Helpers
 
         private readonly Dictionary<string, List<int>> _reusableItemDefaults;
         private readonly Dictionary<string, Queue<int>> _availableItems;
+        private readonly Dictionary<string, HashSet<int>> _lockedItems;
 
-        public ItemFactory(string dataPath)
+        public ItemFactory(string dataPath = null)
         {
-            _reusableItemDefaults = JsonConvert.DeserializeObject<Dictionary<string, List<int>>>(File.ReadAllText(dataPath));
-            _availableItems = new Dictionary<string, Queue<int>>();
+            _reusableItemDefaults = dataPath == null
+                ? new()
+                : JsonConvert.DeserializeObject<Dictionary<string, List<int>>>(File.ReadAllText(dataPath));
+            _availableItems = new();
+            _lockedItems = new();
         }
 
         public Queue<int> GetItemPool(string lvl)
@@ -146,6 +147,20 @@ namespace TRRandomizerCore.Helpers
         public void FreeItem(string lvl, int itemIndex)
         {
             GetItemPool(lvl).Enqueue(itemIndex);
+        }
+
+        public void LockItem(string level, int itemIndex)
+        {
+            if (!_lockedItems.ContainsKey(level))
+            {
+                _lockedItems[level] = new();
+            }
+            _lockedItems[level].Add(itemIndex);
+        }
+
+        public bool IsItemLocked(string level, int itemIndex)
+        {
+            return _lockedItems.ContainsKey(level) && _lockedItems[level].Contains(itemIndex);
         }
     }
 }

--- a/TRRandomizerCore/Helpers/Location.cs
+++ b/TRRandomizerCore/Helpers/Location.cs
@@ -4,7 +4,7 @@ namespace TRRandomizerCore.Helpers
 {
     public class Location
     {
-        public const string DefaultAuthor = "TRRando";
+        public const string DefaultPackID = "TRRando";
 
         public int X { get; set; }
 
@@ -44,8 +44,8 @@ namespace TRRandomizerCore.Helpers
         [DefaultValue(-1)]
         public short TargetType { get; set; }
 
-        [DefaultValue(DefaultAuthor)]
-        public string Author { get; set; }
+        [DefaultValue(DefaultPackID)]
+        public string PackID { get; set; }
 
         public Location()
         {
@@ -66,7 +66,7 @@ namespace TRRandomizerCore.Helpers
             LevelState = LevelState.Any;
             EntityIndex = -1;
             TargetType = -1;
-            Author = DefaultAuthor;
+            PackID = DefaultPackID;
         }
 
         /// <summary>

--- a/TRRandomizerCore/Helpers/Location.cs
+++ b/TRRandomizerCore/Helpers/Location.cs
@@ -4,6 +4,8 @@ namespace TRRandomizerCore.Helpers
 {
     public class Location
     {
+        public const string DefaultAuthor = "TRRando";
+
         public int X { get; set; }
 
         public int Y { get; set; }
@@ -42,6 +44,9 @@ namespace TRRandomizerCore.Helpers
         [DefaultValue(-1)]
         public short TargetType { get; set; }
 
+        [DefaultValue(DefaultAuthor)]
+        public string Author { get; set; }
+
         public Location()
         {
             X = 0;
@@ -61,6 +66,7 @@ namespace TRRandomizerCore.Helpers
             LevelState = LevelState.Any;
             EntityIndex = -1;
             TargetType = -1;
+            Author = DefaultAuthor;
         }
 
         /// <summary>

--- a/TRRandomizerCore/Randomizers/Shared/IMirrorControl.cs
+++ b/TRRandomizerCore/Randomizers/Shared/IMirrorControl.cs
@@ -1,0 +1,8 @@
+﻿namespace TRRandomizerCore.Randomizers;
+
+public interface IMirrorControl
+{
+    void AllocateMirroredLevels(int seed);
+    bool IsMirrored(string levelName);
+    void SetIsMirrored(string levelName, bool mirrored);
+}

--- a/TRRandomizerCore/Randomizers/Shared/ISecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/Shared/ISecretRandomizer.cs
@@ -1,0 +1,6 @@
+﻿namespace TRRandomizerCore.Randomizers;
+
+public interface ISecretRandomizer
+{
+    IEnumerable<string> GetAuthors();
+}

--- a/TRRandomizerCore/Randomizers/Shared/ISecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/Shared/ISecretRandomizer.cs
@@ -2,5 +2,5 @@
 
 public interface ISecretRandomizer
 {
-    IEnumerable<string> GetAuthors();
+    IEnumerable<string> GetPacks();
 }

--- a/TRRandomizerCore/Randomizers/Shared/SecretPicker.cs
+++ b/TRRandomizerCore/Randomizers/Shared/SecretPicker.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using TRRandomizerCore.Editors;
+﻿using TRRandomizerCore.Editors;
 using TRRandomizerCore.Helpers;
 
 namespace TRRandomizerCore.Randomizers
@@ -15,9 +12,33 @@ namespace TRRandomizerCore.Randomizers
         {
             Queue<Location> locations = new Queue<Location>();
 
+            if (Settings.UseAuthoredSecrets)
+            {
+                List<Location> pool = allLocations
+                    .Where(l => l.Author == Settings.SecretAuthor)
+                    .ToList();
+
+                if (pool.Any(l => l.LevelState == LevelState.Mirrored)
+                    && pool.Any(l => l.LevelState == LevelState.NotMirrored))
+                {
+                    // Invalid, authors should be aware of this. Default to removing all mirrored locations.
+                    pool.RemoveAll(l => l.LevelState == LevelState.Mirrored);
+                }
+
+                for (int i = 0; i < pool.Count && locations.Count < totalCount; i++)
+                {
+                    locations.Enqueue(pool[i]);
+                }
+
+                if (locations.Count == totalCount)
+                {
+                    return locations;
+                }
+            }
+
             if (Settings.GuaranteeSecrets)
             {
-                int maxCount = Math.Max(1, (int)Math.Floor(totalCount / 2d));
+                int maxCount = Math.Max(1, (int)Math.Floor(totalCount / 2d)) + locations.Count;
 
                 // Create location pools for the categories selected.
                 List<IEnumerable<Location>> pools = new List<IEnumerable<Location>>();

--- a/TRRandomizerCore/Randomizers/Shared/SecretPicker.cs
+++ b/TRRandomizerCore/Randomizers/Shared/SecretPicker.cs
@@ -14,10 +14,10 @@ namespace TRRandomizerCore.Randomizers
         {
             Queue<Location> locations = new Queue<Location>();
 
-            if (Settings.UseAuthoredSecrets)
+            if (Settings.UseSecretPack)
             {
                 List<Location> pool = allLocations
-                    .Where(l => l.Author == Settings.SecretAuthor)
+                    .Where(l => l.PackID == Settings.SecretPack)
                     .ToList();
 
                 if (pool.Any(l => l.LevelState == LevelState.Mirrored)
@@ -96,7 +96,7 @@ namespace TRRandomizerCore.Randomizers
 
         public void FinaliseSecretPool(IEnumerable<Location> usedLocations, string level)
         {
-            // Authored secrets are permitted to enforce level state
+            // Secrets in packs are permitted to enforce level state
             if (usedLocations.Any(l => l.LevelState == LevelState.Mirrored))
             {
                 Mirrorer.SetIsMirrored(level, true);

--- a/TRRandomizerCore/Randomizers/TR1/TR1ItemRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/TR1ItemRandomizer.cs
@@ -278,9 +278,9 @@ namespace TRRandomizerCore.Randomizers
 
             for (int i = 0; i < level.Data.NumEntities; i++)
             {
-                if (_secretMapping.RewardEntities.Contains(i))
+                if (_secretMapping.RewardEntities.Contains(i)
+                    || ItemFactory.IsItemLocked(_levelInstance.Name, i))
                 {
-                    // These will either be in their default spot or in their dedicated reward room, so leave them be
                     continue;
                 }
 

--- a/TRRandomizerCore/Randomizers/TR1/TR1SecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/TR1SecretRandomizer.cs
@@ -74,6 +74,8 @@ namespace TRRandomizerCore.Randomizers
             {
                 Settings = Settings,
                 Generator = _generator,
+                ItemFactory = ItemFactory,
+                Mirrorer = Mirrorer,
             };
 
             if (ScriptEditor.Edition.IsCommunityPatch && !Settings.UseAuthoredSecrets)
@@ -560,15 +562,7 @@ namespace TRRandomizerCore.Randomizers
 
             AddDamageControl(level, damagingLocationUsed, glitchedDamagingLocationUsed);
 
-            // Authored secrets are permitted to enforce level state
-            if (usedLocations.Any(l => l.LevelState == LevelState.Mirrored))
-            {
-                Mirrorer.SetIsMirrored(level.Name, true);
-            }
-            else if (usedLocations.Any(l => l.LevelState == LevelState.NotMirrored))
-            {
-                Mirrorer.SetIsMirrored(level.Name, false);
-            }
+            _picker.FinaliseSecretPool(usedLocations, level.Name);
 
 #if DEBUG
             Debug.WriteLine(level.Name + ": " +  _picker.DescribeLocations(usedLocations));

--- a/TRRandomizerCore/Randomizers/TR1/TR1SecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/TR1SecretRandomizer.cs
@@ -59,11 +59,11 @@ namespace TRRandomizerCore.Randomizers
             _unarmedLocations = JsonConvert.DeserializeObject<Dictionary<string, List<Location>>>(ReadResource(@"TR1\Locations\unarmed_locations.json"));
         }
 
-        public IEnumerable<string> GetAuthors()
+        public IEnumerable<string> GetPacks()
         {
             return _locations.Values
-                .SelectMany(v => v.Select(l => l.Author))
-                .Where(a => a != Location.DefaultAuthor)
+                .SelectMany(v => v.Select(l => l.PackID))
+                .Where(a => a != Location.DefaultPackID)
                 .Distinct();
         }
 
@@ -78,7 +78,7 @@ namespace TRRandomizerCore.Randomizers
                 Mirrorer = Mirrorer,
             };
 
-            if (ScriptEditor.Edition.IsCommunityPatch && !Settings.UseAuthoredSecrets)
+            if (ScriptEditor.Edition.IsCommunityPatch && !Settings.UseSecretPack)
             {
                 SetSecretCounts();
             }

--- a/TRRandomizerCore/Randomizers/TR1/TR1SecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/TR1SecretRandomizer.cs
@@ -1,8 +1,5 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Numerics;
 using TREnvironmentEditor.Helpers;
 using TREnvironmentEditor.Model.Types;
@@ -23,7 +20,7 @@ using TRRandomizerCore.Utilities;
 
 namespace TRRandomizerCore.Randomizers
 {
-    public class TR1SecretRandomizer : BaseTR1Randomizer
+    public class TR1SecretRandomizer : BaseTR1Randomizer, ISecretRandomizer
     {
         private static readonly string _invalidLocationMsg = "Cannot place a nonvalidated secret where a trigger already exists - {0} [X={1}, Y={2}, Z={3}, R={4}]";
         private static readonly string _trapdoorLocationMsg = "Cannot place a secret on the same sector as a bridge/trapdoor - {0} [X={1}, Y={2}, Z={3}, R={4}]";
@@ -36,7 +33,7 @@ namespace TRRandomizerCore.Randomizers
 
         private static readonly ushort _maxSecretCount = 5;
 
-        private Dictionary<string, List<Location>> _locations, _unarmedLocations;
+        private readonly Dictionary<string, List<Location>> _locations, _unarmedLocations;
 
         private int _proxEvaluationCount;
 
@@ -52,23 +49,34 @@ namespace TRRandomizerCore.Randomizers
         private static readonly int _triggerEdgeLimit = 103; // Within ~10% of a tile edge, triggers will be copied into neighbours
 
         public ItemFactory ItemFactory { get; set; }
-        public List<TR1ScriptedLevel> MirrorLevels { get; set; }
+        public IMirrorControl Mirrorer { get; set; }
 
         private SecretPicker _picker;
+
+        public TR1SecretRandomizer()
+        {
+            _locations = JsonConvert.DeserializeObject<Dictionary<string, List<Location>>>(ReadResource(@"TR1\Locations\locations.json"));
+            _unarmedLocations = JsonConvert.DeserializeObject<Dictionary<string, List<Location>>>(ReadResource(@"TR1\Locations\unarmed_locations.json"));
+        }
+
+        public IEnumerable<string> GetAuthors()
+        {
+            return _locations.Values
+                .SelectMany(v => v.Select(l => l.Author))
+                .Where(a => a != Location.DefaultAuthor)
+                .Distinct();
+        }
 
         public override void Randomize(int seed)
         {
             _generator = new Random(seed);
-            _locations = JsonConvert.DeserializeObject<Dictionary<string, List<Location>>>(ReadResource(@"TR1\Locations\locations.json"));
-            _unarmedLocations = JsonConvert.DeserializeObject<Dictionary<string, List<Location>>>(ReadResource(@"TR1\Locations\unarmed_locations.json"));
-
             _picker = new SecretPicker
             {
                 Settings = Settings,
                 Generator = _generator,
             };
 
-            if (ScriptEditor.Edition.IsCommunityPatch)
+            if (ScriptEditor.Edition.IsCommunityPatch && !Settings.UseAuthoredSecrets)
             {
                 SetSecretCounts();
             }
@@ -417,10 +425,10 @@ namespace TRRandomizerCore.Randomizers
             {
                 if (_devRooms == null || _devRooms.Contains(location.Room))
                 {
-                    if (MirrorLevels.Contains(level.Script) && location.LevelState == LevelState.NotMirrored)
+                    if (Mirrorer.IsMirrored(level.Name) && location.LevelState == LevelState.NotMirrored)
                         continue;
 
-                    if (!MirrorLevels.Contains(level.Script) && location.LevelState == LevelState.Mirrored)
+                    if (!Mirrorer.IsMirrored(level.Name) && location.LevelState == LevelState.Mirrored)
                         continue;
 
                     secret.Location = location;
@@ -476,7 +484,7 @@ namespace TRRandomizerCore.Randomizers
             locations.Shuffle(_generator);
             List<Location> usedLocations = new List<Location>();
 
-            Queue<Location> guaranteedLocations = _picker.GetGuaranteedLocations(locations, MirrorLevels.Contains(level.Script), level.Script.NumSecrets, location =>
+            Queue<Location> guaranteedLocations = _picker.GetGuaranteedLocations(locations, Mirrorer.IsMirrored(level.Name), level.Script.NumSecrets, location =>
             {
                 bool result = EvaluateProximity(location, usedLocations, level, floorData);
                 if (result)
@@ -552,6 +560,16 @@ namespace TRRandomizerCore.Randomizers
 
             AddDamageControl(level, damagingLocationUsed, glitchedDamagingLocationUsed);
 
+            // Authored secrets are permitted to enforce level state
+            if (usedLocations.Any(l => l.LevelState == LevelState.Mirrored))
+            {
+                Mirrorer.SetIsMirrored(level.Name, true);
+            }
+            else if (usedLocations.Any(l => l.LevelState == LevelState.NotMirrored))
+            {
+                Mirrorer.SetIsMirrored(level.Name, false);
+            }
+
 #if DEBUG
             Debug.WriteLine(level.Name + ": " +  _picker.DescribeLocations(usedLocations));
 #endif
@@ -566,10 +584,10 @@ namespace TRRandomizerCore.Randomizers
             if (loc.RequiresGlitch && !Settings.GlitchedSecrets)
                 return false;
 
-            if (MirrorLevels.Contains(level.Script) && loc.LevelState == LevelState.NotMirrored)
+            if (Mirrorer.IsMirrored(level.Name) && loc.LevelState == LevelState.NotMirrored)
                 return false;
 
-            if (!MirrorLevels.Contains(level.Script) && loc.LevelState == LevelState.Mirrored)
+            if (!Mirrorer.IsMirrored(level.Name) && loc.LevelState == LevelState.Mirrored)
                 return false;
 
             if (usedLocs.Count == 0 || usedLocs == null)

--- a/TRRandomizerCore/Randomizers/TR2/TR2ItemRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR2/TR2ItemRandomizer.cs
@@ -1,7 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using TRFDControl;
 using TRFDControl.Utilities;
 using TRGE.Core;
@@ -22,6 +19,7 @@ namespace TRRandomizerCore.Randomizers
         private static readonly List<int> _devRooms = null;
 
         internal TR2TextureMonitorBroker TextureMonitor { get; set; }
+        public ItemFactory ItemFactory { get; set; }
 
         // This replaces plane cargo index as TRGE may have randomized the weaponless level(s), but will also have injected pistols
         // into predefined locations. See FindUnarmedPistolsLocation below.
@@ -342,6 +340,11 @@ namespace TRRandomizerCore.Randomizers
 
                 for (int i = 0; i < _levelInstance.Data.Entities.Count(); i++)
                 {
+                    if (ItemFactory.IsItemLocked(_levelInstance.Name, i))
+                    {
+                        continue;
+                    }
+
                     if (targetents.Contains((TR2Entities)_levelInstance.Data.Entities[i].TypeID) && (i != _unarmedLevelPistolIndex))
                     {
                         Location RandomLocation = new Location();

--- a/TRRandomizerCore/Randomizers/TR2/TR2SecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR2/TR2SecretRandomizer.cs
@@ -1,6 +1,5 @@
 ﻿using Newtonsoft.Json;
 using System.Diagnostics;
-using System.Reflection.Emit;
 using TRGE.Core;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;
@@ -20,6 +19,7 @@ namespace TRRandomizerCore.Randomizers
         private SecretPicker _picker;
 
         public IMirrorControl Mirrorer { get; set; }
+        public ItemFactory ItemFactory { get; set; }
 
         public TR2SecretRandomizer()
         {
@@ -187,14 +187,7 @@ namespace TRRandomizerCore.Randomizers
                 FixSecretTextures();
                 CheckForSecretDamage(secretMap);
 
-                if (secretMap.Values.Any(l => l.LevelState == LevelState.Mirrored))
-                {
-                    Mirrorer.SetIsMirrored(_levelInstance.Name, true);
-                }
-                else if (secretMap.Values.Any(l => l.LevelState == LevelState.NotMirrored))
-                {
-                    Mirrorer.SetIsMirrored(_levelInstance.Name, false);
-                }
+                _picker.FinaliseSecretPool(secretMap.Values, _levelInstance.Name);
 
 #if DEBUG
                 Debug.WriteLine(_levelInstance.Name + ": " + _picker.DescribeLocations(secretMap.Values));
@@ -287,6 +280,8 @@ namespace TRRandomizerCore.Randomizers
             {
                 Settings = Settings,
                 Generator = _generator,
+                ItemFactory = ItemFactory,
+                Mirrorer = Mirrorer,
             };
 
             foreach (TR2ScriptedLevel lvl in Levels)

--- a/TRRandomizerCore/Randomizers/TR2/TR2SecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR2/TR2SecretRandomizer.cs
@@ -1,8 +1,6 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
+using System.Reflection.Emit;
 using TRGE.Core;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;
@@ -13,12 +11,28 @@ using TRRandomizerCore.Zones;
 
 namespace TRRandomizerCore.Randomizers
 {
-    public class TR2SecretRandomizer : BaseTR2Randomizer
+    public class TR2SecretRandomizer : BaseTR2Randomizer, ISecretRandomizer
     {
         private static readonly List<int> _devRooms = null;
         private static readonly int _levelSecretCount = 3;
 
+        private readonly Dictionary<string, List<Location>> _locations;
         private SecretPicker _picker;
+
+        public IMirrorControl Mirrorer { get; set; }
+
+        public TR2SecretRandomizer()
+        {
+            _locations = JsonConvert.DeserializeObject<Dictionary<string, List<Location>>>(ReadResource(@"TR2\Locations\locations.json"));
+        }
+
+        public IEnumerable<string> GetAuthors()
+        {
+            return _locations.Values
+                .SelectMany(v => v.Select(l => l.Author))
+                .Where(a => a != Location.DefaultAuthor)
+                .Distinct();
+        }
 
         private void RandomizeSecrets(List<Location> LevelLocations)
         {
@@ -30,38 +44,66 @@ namespace TRRandomizerCore.Randomizers
                     return;
                 }
 
-                //Apply zoning to the locations to ensure they are spread out.
-                ZonedLocationCollection ZonedLocations = new ZonedLocationCollection();
-
-                ZonedLocations.PopulateZones(GetResourcePath(@"TR2\Zones\" + _levelInstance.Name + "-Zones.json"), LevelLocations, ZonePopulationMethod.SecretsOnly);
-
                 Location goldLocation = null;
                 Location jadeLocation = null;
                 Location stoneLocation = null;
 
                 // Applied guaranteed logic first.
-                IEnumerable<Location> allLocations = ZonedLocations.GoldZone.Concat(ZonedLocations.JadeZone).Concat(ZonedLocations.StoneZone);
-                Queue<Location> guaranteedLocations = _picker.GetGuaranteedLocations(allLocations, false, _levelSecretCount);
+                Queue<Location> guaranteedLocations = _picker.GetGuaranteedLocations(LevelLocations, false, _levelSecretCount);
+
+                //Apply zoning to the locations to ensure they are spread out.                
+                List<Location> stoneZone, jadeZone, goldZone;
+                bool authorMode = Settings.UseAuthoredSecrets && LevelLocations.Any(l => l.Author != Location.DefaultAuthor);
+                if (authorMode)
+                {
+                    stoneZone = jadeZone = goldZone = LevelLocations;
+                    guaranteedLocations = new(guaranteedLocations.Reverse());
+                }
+                else
+                {
+                    ZonedLocationCollection zones = new();
+                    zones.PopulateZones(GetResourcePath(@"TR2\Zones\" + _levelInstance.Name + "-Zones.json"), LevelLocations, ZonePopulationMethod.SecretsOnly);
+                    stoneZone = zones.StoneZone;
+                    jadeZone = zones.JadeZone;
+                    goldZone = zones.GoldZone;
+                }
+
+                bool TestLocation(Location location, params Location[] setLocations)
+                {
+                    if (authorMode)
+                    {
+                        return true;
+                    }
+
+                    bool valid = true;
+                    foreach (Location setLocation in setLocations)
+                    {
+                        valid &= setLocation == null || setLocation.Room != location.Room;
+                    }
+
+                    return valid;
+                }
+
                 while (guaranteedLocations.Count > 0)
                 {
                     Location location = guaranteedLocations.Dequeue();
-                    if (ZonedLocations.GoldZone.Contains(location) && goldLocation == null)
+                    if (goldZone.Contains(location) && goldLocation == null)
                     {
-                        if ((stoneLocation == null || location.Room != stoneLocation.Room) && (jadeLocation == null || location.Room != jadeLocation.Room))
+                        if (TestLocation(location, stoneLocation, jadeLocation))
                         {
                             goldLocation = location;
                         }
                     }
-                    else if (ZonedLocations.JadeZone.Contains(location) && jadeLocation == null)
+                    else if (jadeZone.Contains(location) && jadeLocation == null)
                     {
-                        if ((stoneLocation == null || location.Room != stoneLocation.Room) && (goldLocation == null || location.Room != goldLocation.Room))
+                        if (TestLocation(location, stoneLocation, goldLocation))
                         {
                             jadeLocation = location;
                         }
                     }
                     else if (stoneLocation == null)
                     {
-                        if ((jadeLocation == null || location.Room != jadeLocation.Room) && (goldLocation == null || location.Room != goldLocation.Room))
+                        if (TestLocation(location, jadeLocation, goldLocation))
                         {
                             stoneLocation = location;
                         }
@@ -74,7 +116,7 @@ namespace TRRandomizerCore.Randomizers
                 {
                     do
                     {
-                        goldLocation = ZonedLocations.GoldZone[_generator.Next(0, ZonedLocations.GoldZone.Count)];
+                        goldLocation = goldZone[_generator.Next(0, goldZone.Count)];
                     } while ((goldLocation.Difficulty == Difficulty.Hard && Settings.HardSecrets == false) ||
                             (goldLocation.RequiresGlitch == true && Settings.GlitchedSecrets == false));
                 }
@@ -83,7 +125,7 @@ namespace TRRandomizerCore.Randomizers
                 {
                     do
                     {
-                        jadeLocation = ZonedLocations.JadeZone[_generator.Next(0, ZonedLocations.JadeZone.Count)];
+                        jadeLocation = jadeZone[_generator.Next(0, jadeZone.Count)];
                     } while ((jadeLocation.Room == goldLocation.Room) ||
                             (jadeLocation.Difficulty == Difficulty.Hard && Settings.HardSecrets == false) ||
                             (jadeLocation.RequiresGlitch == true && Settings.GlitchedSecrets == false));
@@ -93,7 +135,7 @@ namespace TRRandomizerCore.Randomizers
                 {
                     do
                     {
-                        stoneLocation = ZonedLocations.StoneZone[_generator.Next(0, ZonedLocations.StoneZone.Count)];
+                        stoneLocation = stoneZone[_generator.Next(0, stoneZone.Count)];
                     } while ((stoneLocation.Room == goldLocation.Room) ||
                             (stoneLocation.Room == jadeLocation.Room) ||
                             (stoneLocation.Difficulty == Difficulty.Hard && Settings.HardSecrets == false) ||
@@ -144,6 +186,15 @@ namespace TRRandomizerCore.Randomizers
 
                 FixSecretTextures();
                 CheckForSecretDamage(secretMap);
+
+                if (secretMap.Values.Any(l => l.LevelState == LevelState.Mirrored))
+                {
+                    Mirrorer.SetIsMirrored(_levelInstance.Name, true);
+                }
+                else if (secretMap.Values.Any(l => l.LevelState == LevelState.NotMirrored))
+                {
+                    Mirrorer.SetIsMirrored(_levelInstance.Name, false);
+                }
 
 #if DEBUG
                 Debug.WriteLine(_levelInstance.Name + ": " + _picker.DescribeLocations(secretMap.Values));
@@ -238,18 +289,18 @@ namespace TRRandomizerCore.Randomizers
                 Generator = _generator,
             };
 
-            Dictionary<string, List<Location>> Locations = JsonConvert.DeserializeObject<Dictionary<string, List<Location>>>(ReadResource(@"TR2\Locations\locations.json"));
-
             foreach (TR2ScriptedLevel lvl in Levels)
             {
                 //Read the level into a level object
                 LoadLevelInstance(lvl);
+                if (_locations.ContainsKey(_levelInstance.Name))
+                {
+                    //Apply the modifications
+                    RandomizeSecrets(_locations[_levelInstance.Name]);
 
-                //Apply the modifications
-                RandomizeSecrets(Locations[_levelInstance.Name]);
-
-                //Write back the level file
-                SaveLevelInstance();
+                    //Write back the level file
+                    SaveLevelInstance();
+                }
 
                 if (!TriggerProgress())
                 {

--- a/TRRandomizerCore/Randomizers/TR2/TR2SecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR2/TR2SecretRandomizer.cs
@@ -26,11 +26,11 @@ namespace TRRandomizerCore.Randomizers
             _locations = JsonConvert.DeserializeObject<Dictionary<string, List<Location>>>(ReadResource(@"TR2\Locations\locations.json"));
         }
 
-        public IEnumerable<string> GetAuthors()
+        public IEnumerable<string> GetPacks()
         {
             return _locations.Values
-                .SelectMany(v => v.Select(l => l.Author))
-                .Where(a => a != Location.DefaultAuthor)
+                .SelectMany(v => v.Select(l => l.PackID))
+                .Where(a => a != Location.DefaultPackID)
                 .Distinct();
         }
 
@@ -53,8 +53,8 @@ namespace TRRandomizerCore.Randomizers
 
                 //Apply zoning to the locations to ensure they are spread out.                
                 List<Location> stoneZone, jadeZone, goldZone;
-                bool authorMode = Settings.UseAuthoredSecrets && LevelLocations.Any(l => l.Author != Location.DefaultAuthor);
-                if (authorMode)
+                bool secretPackMode = Settings.UseSecretPack && LevelLocations.Any(l => l.PackID != Location.DefaultPackID);
+                if (secretPackMode)
                 {
                     stoneZone = jadeZone = goldZone = LevelLocations;
                     guaranteedLocations = new(guaranteedLocations.Reverse());
@@ -70,7 +70,7 @@ namespace TRRandomizerCore.Randomizers
 
                 bool TestLocation(Location location, params Location[] setLocations)
                 {
-                    if (authorMode)
+                    if (secretPackMode)
                     {
                         return true;
                     }

--- a/TRRandomizerCore/Randomizers/TR3/TR3ItemRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/TR3ItemRandomizer.cs
@@ -252,9 +252,9 @@ namespace TRRandomizerCore.Randomizers
 
             for (int i = 0; i < level.Data.NumEntities; i++)
             {
-                if (_secretMapping.RewardEntities.Contains(i))
+                if (_secretMapping.RewardEntities.Contains(i)
+                    || ItemFactory.IsItemLocked(_levelInstance.Name, i))
                 {
-                    // These will either be in their default spot or in their dedicated reward room, so leave them be
                     continue;
                 }
 

--- a/TRRandomizerCore/Randomizers/TR3/TR3SecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/TR3SecretRandomizer.cs
@@ -59,11 +59,11 @@ namespace TRRandomizerCore.Randomizers
             _unarmedLocations = JsonConvert.DeserializeObject<Dictionary<string, List<Location>>>(ReadResource(@"TR3\Locations\unarmed_locations.json"));
         }
 
-        public IEnumerable<string> GetAuthors()
+        public IEnumerable<string> GetPacks()
         {
             return _locations.Values
-                .SelectMany(v => v.Select(l => l.Author))
-                .Where(a => a != Location.DefaultAuthor)
+                .SelectMany(v => v.Select(l => l.PackID))
+                .Where(a => a != Location.DefaultPackID)
                 .Distinct();
         }
 

--- a/TRRandomizerCore/Randomizers/TR3/TR3SecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/TR3SecretRandomizer.cs
@@ -74,6 +74,8 @@ namespace TRRandomizerCore.Randomizers
             {
                 Settings = Settings,
                 Generator = _generator,
+                ItemFactory = ItemFactory,
+                Mirrorer = Mirrorer,
             };
 
             SetMessage("Randomizing secrets - loading levels");
@@ -489,14 +491,7 @@ namespace TRRandomizerCore.Randomizers
 
             AddDamageControl(level, pickupTypes, damagingLocationUsed, glitchedDamagingLocationUsed);
 
-            if (usedLocations.Any(l => l.LevelState == LevelState.Mirrored))
-            {
-                Mirrorer.SetIsMirrored(level.Name, true);
-            }
-            else if (usedLocations.Any(l => l.LevelState == LevelState.NotMirrored))
-            {
-                Mirrorer.SetIsMirrored(level.Name, false);
-            }
+            _picker.FinaliseSecretPool(usedLocations, level.Name);
 
 #if DEBUG
             Debug.WriteLine(level.Name + ": " + _picker.DescribeLocations(usedLocations));

--- a/TRRandomizerCore/Randomizers/TR3/TR3SecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/TR3SecretRandomizer.cs
@@ -21,7 +21,7 @@ using TRRandomizerCore.Utilities;
 
 namespace TRRandomizerCore.Randomizers
 {
-    public class TR3SecretRandomizer : BaseTR3Randomizer
+    public class TR3SecretRandomizer : BaseTR3Randomizer, ISecretRandomizer
     {
         private static readonly string _invalidLocationMsg = "Cannot place a nonvalidated secret where a trigger already exists - {0} [X={1}, Y={2}, Z={3}, R={4}]";
         private static readonly string _trapdoorLocationMsg = "Cannot place a secret on the same sector as a bridge/trapdoor - {0} [X={1}, Y={2}, Z={3}, R={4}]";
@@ -32,7 +32,7 @@ namespace TRRandomizerCore.Randomizers
         private static readonly List<int> _devRooms = null;
         private static readonly ushort _devModeSecretCount = 6;
 
-        private Dictionary<string, List<Location>> _locations, _unarmedLocations;
+        private readonly Dictionary<string, List<Location>> _locations, _unarmedLocations;
 
         private int _proxEvaluationCount;
 
@@ -49,16 +49,27 @@ namespace TRRandomizerCore.Randomizers
 
         internal TR3TextureMonitorBroker TextureMonitor { get; set; }
         public ItemFactory ItemFactory { get; set; }
-        public List<TR3ScriptedLevel> MirrorLevels { get; set; }
+        public IMirrorControl Mirrorer { get; set; }
 
         private SecretPicker _picker;
+
+        public TR3SecretRandomizer()
+        {
+            _locations = JsonConvert.DeserializeObject<Dictionary<string, List<Location>>>(ReadResource(@"TR3\Locations\locations.json"));
+            _unarmedLocations = JsonConvert.DeserializeObject<Dictionary<string, List<Location>>>(ReadResource(@"TR3\Locations\unarmed_locations.json"));
+        }
+
+        public IEnumerable<string> GetAuthors()
+        {
+            return _locations.Values
+                .SelectMany(v => v.Select(l => l.Author))
+                .Where(a => a != Location.DefaultAuthor)
+                .Distinct();
+        }
 
         public override void Randomize(int seed)
         {
             _generator = new Random(seed);
-            _locations = JsonConvert.DeserializeObject<Dictionary<string, List<Location>>>(ReadResource(@"TR3\Locations\locations.json"));
-            _unarmedLocations = JsonConvert.DeserializeObject<Dictionary<string, List<Location>>>(ReadResource(@"TR3\Locations\unarmed_locations.json"));
-
             _picker = new SecretPicker
             {
                 Settings = Settings,
@@ -346,10 +357,10 @@ namespace TRRandomizerCore.Randomizers
             {
                 if (_devRooms == null || _devRooms.Contains(location.Room))
                 {
-                    if (MirrorLevels.Contains(level.Script) && location.LevelState == LevelState.NotMirrored)
+                    if (Mirrorer.IsMirrored(level.Name) && location.LevelState == LevelState.NotMirrored)
                         continue;
 
-                    if (!MirrorLevels.Contains(level.Script) && location.LevelState == LevelState.Mirrored)
+                    if (!Mirrorer.IsMirrored(level.Name) && location.LevelState == LevelState.Mirrored)
                         continue;
 
                     secret.Location = location;
@@ -404,7 +415,7 @@ namespace TRRandomizerCore.Randomizers
             List<Location> locations = _locations[level.Name];
             List<Location> usedLocations = new List<Location>();
 
-            Queue<Location> guaranteedLocations = _picker.GetGuaranteedLocations(locations, MirrorLevels.Contains(level.Script), level.Script.NumSecrets, location =>
+            Queue<Location> guaranteedLocations = _picker.GetGuaranteedLocations(locations, Mirrorer.IsMirrored(level.Name), level.Script.NumSecrets, location =>
             {
                 bool result = EvaluateProximity(location, usedLocations, level);
                 if (result)
@@ -478,6 +489,15 @@ namespace TRRandomizerCore.Randomizers
 
             AddDamageControl(level, pickupTypes, damagingLocationUsed, glitchedDamagingLocationUsed);
 
+            if (usedLocations.Any(l => l.LevelState == LevelState.Mirrored))
+            {
+                Mirrorer.SetIsMirrored(level.Name, true);
+            }
+            else if (usedLocations.Any(l => l.LevelState == LevelState.NotMirrored))
+            {
+                Mirrorer.SetIsMirrored(level.Name, false);
+            }
+
 #if DEBUG
             Debug.WriteLine(level.Name + ": " + _picker.DescribeLocations(usedLocations));
 #endif
@@ -494,10 +514,10 @@ namespace TRRandomizerCore.Randomizers
             if (loc.RequiresGlitch && !Settings.GlitchedSecrets)
                 return false;
 
-            if (MirrorLevels.Contains(level.Script) && loc.LevelState == LevelState.NotMirrored)
+            if (Mirrorer.IsMirrored(level.Name) && loc.LevelState == LevelState.NotMirrored)
                 return false;
 
-            if (!MirrorLevels.Contains(level.Script) && loc.LevelState == LevelState.Mirrored)
+            if (!Mirrorer.IsMirrored(level.Name) && loc.LevelState == LevelState.Mirrored)
                 return false;
 
             if (usedLocs.Count == 0 || usedLocs == null)

--- a/TRRandomizerCore/Resources/Documentation/SECRETS.md
+++ b/TRRandomizerCore/Resources/Documentation/SECRETS.md
@@ -76,6 +76,25 @@ Use trview to generate secret locations by making use of the available [randomiz
 
 https://github.com/LostArtefacts/TR-Rando/blob/master/TRRandomizerCore/Resources/Shared/randomizer.json
 
+### Property guide
+
+| Property | Usage | Description |
+|-|-|-|
+| Angle | Items, Enemies, Vehicles | Sets the Y rotation of an entity. |
+| Author | Secrets | Used in [authored secrets mode](#authored-secrets) |
+| Difficulty | Secrets | Sets the difficulty level of a secret. |
+| Entity Index | Enemies | For TR1 only, used to link normal enemies to Atlantean egg wall locations during randomization. |
+| Entity Index | Secrets | Allows a secret to be linked to another pickup entity, such that the pickup location will be locked i.e. ignored in item randomization. |
+| Invalidates Room | Items | Indicates that every sector in a room is invalid for general item positioning. |
+| Key Item Group ID | Items | For TR1 and TR3, links locations to key items IDs to form zoning. See `TREntities` and `TR3Entities`. |
+| Level State | Secrets | Indicates that a secret can only be used when a level is in a specific mirroring state e.g. for specific glitches. |
+| Requires Damage | Secrets | Indicates that Lara will take damage collecting this secret; medipacks will be provided when this flag is detected. |
+| Requires Glitch | Secrets | A glitch is needed to collect this secret - links to the UI option available to users. |
+| Target Type | Vehicles | Links a location to a specific model ID, currently used for positioning randomized vehicles. |
+| Validated | Items | If a room has `Invalidates Room` set to `true`, additional locations can be added with `Validated` set to `false` - this means that the entire room is excluded apart from those specific locations. |
+| Validated | Secrets | For TR1 and TR3, if secrets are to be placed where there are already triggers, they will not be chosen during randomization unless `Validated` is selected. This allows for debugging to test that trigger behaviour remains as expected. |
+| Vehicle Required | Secrets | Indicates that a vehicle is required to collect this secret, and so any planned randomization of existing vehicles in the level will not take place. Note that this will not automatically add a vehicle. |
+
 ## Authored Secrets
 The randomizer supports the idea of branded secrets by specific authors, so allowing players to pick those specific secrets in a playthrough. To author your own secrets, follow these steps.
 

--- a/TRRandomizerCore/Resources/Documentation/SECRETS.md
+++ b/TRRandomizerCore/Resources/Documentation/SECRETS.md
@@ -82,13 +82,13 @@ Not all properties are used in every circumstance, and their meanings can differ
 | Property | Usage | Description |
 |-|-|-|
 | Angle | Items, Enemies, Vehicles | Sets the Y rotation of an entity. |
-| Author | Secrets | Used in [authored secrets mode](#authored-secrets) |
 | Difficulty | Secrets | Sets the difficulty level of a secret. |
 | Entity Index | Enemies | For TR1 only, used to link normal enemies to Atlantean egg wall locations during randomization. |
 | Entity Index | Secrets | Allows a secret to be linked to another pickup entity, such that the pickup location will be locked i.e. ignored in item randomization. |
 | Invalidates Room | Items | Indicates that every sector in a room is invalid for general item positioning. |
 | Key Item Group ID | Items | For TR1 and TR3, links locations to key items IDs to form zoning. See `TREntities` and `TR3Entities`. |
 | Level State | Secrets | Indicates that a secret can only be used when a level is in a specific mirroring state e.g. for specific glitches. |
+| Pack ID | Secrets | Used in [secret pack mode](#secret-packs) |
 | Requires Damage | Secrets | Indicates that Lara will take damage collecting this secret; medipacks will be provided when this flag is detected. |
 | Requires Glitch | Secrets | A glitch is needed to collect this secret - links to the UI option available to users. |
 | Target Type | Vehicles | Links a location to a specific model ID, currently used for positioning randomized vehicles. |
@@ -96,31 +96,31 @@ Not all properties are used in every circumstance, and their meanings can differ
 | Validated | Secrets | For TR1 and TR3, if secrets are to be placed where there are already triggers, they will not be chosen during randomization unless `Validated` is selected. This allows for debugging to test that trigger behaviour remains as expected. |
 | Vehicle Required | Secrets | Indicates that a vehicle is required to collect this secret, and so any planned randomization of existing vehicles in the level will not take place. Note that this will not automatically add a vehicle. |
 
-## Authored Secrets
-The randomizer supports the idea of branded secrets by specific authors, so allowing players to pick those specific secrets in a playthrough. To author your own secrets, follow these steps.
+## Secret Packs
+The randomizer supports pre-defined secret packs, so allowing players to play with secrets that have been chosen by community members. To author your own secret pack, follow these steps.
 
-1. Open your copy of `%LOCALAPPDATA%/trview/randomizer.json` and locate the `Author` property. Add your name to the `options` array (this is how your name will be displayed both in trview and the randomizer itself).
+1. Open your copy of `%LOCALAPPDATA%/trview/randomizer.json` and locate the `PackID` property. Add your pack title to the `options` array (this is what will be displayed both in trview and the randomizer itself).
 2. Restart trview if you have it open.
-3. Setup a local folder with each level for the game you wish to author secrets for. Ensure that the levels are vanilla, and that the level file names are all in uppercase.
+3. Setup a local folder with each level for the game you wish to create a secret pack for. Ensure that the levels are vanilla, and that the level file names are all in uppercase.
 4. In trview, open the first level in the folder you have created above.
 5. Click on `Settings` and ensure that `Enable Randomizer Tools` is selected in the `General` tab.
-6. Click on `Windows > Route`, then in the Route window, select `File > Open`. Select the relevant randomizer locations file for the game.
-7. You will now see waypoints marking secret locations. You can add new waypoints and set the `Author` property to your name, or edit existing ones if applicable.
+6. Click on `Windows > Route`, then in the Route window, select `File > Open`. Select the relevant randomizer locations file for the game e.g. `Resources/TR1/locations.json` in your randomizer folder.
+7. You will now see waypoints marking secret locations. You can add new waypoints and set the `PackID` property to your pack, or edit existing ones if applicable.
 8. Clicking on the other level names in the Route window will open that level.
 9. Once you have finished, click `File > Save` in the Route window.
 10. You can now submit a pull request with the changed locations file and `randomizer.json` trview file if applicable.
 
-Note that the `Requires Glitch` and `Difficulty` properties are ignored for authored secrets - that is, they will be included regardless. However, you should ensure that these properties are correctly set anyway, as your secrets may be included in standard playthroughs, and so the user's choices in the randomizer should be honoured.
+Note that the `Requires Glitch` and `Difficulty` properties are ignored for secrets that are part of a pack - that is, they will be included regardless. However, you should ensure that these properties are correctly set anyway, as your secrets may be included in standard playthroughs, and so the user's choices in the randomizer should be honoured.
 
 ### Level State
-Be sure to set the `Level State` property as well. If an authored secret only works when the level is mirrored, then this will enforce mirroring on that level. Equally, `Not Mirrored` means the secret only works when the level is in its normal state. `Any` is the default, and means the secret works in either state.
+Be sure to set the `Level State` property as well. If a secret within a pack only works when the level is mirrored, then this will enforce mirroring on that level. Equally, `Not Mirrored` means the secret only works when the level is in its normal state. `Any` is the default, and means the secret works in either state.
 
-Be careful not to enforce a mirrored secret and non-mirrored in the same authored set. If this does happen, the randomizer will ignore your mirrored secret. You can create different authored sets instead as an alternative.
+Be careful not to enforce a mirrored secret and non-mirrored in the same level. If this does happen, the randomizer will ignore your mirrored secret. You can create separate packs as an alternative.
 
 Note that in normal mode, secrets whose states do not match the level are simply skipped and another is chosen.
 
 ### TR2 Zoning
-As authored secrets may not necessarily fall into the default [secret zones](https://github.com/LostArtefacts/TR-Rando/wiki/Zones#secrets), you should position your waypoints manually in stone-jade-gold order instead. For TR1 and TR3, this is not important due to the different zoning technique and the arbitrary artefact types.
+As pre-defined secrets may not necessarily fall into the default [zones](https://github.com/LostArtefacts/TR-Rando/wiki/Zones#secrets), you should position your waypoints manually in stone-jade-gold order instead. For TR1 and TR3, this is not important due to the different zoning technique and the arbitrary artefact types.
 
 ### Underwater Corner Secrets
 When placing secrets in corners underwater, there is a minimum distance from each wall the secret will need to be positioned - this is 130 units. Any closer to the wall and Lara won't pick the secret up.

--- a/TRRandomizerCore/Resources/Documentation/SECRETS.md
+++ b/TRRandomizerCore/Resources/Documentation/SECRETS.md
@@ -74,7 +74,33 @@ Currently, the number of secrets per level is hard-coded to the level's original
 # Generating Locations
 Use trview to generate secret locations by making use of the available [randomizer settings](https://github.com/chreden/trview#randomizer-integration) feature. The file below should be copied locally to `%LOCALAPPDATA%/trview`.
 
-https://github.com/DanzaG/TR2-Rando/blob/master/TRRandomizerCore/Resources/Shared/randomizer.json
+https://github.com/LostArtefacts/TR-Rando/blob/master/TRRandomizerCore/Resources/Shared/randomizer.json
+
+## Authored Secrets
+The randomizer supports the idea of branded secrets by specific authors, so allowing players to pick those specific secrets in a playthrough. To author your own secrets, follow these steps.
+
+1. Open your copy of `%LOCALAPPDATA%/trview/randomizer.json` and locate the `Author` property. Add your name to the `options` array (this is how your name will be displayed both in trview and the randomizer itself).
+2. Restart trview if you have it open.
+3. Setup a local folder with each level for the game you wish to author secrets for. Ensure that the levels are vanilla, and that the level file names are all in uppercase.
+4. In trview, open the first level in the folder you have created above.
+5. Click on `Settings` and ensure that `Enable Randomizer Tools` is selected in the `General` tab.
+6. Click on `Windows > Route`, then in the Route window, select `File > Open`. Select the relevant randomizer locations file for the game.
+7. You will now see waypoints marking secret locations. You can add new waypoints and set the `Author` property to your name, or edit existing ones if applicable.
+8. Clicking on the other level names in the Route window will open that level.
+9. Once you have finished, click `File > Save` in the Route window.
+10. You can now submit a pull request with the changed locations file and `randomizer.json` trview file if applicable.
+
+Note that the `Requires Glitch` and `Difficulty` properties are ignored for authored secrets - that is, they will be included regardless. However, you should ensure that these properties are correctly set anyway, as your secrets may be included in standard playthroughs, and so the user's choices in the randomizer should be honoured.
+
+### Level State
+Be sure to set the `Level State` property as well. If an authored secret only works when the level is mirrored, then this will enforce mirroring on that level. Equally, `Not Mirrored` means the secret only works when the level is in its normal state. `Any` is the default, and means the secret works in either state.
+
+Be careful not to enforce a mirrored secret and non-mirrored in the same authored set. If this does happen, the randomizer will ignore your mirrored secret. You can create different authored sets instead as an alternative.
+
+Note that in normal mode, secrets whose states do not match the level are simply skipped and another is chosen.
+
+### TR2 Zoning
+As authored secrets may not necessarily fall into the default [secret zones](https://github.com/LostArtefacts/TR-Rando/wiki/Zones#secrets), you should position your waypoints manually in stone-jade-gold order instead. For TR1 and TR3, this is not important due to the different zoning technique and the arbitrary artefact types.
 
 ### Underwater Corner Secrets
 When placing secrets in corners underwater, there is a minimum distance from each wall the secret will need to be positioned - this is 130 units. Any closer to the wall and Lara won't pick the secret up.

--- a/TRRandomizerCore/Resources/Documentation/SECRETS.md
+++ b/TRRandomizerCore/Resources/Documentation/SECRETS.md
@@ -77,6 +77,7 @@ Use trview to generate secret locations by making use of the available [randomiz
 https://github.com/LostArtefacts/TR-Rando/blob/master/TRRandomizerCore/Resources/Shared/randomizer.json
 
 ### Property guide
+Not all properties are used in every circumstance, and their meanings can differ based on where they are used. Use the guide below for reference.
 
 | Property | Usage | Description |
 |-|-|-|

--- a/TRRandomizerCore/Resources/Shared/randomizer.json
+++ b/TRRandomizerCore/Resources/Shared/randomizer.json
@@ -57,10 +57,16 @@
       "display": "Target Type",
       "type": "number"
     },
-    "Author": {
+    "PackID": {
       "default": "TRRando",
-      "display": "Author",
-      "options": [ "TRRando", "apel", "Danza", "Eycore", "Lahm" ],
+      "display": "Pack ID",
+      "options": [
+        "TRRando",
+        "apel",
+        "Danza",
+        "Eycore",
+        "Lahm"
+      ],
       "type": "string"
     }
   }

--- a/TRRandomizerCore/Resources/Shared/randomizer.json
+++ b/TRRandomizerCore/Resources/Shared/randomizer.json
@@ -56,6 +56,12 @@
       "default": -1,
       "display": "Target Type",
       "type": "number"
+    },
+    "Author": {
+      "default": "TRRando",
+      "display": "Author",
+      "options": [ "TRRando", "apel", "Danza", "Eycore", "Lahm" ],
+      "type": "string"
     }
   }
 }

--- a/TRRandomizerCore/TRRandomizerController.cs
+++ b/TRRandomizerCore/TRRandomizerController.cs
@@ -1388,19 +1388,19 @@ namespace TRRandomizerCore
             set => LevelRandomizer.MaxSecretCount = value;
         }
 
-        public bool UseAuthoredSecrets
+        public bool UseSecretPack
         {
-            get => LevelRandomizer.UseAuthoredSecrets;
-            set => LevelRandomizer.UseAuthoredSecrets = value;
+            get => LevelRandomizer.UseSecretPack;
+            set => LevelRandomizer.UseSecretPack = value;
         }
 
-        public string SecretAuthor
+        public string SecretPack
         {
-            get => LevelRandomizer.SecretAuthor;
-            set => LevelRandomizer.SecretAuthor = value;
+            get => LevelRandomizer.SecretPack;
+            set => LevelRandomizer.SecretPack = value;
         }
 
-        public string[] AvailableSecretAuthors
+        public string[] AvailableSecretPacks
         {
             get
             {
@@ -1411,7 +1411,7 @@ namespace TRRandomizerCore
                     TRVersion.TR3 => new TR3SecretRandomizer(),
                     _ => throw new Exception(),
                 };
-                return randomizer.GetAuthors()
+                return randomizer.GetPacks()
                     .OrderBy(a => a.ToLower())
                     .ToArray();
             }

--- a/TRRandomizerCore/TRRandomizerController.cs
+++ b/TRRandomizerCore/TRRandomizerController.cs
@@ -1388,6 +1388,35 @@ namespace TRRandomizerCore
             set => LevelRandomizer.MaxSecretCount = value;
         }
 
+        public bool UseAuthoredSecrets
+        {
+            get => LevelRandomizer.UseAuthoredSecrets;
+            set => LevelRandomizer.UseAuthoredSecrets = value;
+        }
+
+        public string SecretAuthor
+        {
+            get => LevelRandomizer.SecretAuthor;
+            set => LevelRandomizer.SecretAuthor = value;
+        }
+
+        public string[] AvailableSecretAuthors
+        {
+            get
+            {
+                ISecretRandomizer randomizer = _editor.Edition.Version switch
+                {
+                    TRVersion.TR1 => new TR1SecretRandomizer(),
+                    TRVersion.TR2 => new TR2SecretRandomizer(),
+                    TRVersion.TR3 => new TR3SecretRandomizer(),
+                    _ => throw new Exception(),
+                };
+                return randomizer.GetAuthors()
+                    .OrderBy(a => a.ToLower())
+                    .ToArray();
+            }
+        }
+
         public bool IncludeKeyItems
         {
             get => LevelRandomizer.IncludeKeyItems;

--- a/TRRandomizerView/Controls/EditorControl.xaml
+++ b/TRRandomizerView/Controls/EditorControl.xaml
@@ -236,6 +236,7 @@
                                         MainDescription="Customize the secret randomization."
                                         BoolItemsSource="{Binding Data.SecretBoolItemControls, Source={StaticResource proxy}}"
                                         HasBoolItems="True"
+                                        HasAuthoredSecretMode="{Binding Data.IsAuthoredSecretsTypeSupported, Source={StaticResource proxy}}"
                                         HasSecretCountMode="{Binding Data.IsSecretCountTypeSupported, Source={StaticResource proxy}}"
                                         ControllerProxy="{Binding Data, Source={StaticResource proxy}}">
                 </windows:AdvancedWindow>
@@ -261,6 +262,7 @@
                                         MainDescription="Customize the secret randomization."
                                         BoolItemsSource="{Binding Data.SecretBoolItemControls, Source={StaticResource proxy}}"
                                         HasBoolItems="True"
+                                        HasAuthoredSecretMode="{Binding Data.IsAuthoredSecretsTypeSupported, Source={StaticResource proxy}}"
                                         HasSecretCountMode="{Binding Data.IsSecretCountTypeSupported, Source={StaticResource proxy}}"
                                         ControllerProxy="{Binding Data, Source={StaticResource proxy}}">
                 </windows:AdvancedWindow>

--- a/TRRandomizerView/Controls/EditorControl.xaml
+++ b/TRRandomizerView/Controls/EditorControl.xaml
@@ -236,7 +236,7 @@
                                         MainDescription="Customize the secret randomization."
                                         BoolItemsSource="{Binding Data.SecretBoolItemControls, Source={StaticResource proxy}}"
                                         HasBoolItems="True"
-                                        HasAuthoredSecretMode="{Binding Data.IsAuthoredSecretsTypeSupported, Source={StaticResource proxy}}"
+                                        HasSecretPackMode="{Binding Data.IsSecretPackTypeSupported, Source={StaticResource proxy}}"
                                         HasSecretCountMode="{Binding Data.IsSecretCountTypeSupported, Source={StaticResource proxy}}"
                                         ControllerProxy="{Binding Data, Source={StaticResource proxy}}">
                 </windows:AdvancedWindow>
@@ -262,7 +262,7 @@
                                         MainDescription="Customize the secret randomization."
                                         BoolItemsSource="{Binding Data.SecretBoolItemControls, Source={StaticResource proxy}}"
                                         HasBoolItems="True"
-                                        HasAuthoredSecretMode="{Binding Data.IsAuthoredSecretsTypeSupported, Source={StaticResource proxy}}"
+                                        HasSecretPackMode="{Binding Data.IsSecretPackTypeSupported, Source={StaticResource proxy}}"
                                         HasSecretCountMode="{Binding Data.IsSecretCountTypeSupported, Source={StaticResource proxy}}"
                                         ControllerProxy="{Binding Data, Source={StaticResource proxy}}">
                 </windows:AdvancedWindow>

--- a/TRRandomizerView/Model/ControllerOptions.cs
+++ b/TRRandomizerView/Model/ControllerOptions.cs
@@ -68,6 +68,9 @@ namespace TRRandomizerView.Model
         private uint _uncontrolledSFXCount;
         private bool _uncontrolledSFXAssaultCourse;
         private uint _rainLevelCount, _snowLevelCount, _coldLevelCount;
+        private bool _useAuthoredSecrets;
+        private string _secretAuthor;
+        private string[] _availableSecretAuthors;
 
         private List<BoolItemControlClass> _secretBoolItemControls, _itemBoolItemControls, _enemyBoolItemControls, _textureBoolItemControls, _audioBoolItemControls, _outfitBoolItemControls, _textBoolItemControls, _startBoolItemControls, _environmentBoolItemControls, _healthBoolItemControls, _weatherBoolItemControls;
         private List<BoolItemIDControlClass> _selectableEnemies;
@@ -2069,6 +2072,43 @@ namespace TRRandomizerView.Model
             }
         }
 
+        public bool UseAuthoredSecrets
+        {
+            get => _useAuthoredSecrets;
+            set
+            {
+                _useAuthoredSecrets = value;
+                FirePropertyChanged();
+                FirePropertyChanged(nameof(UseGenericSecrets));
+            }
+        }
+
+        public bool UseGenericSecrets
+        {
+            get => !IsAuthoredSecretsTypeSupported || !UseAuthoredSecrets;
+        }
+
+        public string SecretAuthor
+        {
+            get => _secretAuthor;
+            set
+            {
+                _secretAuthor = value;
+                FirePropertyChanged();
+            }
+        }
+
+        public string[] AvailableSecretAuthors
+        {
+            get => _availableSecretAuthors;
+            set
+            {
+                _availableSecretAuthors = value;
+                FirePropertyChanged();
+                FirePropertyChanged(nameof(IsAuthoredSecretsTypeSupported));
+            }
+        }
+
         public BoolItemControlClass DocileWillard
         {
             get => _docileWillard;
@@ -3061,7 +3101,14 @@ namespace TRRandomizerView.Model
             UseRandomSecretModels.Value = _controller.UseRandomSecretModels;
             SecretCountMode = _controller.SecretCountMode;
             MaxSecretCount = _controller.MaxSecretCount;
-            MinSecretCount = _controller.MinSecretCount;
+            MinSecretCount = _controller.MinSecretCount;            
+            AvailableSecretAuthors = _controller.AvailableSecretAuthors;
+            SecretAuthor = _controller.SecretAuthor;
+            UseAuthoredSecrets = _controller.UseAuthoredSecrets;
+            if ((SecretAuthor == null || SecretAuthor == string.Empty) && AvailableSecretAuthors.Length > 0)
+            {
+                SecretAuthor = AvailableSecretAuthors[0];
+            }
 
             RandomizeTextures = _controller.RandomizeTextures;
             TextureSeed = _controller.TextureSeed;
@@ -3345,6 +3392,8 @@ namespace TRRandomizerView.Model
             _controller.SecretCountMode = SecretCountMode;
             _controller.MinSecretCount = MinSecretCount;
             _controller.MaxSecretCount = MaxSecretCount;
+            _controller.UseAuthoredSecrets = UseAuthoredSecrets;
+            _controller.SecretAuthor = SecretAuthor;
 
             _controller.RandomizeTextures = RandomizeTextures;
             _controller.TextureSeed = TextureSeed;
@@ -3504,6 +3553,7 @@ namespace TRRandomizerView.Model
         public bool IsRewardRoomsTypeSupported => IsRandomizationSupported(TRRandomizerType.RewardRooms);
         public bool IsSecretModelsTypeSupported => IsRandomizationSupported(TRRandomizerType.SecretModels);
         public bool IsSecretCountTypeSupported => IsRandomizationSupported(TRRandomizerType.SecretCount);
+        public bool IsAuthoredSecretsTypeSupported => AvailableSecretAuthors?.Length > 0;
         public bool IsSecretRewardTypeSupported => IsRandomizationSupported(TRRandomizerType.SecretReward);
         public bool IsItemTypeSupported => IsRandomizationSupported(TRRandomizerType.Item);
         public bool IsKeyItemTypeSupported => IsRandomizationSupported(TRRandomizerType.KeyItems);

--- a/TRRandomizerView/Model/ControllerOptions.cs
+++ b/TRRandomizerView/Model/ControllerOptions.cs
@@ -68,9 +68,9 @@ namespace TRRandomizerView.Model
         private uint _uncontrolledSFXCount;
         private bool _uncontrolledSFXAssaultCourse;
         private uint _rainLevelCount, _snowLevelCount, _coldLevelCount;
-        private bool _useAuthoredSecrets;
-        private string _secretAuthor;
-        private string[] _availableSecretAuthors;
+        private bool _useSecretPack;
+        private string _secretPack;
+        private string[] _availableSecretPacks;
 
         private List<BoolItemControlClass> _secretBoolItemControls, _itemBoolItemControls, _enemyBoolItemControls, _textureBoolItemControls, _audioBoolItemControls, _outfitBoolItemControls, _textBoolItemControls, _startBoolItemControls, _environmentBoolItemControls, _healthBoolItemControls, _weatherBoolItemControls;
         private List<BoolItemIDControlClass> _selectableEnemies;
@@ -2072,12 +2072,12 @@ namespace TRRandomizerView.Model
             }
         }
 
-        public bool UseAuthoredSecrets
+        public bool UseSecretPack
         {
-            get => _useAuthoredSecrets;
+            get => _useSecretPack;
             set
             {
-                _useAuthoredSecrets = value;
+                _useSecretPack = value;
                 FirePropertyChanged();
                 FirePropertyChanged(nameof(UseGenericSecrets));
             }
@@ -2085,27 +2085,27 @@ namespace TRRandomizerView.Model
 
         public bool UseGenericSecrets
         {
-            get => !IsAuthoredSecretsTypeSupported || !UseAuthoredSecrets;
+            get => !IsSecretPackTypeSupported || !UseSecretPack;
         }
 
-        public string SecretAuthor
+        public string SecretPack
         {
-            get => _secretAuthor;
+            get => _secretPack;
             set
             {
-                _secretAuthor = value;
+                _secretPack = value;
                 FirePropertyChanged();
             }
         }
 
-        public string[] AvailableSecretAuthors
+        public string[] AvailableSecretPacks
         {
-            get => _availableSecretAuthors;
+            get => _availableSecretPacks;
             set
             {
-                _availableSecretAuthors = value;
+                _availableSecretPacks = value;
                 FirePropertyChanged();
-                FirePropertyChanged(nameof(IsAuthoredSecretsTypeSupported));
+                FirePropertyChanged(nameof(IsSecretPackTypeSupported));
             }
         }
 
@@ -3102,12 +3102,12 @@ namespace TRRandomizerView.Model
             SecretCountMode = _controller.SecretCountMode;
             MaxSecretCount = _controller.MaxSecretCount;
             MinSecretCount = _controller.MinSecretCount;            
-            AvailableSecretAuthors = _controller.AvailableSecretAuthors;
-            SecretAuthor = _controller.SecretAuthor;
-            UseAuthoredSecrets = _controller.UseAuthoredSecrets;
-            if ((SecretAuthor == null || SecretAuthor == string.Empty) && AvailableSecretAuthors.Length > 0)
+            AvailableSecretPacks = _controller.AvailableSecretPacks;
+            SecretPack = _controller.SecretPack;
+            UseSecretPack = _controller.UseSecretPack;
+            if ((SecretPack == null || SecretPack == string.Empty) && AvailableSecretPacks.Length > 0)
             {
-                SecretAuthor = AvailableSecretAuthors[0];
+                SecretPack = AvailableSecretPacks[0];
             }
 
             RandomizeTextures = _controller.RandomizeTextures;
@@ -3392,8 +3392,8 @@ namespace TRRandomizerView.Model
             _controller.SecretCountMode = SecretCountMode;
             _controller.MinSecretCount = MinSecretCount;
             _controller.MaxSecretCount = MaxSecretCount;
-            _controller.UseAuthoredSecrets = UseAuthoredSecrets;
-            _controller.SecretAuthor = SecretAuthor;
+            _controller.UseSecretPack = UseSecretPack;
+            _controller.SecretPack = SecretPack;
 
             _controller.RandomizeTextures = RandomizeTextures;
             _controller.TextureSeed = TextureSeed;
@@ -3553,7 +3553,7 @@ namespace TRRandomizerView.Model
         public bool IsRewardRoomsTypeSupported => IsRandomizationSupported(TRRandomizerType.RewardRooms);
         public bool IsSecretModelsTypeSupported => IsRandomizationSupported(TRRandomizerType.SecretModels);
         public bool IsSecretCountTypeSupported => IsRandomizationSupported(TRRandomizerType.SecretCount);
-        public bool IsAuthoredSecretsTypeSupported => AvailableSecretAuthors?.Length > 0;
+        public bool IsSecretPackTypeSupported => AvailableSecretPacks?.Length > 0;
         public bool IsSecretRewardTypeSupported => IsRandomizationSupported(TRRandomizerType.SecretReward);
         public bool IsItemTypeSupported => IsRandomizationSupported(TRRandomizerType.Item);
         public bool IsKeyItemTypeSupported => IsRandomizationSupported(TRRandomizerType.KeyItems);

--- a/TRRandomizerView/Windows/AdvancedWindow.xaml
+++ b/TRRandomizerView/Windows/AdvancedWindow.xaml
@@ -1588,15 +1588,15 @@
                 </Grid>
             </StackPanel>
 
-            <!-- Authored Secret Mode -->
+            <!-- Secret Packs -->
             <StackPanel Grid.Row="20"
-                        Visibility="{Binding HasAuthoredSecretMode, Converter={StaticResource BoolToCollapsedConverter}}">
+                        Visibility="{Binding HasSecretPackMode, Converter={StaticResource BoolToCollapsedConverter}}">
                 <StackPanel.Resources>
                     <cvt:ComparisonConverter x:Key="ComparisonConverter" />
                 </StackPanel.Resources>
 
                 <TextBlock Style="{StaticResource HeaderStyle}"
-                           Text="Authored Secret Mode"/>
+                           Text="Secret Packs"/>
 
                 <Grid Margin="0,5,0,0">
                     <Grid.RowDefinitions>
@@ -1609,10 +1609,10 @@
                     </Grid.ColumnDefinitions>
 
                     <Border>
-                        <CheckBox IsChecked="{Binding ControllerProxy.UseAuthoredSecrets, Mode=TwoWay}"
+                        <CheckBox IsChecked="{Binding ControllerProxy.UseSecretPack, Mode=TwoWay}"
                                   VerticalAlignment="Center">
                             <Label Padding="0"
-                                   Content="Use authored mode" />
+                                   Content="Use secret pack" />
                         </CheckBox>
                     </Border>
 
@@ -1620,10 +1620,10 @@
                             Grid.RowSpan="2">
                         <Label Style="{StaticResource OptionDescriptionStyle}">
                             <TextBlock>
-                                Use pre-defined secrets by your chosen author. This may enforce glitched/hard secrets, and may
+                                Use a pre-defined secret pack, compiled by community members. This may enforce glitched/hard secrets, and may
                                 <LineBreak/>modify level environments to match. See
-                                <Hyperlink ToolTip="https://github.com/LostArtefacts/TR-Rando/blob/master/TRRandomizerCore/Resources/Documentation/SECRETS.md"
-                                           NavigateUri="https://github.com/LostArtefacts/TR-Rando/blob/master/TRRandomizerCore/Resources/Documentation/SECRETS.md"
+                                <Hyperlink ToolTip="https://github.com/LostArtefacts/TR-Rando/blob/master/TRRandomizerCore/Resources/Documentation/SECRETS.md#secret-packs"
+                                           NavigateUri="https://github.com/LostArtefacts/TR-Rando/blob/master/TRRandomizerCore/Resources/Documentation/SECRETS.md#secret-packs"
                                            RequestNavigate="Hyperlink_RequestNavigate">GitHub</Hyperlink> for full details.
                             </TextBlock>
                         </Label>
@@ -1631,9 +1631,9 @@
 
                     <Border Margin="0,3,0,0"
                             Grid.Row="1">
-                        <ComboBox ItemsSource="{Binding ControllerProxy.AvailableSecretAuthors}"
-                                  SelectedItem="{Binding ControllerProxy.SecretAuthor, Mode=TwoWay}"
-                                  IsEnabled="{Binding ControllerProxy.UseAuthoredSecrets}"
+                        <ComboBox ItemsSource="{Binding ControllerProxy.AvailableSecretPacks}"
+                                  SelectedItem="{Binding ControllerProxy.SecretPack, Mode=TwoWay}"
+                                  IsEnabled="{Binding ControllerProxy.UseSecretPack}"
                                   HorizontalAlignment="Stretch"
                                   VerticalAlignment="Center"/>
                     </Border>

--- a/TRRandomizerView/Windows/AdvancedWindow.xaml
+++ b/TRRandomizerView/Windows/AdvancedWindow.xaml
@@ -88,6 +88,7 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
             <Grid.ColumnDefinitions>
@@ -1471,7 +1472,8 @@
 
             <!-- Secret Count -->
             <StackPanel Grid.Row="19"
-                        Visibility="{Binding HasSecretCountMode, Converter={StaticResource BoolToCollapsedConverter}}">
+                        Visibility="{Binding HasSecretCountMode, Converter={StaticResource BoolToCollapsedConverter}}"
+                        IsEnabled="{Binding ControllerProxy.UseGenericSecrets}">
                 <StackPanel.Resources>
                     <cvt:ComparisonConverter x:Key="ComparisonConverter" />
                 </StackPanel.Resources>
@@ -1586,8 +1588,60 @@
                 </Grid>
             </StackPanel>
 
-            <!-- Weather -->
+            <!-- Authored Secret Mode -->
             <StackPanel Grid.Row="20"
+                        Visibility="{Binding HasAuthoredSecretMode, Converter={StaticResource BoolToCollapsedConverter}}">
+                <StackPanel.Resources>
+                    <cvt:ComparisonConverter x:Key="ComparisonConverter" />
+                </StackPanel.Resources>
+
+                <TextBlock Style="{StaticResource HeaderStyle}"
+                           Text="Authored Secret Mode"/>
+
+                <Grid Margin="0,5,0,0">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" SharedSizeGroup="SSG1"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+
+                    <Border>
+                        <CheckBox IsChecked="{Binding ControllerProxy.UseAuthoredSecrets, Mode=TwoWay}"
+                                  VerticalAlignment="Center">
+                            <Label Padding="0"
+                                   Content="Use authored mode" />
+                        </CheckBox>
+                    </Border>
+
+                    <Border Grid.Column="1"
+                            Grid.RowSpan="2">
+                        <Label Style="{StaticResource OptionDescriptionStyle}">
+                            <TextBlock>
+                                Use pre-defined secrets by your chosen author. This may enforce glitched/hard secrets, and may
+                                <LineBreak/>modify level environments to match. See
+                                <Hyperlink ToolTip="https://github.com/LostArtefacts/TR-Rando/blob/master/TRRandomizerCore/Resources/Documentation/SECRETS.md"
+                                           NavigateUri="https://github.com/LostArtefacts/TR-Rando/blob/master/TRRandomizerCore/Resources/Documentation/SECRETS.md"
+                                           RequestNavigate="Hyperlink_RequestNavigate">GitHub</Hyperlink> for full details.
+                            </TextBlock>
+                        </Label>
+                    </Border>
+
+                    <Border Margin="0,3,0,0"
+                            Grid.Row="1">
+                        <ComboBox ItemsSource="{Binding ControllerProxy.AvailableSecretAuthors}"
+                                  SelectedItem="{Binding ControllerProxy.SecretAuthor, Mode=TwoWay}"
+                                  IsEnabled="{Binding ControllerProxy.UseAuthoredSecrets}"
+                                  HorizontalAlignment="Stretch"
+                                  VerticalAlignment="Center"/>
+                    </Border>
+                </Grid>
+            </StackPanel>
+
+            <!-- Weather -->
+            <StackPanel Grid.Row="21"
                         Visibility="{Binding HasWeatherMode, Converter={StaticResource BoolToCollapsedConverter}}">
 
                 <TextBlock Style="{StaticResource HeaderStyle}"

--- a/TRRandomizerView/Windows/AdvancedWindow.xaml.cs
+++ b/TRRandomizerView/Windows/AdvancedWindow.xaml.cs
@@ -101,9 +101,15 @@ namespace TRRandomizerView.Windows
         (
             nameof(HasHealthMode), typeof(bool), typeof(AdvancedWindow)
         );
+
         public static readonly DependencyProperty HasSecretCountModeProperty = DependencyProperty.Register
         (
             nameof(HasSecretCountMode), typeof(bool), typeof(AdvancedWindow)
+        );
+
+        public static readonly DependencyProperty HasAuthoredSecretModeProperty = DependencyProperty.Register
+        (
+            nameof(HasAuthoredSecretMode), typeof(bool), typeof(AdvancedWindow)
         );
 
         public static readonly DependencyProperty HasWeatherModeProperty = DependencyProperty.Register
@@ -222,6 +228,12 @@ namespace TRRandomizerView.Windows
         {
             get => (bool)GetValue(HasSecretCountModeProperty);
             set => SetValue(HasSecretCountModeProperty, value);
+        }
+
+        public bool HasAuthoredSecretMode
+        {
+            get => (bool)GetValue(HasAuthoredSecretModeProperty);
+            set => SetValue(HasAuthoredSecretModeProperty, value);
         }
 
         public bool HasWeatherMode

--- a/TRRandomizerView/Windows/AdvancedWindow.xaml.cs
+++ b/TRRandomizerView/Windows/AdvancedWindow.xaml.cs
@@ -107,9 +107,9 @@ namespace TRRandomizerView.Windows
             nameof(HasSecretCountMode), typeof(bool), typeof(AdvancedWindow)
         );
 
-        public static readonly DependencyProperty HasAuthoredSecretModeProperty = DependencyProperty.Register
+        public static readonly DependencyProperty HasSecretPackModeProperty = DependencyProperty.Register
         (
-            nameof(HasAuthoredSecretMode), typeof(bool), typeof(AdvancedWindow)
+            nameof(HasSecretPackMode), typeof(bool), typeof(AdvancedWindow)
         );
 
         public static readonly DependencyProperty HasWeatherModeProperty = DependencyProperty.Register
@@ -230,10 +230,10 @@ namespace TRRandomizerView.Windows
             set => SetValue(HasSecretCountModeProperty, value);
         }
 
-        public bool HasAuthoredSecretMode
+        public bool HasSecretPackMode
         {
-            get => (bool)GetValue(HasAuthoredSecretModeProperty);
-            set => SetValue(HasAuthoredSecretModeProperty, value);
+            get => (bool)GetValue(HasSecretPackModeProperty);
+            set => SetValue(HasSecretPackModeProperty, value);
         }
 
         public bool HasWeatherMode


### PR DESCRIPTION
Allows pre-defined secret sets to be used rather than the normal randomized approach. This will be followed up with data PRs for the secret locations themselves. The idea initially will be the "top pick" of existing secrets for TR1-3, but we will also be adding apel's re-arranged TR2 secrets as an option, and hopefully the solution will be open enough for others to submit their own ideas.

One thing I'm not sure about is the naming - "Authored Secrets" or perhaps "Branded Secrets"?

Part of #510.