### PR TITLE
Add TR2 secret pack

### DIFF
--- a/TREnvironmentEditor/Model/EMType.cs
+++ b/TREnvironmentEditor/Model/EMType.cs
@@ -87,6 +87,7 @@
         ConvertSpriteSequence = 143,
         ConvertModel = 144,
         ImportNonGraphicsModel = 145,
+        CopySpriteSequence = 146,
 
         // NOOP/Placeholder
         NOOP = 1000

--- a/TREnvironmentEditor/Model/Types/Models/EMCopySpriteSequenceFunction.cs
+++ b/TREnvironmentEditor/Model/Types/Models/EMCopySpriteSequenceFunction.cs
@@ -1,0 +1,49 @@
+﻿using TRLevelControl.Model;
+
+namespace TREnvironmentEditor.Model.Types;
+
+public class EMCopySpriteSequenceFunction : BaseEMFunction
+{
+    public short BaseSpriteID { get; set; }
+    public short TargetSpriteID { get; set; }
+
+    public override void ApplyToLevel(TR1Level level)
+    {
+        List<TRSpriteSequence> sequences = level.SpriteSequences.ToList();
+        CopySpriteSequence(sequences);
+        level.SpriteSequences = sequences.ToArray();
+        level.NumSpriteSequences = (uint)sequences.Count;
+    }
+
+    public override void ApplyToLevel(TR2Level level)
+    {
+        List<TRSpriteSequence> sequences = level.SpriteSequences.ToList();
+        CopySpriteSequence(sequences);
+        level.SpriteSequences = sequences.ToArray();
+        level.NumSpriteSequences = (uint)sequences.Count;
+    }
+
+    public override void ApplyToLevel(TR3Level level)
+    {
+        List<TRSpriteSequence> sequences = level.SpriteSequences.ToList();
+        CopySpriteSequence(sequences);
+        level.SpriteSequences = sequences.ToArray();
+        level.NumSpriteSequences = (uint)sequences.Count;
+    }
+
+    private void CopySpriteSequence(List<TRSpriteSequence> sequences)
+    {
+        TRSpriteSequence baseSequence = sequences.Find(s => s.SpriteID == BaseSpriteID);
+        TRSpriteSequence targetSequence = sequences.Find(s => s.SpriteID == TargetSpriteID);
+
+        if (baseSequence != null && targetSequence == null)
+        {
+            sequences.Add(new()
+            {
+                NegativeLength = baseSequence.NegativeLength,
+                Offset = baseSequence.Offset,
+                SpriteID = TargetSpriteID
+            });
+        }
+    }
+}

--- a/TREnvironmentEditor/Parsing/EMConverter.cs
+++ b/TREnvironmentEditor/Parsing/EMConverter.cs
@@ -192,6 +192,8 @@ namespace TREnvironmentEditor.Parsing
                     return JsonConvert.DeserializeObject<EMConvertModelFunction>(jo.ToString(), this);
                 case EMType.ImportNonGraphicsModel:
                     return JsonConvert.DeserializeObject<EMImportNonGraphicsModelFunction>(jo.ToString(), this);
+                case EMType.CopySpriteSequence:
+                    return JsonConvert.DeserializeObject<EMCopySpriteSequenceFunction>(jo.ToString(), this);
 
                 // NOOP
                 case EMType.NOOP:

--- a/TRRandomizerCore/Resources/Documentation/SECRETS.md
+++ b/TRRandomizerCore/Resources/Documentation/SECRETS.md
@@ -119,6 +119,8 @@ Be careful not to enforce a mirrored secret and non-mirrored in the same level. 
 
 Note that in normal mode, secrets whose states do not match the level are simply skipped and another is chosen.
 
+Other environment changes should also be kept in mind when placing secrets; for example, rooms may be flooded/drained or some geometry may change. Refer to the specific level environment files in each case. Conditional changes can be made to either undo other environment modifications, or to add your own changes to fit your secrets. Conditional changes are performed following all other standard environment changes, aside from level mirroring, which is always performed last.
+
 ### TR2 Zoning
 As pre-defined secrets may not necessarily fall into the default [zones](https://github.com/LostArtefacts/TR-Rando/wiki/Zones#secrets), you should position your waypoints manually in stone-jade-gold order instead. For TR1 and TR3, this is not important due to the different zoning technique and the arbitrary artefact types.
 

--- a/TRRandomizerCore/Resources/TR2/Environment/BOAT.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR2/Environment/BOAT.TR2-Environment.json
@@ -917,447 +917,7 @@
       ]
     ]
   ],
-  "OneOf": [
-    {
-      "Leader": [
-        {
-          "Comments": "Move the first duplicated door downwards and to the other side.",
-          "EMType": 44,
-          "EntityIndex": 57,
-          "TargetLocation": {
-            "X": 46592,
-            "Y": 2304,
-            "Z": 47616,
-            "Room": 15,
-            "Angle": -32768
-          }
-        },
-        {
-          "Comments": "Move the second duplicated door downwards and to the other side.",
-          "EMType": 44,
-          "EntityIndex": 58,
-          "TargetLocation": {
-            "X": 47616,
-            "Y": 2304,
-            "Z": 47616,
-            "Room": 15,
-            "Angle": -32768
-          }
-        },
-        {
-          "Comments": "Make visibility portals between rooms 22 & 68 and 15 & 98.",
-          "EMType": 81,
-          "Portals": [
-            {
-              "BaseRoom": 22,
-              "AdjoiningRoom": 68,
-              "Normal": {
-                "Z": -1
-              },
-              "Vertices": [
-                {
-                  "X": 1024,
-                  "Y": 256,
-                  "Z": 6144
-                },
-                {
-                  "X": 1024,
-                  "Y": -2048,
-                  "Z": 6144
-                },
-                {
-                  "X": 3072,
-                  "Y": -2048,
-                  "Z": 6144
-                },
-                {
-                  "X": 3072,
-                  "Y": 256,
-                  "Z": 6144
-                }
-              ]
-            },
-            {
-              "BaseRoom": 68,
-              "AdjoiningRoom": 22,
-              "Normal": {
-                "Z": 1
-              },
-              "Vertices": [
-                {
-                  "X": 4096,
-                  "Y": 256,
-                  "Z": 1024
-                },
-                {
-                  "X": 4096,
-                  "Y": -1792,
-                  "Z": 1024
-                },
-                {
-                  "X": 6144,
-                  "Y": -1792,
-                  "Z": 1024
-                },
-                {
-                  "X": 6144,
-                  "Y": 256,
-                  "Z": 1024
-                }
-              ]
-            },
-            {
-              "BaseRoom": 15,
-              "AdjoiningRoom": 98,
-              "Normal": {
-                "Z": -1
-              },
-              "Vertices": [
-                {
-                  "X": 1024,
-                  "Y": 1024,
-                  "Z": 6144
-                },
-                {
-                  "X": 1024,
-                  "Y": 256,
-                  "Z": 6144
-                },
-                {
-                  "X": 3072,
-                  "Y": 256,
-                  "Z": 6144
-                },
-                {
-                  "X": 3072,
-                  "Y": 1024,
-                  "Z": 6144
-                }
-              ]
-            },
-            {
-              "BaseRoom": 98,
-              "AdjoiningRoom": 15,
-              "Normal": {
-                "Z": 1
-              },
-              "Vertices": [
-                {
-                  "X": 4096,
-                  "Y": 1536,
-                  "Z": 1024
-                },
-                {
-                  "X": 4096,
-                  "Y": 256,
-                  "Z": 1024
-                },
-                {
-                  "X": 6144,
-                  "Y": 256,
-                  "Z": 1024
-                },
-                {
-                  "X": 6144,
-                  "Y": 1536,
-                  "Z": 1024
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "Comments": "Make collisional portals between rooms 22 & 68 and 15 & 98.",
-          "EMType": 82,
-          "Portals": {
-            "22": {
-              "68": [
-                {
-                  "X": 47551,
-                  "Y": 1358,
-                  "Z": 48285
-                },
-                {
-                  "X": 46527,
-                  "Y": 1358,
-                  "Z": 48285
-                }
-              ]
-            },
-            "15": {
-              "98": [
-                {
-                  "X": 47551,
-                  "Y": 1358,
-                  "Z": 48285
-                },
-                {
-                  "X": 46527,
-                  "Y": 1358,
-                  "Z": 48285
-                }
-              ]
-            },
-            "68": {
-              "22": [
-                {
-                  "X": 47608,
-                  "Y": 256,
-                  "Z": 47886
-                },
-                {
-                  "X": 46534,
-                  "Y": 256,
-                  "Z": 47872
-                }
-              ]
-            },
-            "98": {
-              "15": [
-                {
-                  "X": 47608,
-                  "Y": 256,
-                  "Z": 47886
-                },
-                {
-                  "X": 46534,
-                  "Y": 256,
-                  "Z": 47872
-                }
-              ]
-            }
-          }
-        },
-        {
-          "Comments": "Remove rectangles 15 and 26 from room 15.",
-          "EMType": 22,
-          "GeometryMap": {
-            "15": {
-              "Rectangles": [
-                15,
-                26
-              ]
-            }
-          }
-        },
-        {
-          "Comments": "Decrease the height of rectangles 26 and 34 in room 98 to match the geometry in room 15.",
-          "EMType": 23,
-          "Modifications": [
-            {
-              "RoomNumber": 98,
-              "FaceIndex": 26,
-              "VertexChanges": {
-                "0": {
-                  "Y": 768
-                },
-                "1": {
-                  "Y": 256
-                }
-              }
-            },
-            {
-              "RoomNumber": 98,
-              "FaceIndex": 34,
-              "VertexChanges": {
-                "0": {
-                  "Y": 768
-                },
-                "1": {
-                  "Y": 768
-                }
-              }
-            }
-          ]
-        },
-        {
-          "Comments": "Refacing for above to avoid squashing.",
-          "EMType": 21,
-          "TextureMap": {
-            "1623": {
-              "98": {
-                "Rectangles": [
-                  34
-                ]
-              }
-            }
-          }
-        },
-        {
-          "Comments": "Default button position for the double-double doors.",
-          "EMType": 41,
-          "Tags": [
-            1
-          ],
-          "EntityIndex": 20,
-          "Location": {
-            "X": 49664,
-            "Z": 41472,
-            "Room": 20,
-            "Angle": 16384
-          }
-        },
-        {
-          "Comments": "A trigger for above - open doors 17, 18, 57 and 58.",
-          "EMType": 61,
-          "Locations": [
-            {
-              "X": 49664,
-              "Z": 41472,
-              "Room": 20
-            }
-          ],
-          "Trigger": {
-            "TrigType": 2,
-            "Mask": 31,
-            "SwitchOrKeyRef": 20,
-            "Actions": [
-              {
-                "Parameter": 17
-              },
-              {
-                "Parameter": 18
-              },
-              {
-                "Parameter": 57
-              },
-              {
-                "Parameter": 58
-              }
-            ]
-          }
-        },
-        {
-          "Comments": "Add a camera for above",
-          "EMType": 65,
-          "Camera": {
-            "X": 54256,
-            "Y": -512,
-            "Z": 51336,
-            "Room": 79
-          },
-          "LookAtItem": 17,
-          "AttachToItems": [
-            20
-          ],
-          "CameraAction": {
-            "Value": 2,
-            "Timer": 2,
-            "Continue": true
-          }
-        },
-        {
-          "Comments": "A glitched secret may be in the hidden room 152, so move it as this is no longer reachable.",
-          "EMType": 43,
-          "Types": [
-            190
-          ],
-          "SectorLocations": [
-            {
-              "X": 46181,
-              "Y": 256,
-              "Z": 47205,
-              "Room": 152
-            }
-          ],
-          "TargetLocation": {
-            "X": 63589,
-            "Y": -4403,
-            "Z": 59493,
-            "Room": 111
-          }
-        }
-      ],
-      "Followers": [
-        [
-          {
-            "Comments": "NOOP - use the default button position.",
-            "EMType": 1000
-          }
-        ],
-        [
-          {
-            "Comments": "Potential new button position for the double-double doors button.",
-            "EMType": 41,
-            "Tags": [
-              1
-            ],
-            "EntityIndex": 20,
-            "Location": {
-              "X": 49664,
-              "Z": 42496,
-              "Room": 20,
-              "Angle": 16384
-            }
-          }
-        ],
-        [
-          {
-            "Comments": "Potential new button position for the double-double doors button.",
-            "EMType": 41,
-            "Tags": [
-              1
-            ],
-            "EntityIndex": 20,
-            "Location": {
-              "X": 49664,
-              "Z": 40448,
-              "Room": 20,
-              "Angle": 16384
-            }
-          }
-        ],
-        [
-          {
-            "Comments": "Potential new button position for the double-double doors button.",
-            "EMType": 41,
-            "Tags": [
-              1
-            ],
-            "EntityIndex": 20,
-            "Location": {
-              "X": 49664,
-              "Z": 38400,
-              "Room": 20,
-              "Angle": 16384
-            }
-          }
-        ],
-        [
-          {
-            "Comments": "Potential new button position for the double-double doors button.",
-            "EMType": 41,
-            "Tags": [
-              1
-            ],
-            "EntityIndex": 20,
-            "Location": {
-              "X": 58880,
-              "Z": 31232,
-              "Angle": 16384
-            }
-          }
-        ],
-        [
-          {
-            "Comments": "Potential new button position for the double-double doors button.",
-            "EMType": 41,
-            "Tags": [
-              1
-            ],
-            "EntityIndex": 20,
-            "Location": {
-              "X": 47600,
-              "Y": -4096,
-              "Z": 32256,
-              "Room": 34,
-              "Angle": -16384
-            }
-          }
-        ]
-      ]
-    }
-  ],
+  "OneOf": [],
   "ConditionalAllWithin": [],
   "ConditionalAll": [
     {
@@ -1658,6 +1218,432 @@
       ]
     }
   ],
-  "ConditionalOneOf": [],
+  "ConditionalOneOf": [
+    {
+      "Condition": {
+        "Comments": "If room 152 does not contain a secret, add a shortcut between rooms 22 and 68.",
+        "ConditionType": 1,
+        "RoomIndex": 152
+      },
+      "OnFalse": {
+        "Leader": [
+          {
+            "Comments": "Move the first duplicated door downwards and to the other side.",
+            "EMType": 44,
+            "EntityIndex": 57,
+            "TargetLocation": {
+              "X": 46592,
+              "Y": 2304,
+              "Z": 47616,
+              "Room": 15,
+              "Angle": -32768
+            }
+          },
+          {
+            "Comments": "Move the second duplicated door downwards and to the other side.",
+            "EMType": 44,
+            "EntityIndex": 58,
+            "TargetLocation": {
+              "X": 47616,
+              "Y": 2304,
+              "Z": 47616,
+              "Room": 15,
+              "Angle": -32768
+            }
+          },
+          {
+            "Comments": "Make visibility portals between rooms 22 & 68 and 15 & 98.",
+            "EMType": 81,
+            "Portals": [
+              {
+                "BaseRoom": 22,
+                "AdjoiningRoom": 68,
+                "Normal": {
+                  "Z": -1
+                },
+                "Vertices": [
+                  {
+                    "X": 1024,
+                    "Y": 256,
+                    "Z": 6144
+                  },
+                  {
+                    "X": 1024,
+                    "Y": -2048,
+                    "Z": 6144
+                  },
+                  {
+                    "X": 3072,
+                    "Y": -2048,
+                    "Z": 6144
+                  },
+                  {
+                    "X": 3072,
+                    "Y": 256,
+                    "Z": 6144
+                  }
+                ]
+              },
+              {
+                "BaseRoom": 68,
+                "AdjoiningRoom": 22,
+                "Normal": {
+                  "Z": 1
+                },
+                "Vertices": [
+                  {
+                    "X": 4096,
+                    "Y": 256,
+                    "Z": 1024
+                  },
+                  {
+                    "X": 4096,
+                    "Y": -1792,
+                    "Z": 1024
+                  },
+                  {
+                    "X": 6144,
+                    "Y": -1792,
+                    "Z": 1024
+                  },
+                  {
+                    "X": 6144,
+                    "Y": 256,
+                    "Z": 1024
+                  }
+                ]
+              },
+              {
+                "BaseRoom": 15,
+                "AdjoiningRoom": 98,
+                "Normal": {
+                  "Z": -1
+                },
+                "Vertices": [
+                  {
+                    "X": 1024,
+                    "Y": 1024,
+                    "Z": 6144
+                  },
+                  {
+                    "X": 1024,
+                    "Y": 256,
+                    "Z": 6144
+                  },
+                  {
+                    "X": 3072,
+                    "Y": 256,
+                    "Z": 6144
+                  },
+                  {
+                    "X": 3072,
+                    "Y": 1024,
+                    "Z": 6144
+                  }
+                ]
+              },
+              {
+                "BaseRoom": 98,
+                "AdjoiningRoom": 15,
+                "Normal": {
+                  "Z": 1
+                },
+                "Vertices": [
+                  {
+                    "X": 4096,
+                    "Y": 1536,
+                    "Z": 1024
+                  },
+                  {
+                    "X": 4096,
+                    "Y": 256,
+                    "Z": 1024
+                  },
+                  {
+                    "X": 6144,
+                    "Y": 256,
+                    "Z": 1024
+                  },
+                  {
+                    "X": 6144,
+                    "Y": 1536,
+                    "Z": 1024
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "Comments": "Make collisional portals between rooms 22 & 68 and 15 & 98.",
+            "EMType": 82,
+            "Portals": {
+              "22": {
+                "68": [
+                  {
+                    "X": 47551,
+                    "Y": 1358,
+                    "Z": 48285
+                  },
+                  {
+                    "X": 46527,
+                    "Y": 1358,
+                    "Z": 48285
+                  }
+                ]
+              },
+              "15": {
+                "98": [
+                  {
+                    "X": 47551,
+                    "Y": 1358,
+                    "Z": 48285
+                  },
+                  {
+                    "X": 46527,
+                    "Y": 1358,
+                    "Z": 48285
+                  }
+                ]
+              },
+              "68": {
+                "22": [
+                  {
+                    "X": 47608,
+                    "Y": 256,
+                    "Z": 47886
+                  },
+                  {
+                    "X": 46534,
+                    "Y": 256,
+                    "Z": 47872
+                  }
+                ]
+              },
+              "98": {
+                "15": [
+                  {
+                    "X": 47608,
+                    "Y": 256,
+                    "Z": 47886
+                  },
+                  {
+                    "X": 46534,
+                    "Y": 256,
+                    "Z": 47872
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "Comments": "Remove rectangles 15 and 26 from room 15.",
+            "EMType": 22,
+            "GeometryMap": {
+              "15": {
+                "Rectangles": [
+                  15,
+                  26
+                ]
+              }
+            }
+          },
+          {
+            "Comments": "Decrease the height of rectangles 26 and 34 in room 98 to match the geometry in room 15.",
+            "EMType": 23,
+            "Modifications": [
+              {
+                "RoomNumber": 98,
+                "FaceIndex": 26,
+                "VertexChanges": {
+                  "0": {
+                    "Y": 768
+                  },
+                  "1": {
+                    "Y": 256
+                  }
+                }
+              },
+              {
+                "RoomNumber": 98,
+                "FaceIndex": 34,
+                "VertexChanges": {
+                  "0": {
+                    "Y": 768
+                  },
+                  "1": {
+                    "Y": 768
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "Comments": "Refacing for above to avoid squashing.",
+            "EMType": 21,
+            "TextureMap": {
+              "1623": {
+                "98": {
+                  "Rectangles": [
+                    34
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "Comments": "Default button position for the double-double doors.",
+            "EMType": 41,
+            "Tags": [
+              1
+            ],
+            "EntityIndex": 20,
+            "Location": {
+              "X": 49664,
+              "Z": 41472,
+              "Room": 20,
+              "Angle": 16384
+            }
+          },
+          {
+            "Comments": "A trigger for above - open doors 17, 18, 57 and 58.",
+            "EMType": 61,
+            "Locations": [
+              {
+                "X": 49664,
+                "Z": 41472,
+                "Room": 20
+              }
+            ],
+            "Trigger": {
+              "TrigType": 2,
+              "Mask": 31,
+              "SwitchOrKeyRef": 20,
+              "Actions": [
+                {
+                  "Parameter": 17
+                },
+                {
+                  "Parameter": 18
+                },
+                {
+                  "Parameter": 57
+                },
+                {
+                  "Parameter": 58
+                }
+              ]
+            }
+          },
+          {
+            "Comments": "Add a camera for above",
+            "EMType": 65,
+            "Camera": {
+              "X": 54256,
+              "Y": -512,
+              "Z": 51336,
+              "Room": 79
+            },
+            "LookAtItem": 17,
+            "AttachToItems": [
+              20
+            ],
+            "CameraAction": {
+              "Value": 2,
+              "Timer": 2,
+              "Continue": true
+            }
+          }
+        ],
+        "Followers": [
+          [
+            {
+              "Comments": "NOOP - use the default button position.",
+              "EMType": 1000
+            }
+          ],
+          [
+            {
+              "Comments": "Potential new button position for the double-double doors button.",
+              "EMType": 41,
+              "Tags": [
+                1
+              ],
+              "EntityIndex": 20,
+              "Location": {
+                "X": 49664,
+                "Z": 42496,
+                "Room": 20,
+                "Angle": 16384
+              }
+            }
+          ],
+          [
+            {
+              "Comments": "Potential new button position for the double-double doors button.",
+              "EMType": 41,
+              "Tags": [
+                1
+              ],
+              "EntityIndex": 20,
+              "Location": {
+                "X": 49664,
+                "Z": 40448,
+                "Room": 20,
+                "Angle": 16384
+              }
+            }
+          ],
+          [
+            {
+              "Comments": "Potential new button position for the double-double doors button.",
+              "EMType": 41,
+              "Tags": [
+                1
+              ],
+              "EntityIndex": 20,
+              "Location": {
+                "X": 49664,
+                "Z": 38400,
+                "Room": 20,
+                "Angle": 16384
+              }
+            }
+          ],
+          [
+            {
+              "Comments": "Potential new button position for the double-double doors button.",
+              "EMType": 41,
+              "Tags": [
+                1
+              ],
+              "EntityIndex": 20,
+              "Location": {
+                "X": 58880,
+                "Z": 31232,
+                "Angle": 16384
+              }
+            }
+          ],
+          [
+            {
+              "Comments": "Potential new button position for the double-double doors button.",
+              "EMType": 41,
+              "Tags": [
+                1
+              ],
+              "EntityIndex": 20,
+              "Location": {
+                "X": 47600,
+                "Y": -4096,
+                "Z": 32256,
+                "Room": 34,
+                "Angle": -16384
+              }
+            }
+          ]
+        ]
+      }
+    }
+  ],
   "Mirrored": []
 }

--- a/TRRandomizerCore/Resources/TR2/Environment/CATACOMB.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR2/Environment/CATACOMB.TR2-Environment.json
@@ -2403,7 +2403,45 @@
     }
   ],
   "ConditionalAllWithin": [],
-  "ConditionalAll": [],
+  "ConditionalAll": [
+    {
+      "Condition": {
+        "Comments": "Check if a specific secret is present.",
+        "ConditionType": 22,
+        "Location": {
+          "X": 43520,
+          "Y": 5632,
+          "Z": 50688,
+          "Room": 128
+        }
+      },
+      "OnTrue": [
+        {
+          "Comments": "Make the gong hammer accessible.",
+          "EMType": 44,
+          "EntityIndex": 76,
+          "TargetLocation": {
+            "X": 12800,
+            "Y": 2304,
+            "Z": 45568,
+            "Room": 23
+          }
+        },
+        {
+          "Comments": "Turn it into a puzzle item.",
+          "EMType": 45,
+          "EntityIndex": 76,
+          "NewEntityType": 175
+        },
+        {
+          "Comments": "Change its appearance.",
+          "EMType": 146,
+          "BaseSpriteID": 190,
+          "TargetSpriteID": 175
+        }
+      ]
+    }
+  ],
   "ConditionalOneOf": [],
   "Mirrored": [
     {

--- a/TRRandomizerCore/Resources/TR2/Environment/DECK.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR2/Environment/DECK.TR2-Environment.json
@@ -992,7 +992,33 @@
     }
   ],
   "ConditionalAllWithin": [],
-  "ConditionalAll": [],
+  "ConditionalAll": [
+    {
+      "Condition": {
+        "Comments": "Check if a specific secret is present.",
+        "ConditionType": 22,
+        "Location": {
+          "X": 39424,
+          "Y": -16512,
+          "Z": 73216,
+          "Room": 61
+        }
+      },
+      "OnTrue": [
+        {
+          "Comments": "Move key3.",
+          "EMType": 44,
+          "EntityIndex": 45,
+          "TargetLocation": {
+            "X": 61278,
+            "Y": 1970,
+            "Z": 67389,
+            "Room": 10
+          }
+        }
+      ]
+    }
+  ],
   "ConditionalOneOf": [],
   "Mirrored": []
 }

--- a/TRRandomizerCore/Resources/TR2/Environment/ICECAVE.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR2/Environment/ICECAVE.TR2-Environment.json
@@ -1977,6 +1977,63 @@
           }
         }
       ]
+    },
+    {
+      "Condition": {
+        "Comments": "Check if a specific secret is present.",
+        "ConditionType": 22,
+        "Location": {
+          "X": 64000,
+          "Y": 5632,
+          "Z": 70144,
+          "Room": 46
+        }
+      },
+      "OnTrue": [
+        {
+          "Comments": "Move Lara.",
+          "EMType": 44,
+          "EntityIndex": 58,
+          "TargetLocation": {
+            "X": 76288,
+            "Y": -1792,
+            "Z": 54784,
+            "Room": 97
+          }
+        },
+        {
+          "Comments": "Move switch 66.",
+          "EMType": 44,
+          "EntityIndex": 66,
+          "TargetLocation": {
+            "X": 68096,
+            "Y": -7184,
+            "Z": 73216,
+            "Room": 54,
+            "Angle": -16384
+          }
+        },
+        {
+          "Comments": "Add a trigger to open the door by the first bell.",
+          "EMType": 61,
+          "Locations": [
+            {
+              "X": 60928,
+              "Y": 7936,
+              "Z": 72192,
+              "Room": 93
+            }
+          ],
+          "Trigger": {
+            "Mask": 31,
+            "Actions": [
+              {
+                "Parameter": 60
+              }
+            ]
+          }
+        }
+      ]
     }
   ],
   "ConditionalOneOf": [],

--- a/TRRandomizerCore/Resources/TR2/Environment/MONASTRY.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR2/Environment/MONASTRY.TR2-Environment.json
@@ -3540,6 +3540,33 @@
           }
         }
       ]
+    },
+    {
+      "Condition": {
+        "Comments": "If room 81 contains a secret but Lara has also spawned here, move her back to the OG spot.",
+        "ConditionType": 1,
+        "And": [
+          {
+            "ConditionType": 0,
+            "EntityIndex": 186,
+            "Room": 81
+          }
+        ],
+        "RoomIndex": 81
+      },
+      "OnTrue": [
+        {
+          "EMType": 44,
+          "EntityIndex": 186,
+          "TargetLocation": {
+            "X": 96768,
+            "Y": 3456,
+            "Z": 16896,
+            "Room": 128,
+            "Angle": -16384
+          }
+        }
+      ]
     }
   ],
   "ConditionalOneOf": [],

--- a/TRRandomizerCore/Resources/TR2/Environment/RIG.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR2/Environment/RIG.TR2-Environment.json
@@ -1233,616 +1233,6 @@
     {
       "Leader": [
         {
-          "Comments": "Drain the rooms at the start.",
-          "EMType": 3,
-          "Tags": [
-            2
-          ],
-          "RoomNumbers": [
-            85,
-            86,
-            87,
-            88,
-            89,
-            6,
-            58,
-            77,
-            78,
-            79,
-            14
-          ],
-          "WaterTextures": [
-            1740,
-            1670,
-            1648,
-            1741
-          ]
-        },
-        {
-          "Comments": "Remove the water sound source for above.",
-          "EMType": 103,
-          "Source": {
-            "X": 39424,
-            "Y": -4992,
-            "Z": 85504
-          }
-        },
-        {
-          "Comments": "Remove the water sound source for above.",
-          "EMType": 103,
-          "Source": {
-            "X": 27136,
-            "Y": -6016,
-            "Z": 85504
-          }
-        },
-        {
-          "Comments": "Create some supports for the plane.",
-          "EMType": 1,
-          "Location": {
-            "X": 33266,
-            "Y": 2048,
-            "Z": 82309,
-            "Room": 89
-          },
-          "Clicks": -1,
-          "FloorTexture": 65535,
-          "SideTexture": 1668,
-          "Flags": 15
-        },
-        {
-          "EMType": 1,
-          "Location": {
-            "X": 33266,
-            "Y": 2304,
-            "Z": 82309,
-            "Room": 89
-          },
-          "Clicks": -5,
-          "FloorTexture": 65535,
-          "SideTexture": 1667,
-          "Flags": 15
-        },
-        {
-          "EMType": 1,
-          "Location": {
-            "X": 33266,
-            "Y": 3584,
-            "Z": 82309,
-            "Room": 89
-          },
-          "Clicks": -5,
-          "FloorTexture": 65535,
-          "SideTexture": 1667,
-          "Flags": 15
-        },
-        {
-          "Comments": "Make the support climbable.",
-          "EMType": 0,
-          "Tags": [
-            3
-          ],
-          "TextureMap": {
-            "1645": {
-              "89": {
-                "Rectangles": [
-                  69,
-                  73
-                ]
-              }
-            },
-            "1700": {
-              "89": {
-                "Rectangles": [
-                  65
-                ]
-              }
-            }
-          },
-          "Location": {
-            "X": 33292,
-            "Y": 2048,
-            "Z": 83469,
-            "Room": 89
-          },
-          "IsNegativeZ": true
-        },
-        {
-          "Comments": "Rotate the trapdoor so it doesn't open against the ladder.",
-          "EMType": 44,
-          "EntityIndex": 101,
-          "TargetLocation": {
-            "X": 33280,
-            "Y": -1280,
-            "Z": 83456,
-            "Room": 97,
-            "Angle": -32768
-          }
-        },
-        {
-          "Comments": "More plane supports.",
-          "EMType": 1,
-          "Location": {
-            "X": 33266,
-            "Y": 2048,
-            "Z": 86405,
-            "Room": 89
-          },
-          "Clicks": -1,
-          "FloorTexture": 65535,
-          "SideTexture": 1668,
-          "Flags": 15
-        },
-        {
-          "EMType": 1,
-          "Location": {
-            "X": 33266,
-            "Y": 2304,
-            "Z": 86405,
-            "Room": 89
-          },
-          "Clicks": -5,
-          "FloorTexture": 65535,
-          "SideTexture": 1667,
-          "Flags": 15
-        },
-        {
-          "EMType": 1,
-          "Location": {
-            "X": 33266,
-            "Y": 3584,
-            "Z": 86405,
-            "Room": 89
-          },
-          "Clicks": -5,
-          "FloorTexture": 65535,
-          "SideTexture": 1667,
-          "Flags": 15
-        },
-        {
-          "Comments": "More plane supports.",
-          "EMType": 1,
-          "Location": {
-            "X": 33266,
-            "Y": 2048,
-            "Z": 90501,
-            "Room": 89
-          },
-          "Clicks": -1,
-          "FloorTexture": 65535,
-          "SideTexture": 1668,
-          "Flags": 15
-        },
-        {
-          "EMType": 1,
-          "Location": {
-            "X": 33266,
-            "Y": 2304,
-            "Z": 90501,
-            "Room": 89
-          },
-          "Clicks": -5,
-          "FloorTexture": 65535,
-          "SideTexture": 1667,
-          "Flags": 15
-        },
-        {
-          "EMType": 1,
-          "Location": {
-            "X": 33266,
-            "Y": 3584,
-            "Z": 90501,
-            "Room": 89
-          },
-          "Clicks": -5,
-          "FloorTexture": 65535,
-          "SideTexture": 1667,
-          "Flags": 15
-        },
-        {
-          "Comments": "Make a ladder to get into the drained plane room.",
-          "EMType": 0,
-          "Tags": [
-            3
-          ],
-          "TextureMap": {
-            "1645": {
-              "88": {
-                "Rectangles": [
-                  84,
-                  85
-                ]
-              }
-            }
-          },
-          "Location": {
-            "X": 38363,
-            "Y": 2048,
-            "Z": 82241,
-            "Room": 88
-          },
-          "IsNegativeZ": true
-        },
-        {
-          "Comments": "Block for above ladder.",
-          "EMType": 1,
-          "Location": {
-            "X": 38363,
-            "Y": 2048,
-            "Z": 82241,
-            "Room": 88
-          },
-          "Clicks": -4,
-          "FloorTexture": 1673,
-          "SideTexture": 1694,
-          "Flags": 14
-        },
-        {
-          "Comments": "Put a block near the starting area to get into the plane pit.",
-          "EMType": 1,
-          "Location": {
-            "X": 42597,
-            "Y": 2048,
-            "Z": 95715,
-            "Room": 6
-          },
-          "Clicks": -7,
-          "FloorTexture": 1673,
-          "SideTexture": 1694,
-          "Flags": 3
-        },
-        {
-          "Comments": "Convert the lever next to the fan into a button.",
-          "EMType": 45,
-          "EntityIndex": 96,
-          "NewEntityType": 103
-        },
-        {
-          "Comments": "Shift the button up.",
-          "EMType": 41,
-          "Tags": [
-            1
-          ],
-          "EntityIndex": 96,
-          "Location": {
-            "X": 24064,
-            "Y": 2048,
-            "Z": 91648,
-            "Room": 85,
-            "Angle": -16384
-          }
-        },
-        {
-          "Comments": "Put a block where the button used to be for secret reasons.",
-          "EMType": 1,
-          "Location": {
-            "X": 23926,
-            "Y": 2048,
-            "Z": 91659,
-            "Room": 85
-          },
-          "Clicks": -4,
-          "FloorTexture": 1673,
-          "SideTexture": 1694,
-          "Flags": 13
-        },
-        {
-          "Comments": "Convert the underwater fan into a fire.",
-          "EMType": 45,
-          "EntityIndex": 93,
-          "NewEntityType": 253
-        },
-        {
-          "Comments": "Convert the lever for the fire room into something useful",
-          "EMType": 45,
-          "EntityIndex": 24,
-          "NewEntityType": 150
-        },
-        {
-          "Comments": "Shift the item above.",
-          "EMType": 44,
-          "EntityIndex": 24,
-          "TargetLocation": {
-            "X": 22038,
-            "Y": 3072,
-            "Z": 96766,
-            "Room": 58
-          }
-        },
-        {
-          "Comments": "Delete its old triggers.",
-          "EMType": 62,
-          "Locations": [
-            {
-              "X": 22020,
-              "Y": 768,
-              "Z": 77311,
-              "Room": 14
-            }
-          ]
-        },
-        {
-          "Comments": "Convert the trapdoor that used to lead to the secret to fire as it's now redundant.",
-          "EMType": 45,
-          "EntityIndex": 95,
-          "NewEntityType": 253
-        },
-        {
-          "Comments": "Shift the above fire down.",
-          "EMType": 44,
-          "EntityIndex": 95,
-          "TargetLocation": {
-            "X": 22016,
-            "Y": 3072,
-            "Z": 97792,
-            "Room": 58
-          }
-        },
-        {
-          "Comments": "Make a trigger for it.",
-          "EMType": 61,
-          "Locations": [
-            {
-              "X": 22016,
-              "Y": 3072,
-              "Z": 97792,
-              "Room": 58
-            }
-          ],
-          "Trigger": {
-            "Mask": 31,
-            "Actions": [
-              {
-                "Parameter": 95
-              }
-            ]
-          },
-          "Replace": true
-        },
-        {
-          "Comments": "Make all this fire look intentional.",
-          "EMType": 21,
-          "TextureMap": {
-            "1710": {
-              "77": {
-                "Rectangles": [
-                  20
-                ]
-              },
-              "58": {
-                "Rectangles": [
-                  9
-                ]
-              }
-            },
-            "1667": {
-              "77": {
-                "Rectangles": [
-                  0,
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7,
-                  8,
-                  9,
-                  10,
-                  11,
-                  12,
-                  13,
-                  14,
-                  15,
-                  16,
-                  17,
-                  18,
-                  19,
-                  21,
-                  22,
-                  23,
-                  24,
-                  25
-                ]
-              },
-              "58": {
-                "Rectangles": [
-                  0,
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7,
-                  8,
-                  10,
-                  11,
-                  12,
-                  13,
-                  14,
-                  15
-                ]
-              }
-            },
-            "1649": {
-              "77": {
-                "Triangles": [
-                  0,
-                  1,
-                  2
-                ]
-              }
-            }
-          }
-        },
-        {
-          "Comments": "Make a ladder to get out of room 14.",
-          "EMType": 0,
-          "Tags": [
-            3
-          ],
-          "TextureMap": {
-            "1645": {
-              "14": {
-                "Rectangles": [
-                  68,
-                  69,
-                  70
-                ]
-              }
-            }
-          },
-          "Location": {
-            "X": 23185,
-            "Y": 768,
-            "Z": 76239,
-            "Room": 14
-          },
-          "IsPositiveX": true
-        },
-        {
-          "Comments": "Adjust any secrets in the drained areas.",
-          "EMType": 43,
-          "Types": [
-            190,
-            191,
-            192
-          ],
-          "SectorLocations": [
-            {
-              "X": 22139,
-              "Y": 2048,
-              "Z": 93731,
-              "Room": 77
-            }
-          ],
-          "TargetLocation": {
-            "X": 22488,
-            "Y": 2048,
-            "Z": 90084,
-            "Room": 14
-          }
-        }
-      ],
-      "Followers": [
-        [
-          {
-            "Comments": "Move the button for door 97.",
-            "EMType": 41,
-            "Tags": [
-              1
-            ],
-            "EntityIndex": 96,
-            "Location": {
-              "X": 25088,
-              "Y": 2048,
-              "Z": 91648,
-              "Room": 85,
-              "Angle": -16384
-            }
-          }
-        ],
-        [
-          {
-            "EMType": 41,
-            "Tags": [
-              1
-            ],
-            "EntityIndex": 96,
-            "Location": {
-              "X": 24064,
-              "Y": 2048,
-              "Z": 95744,
-              "Room": 85,
-              "Angle": -16384
-            }
-          }
-        ],
-        [
-          {
-            "EMType": 41,
-            "Tags": [
-              1
-            ],
-            "EntityIndex": 96,
-            "Location": {
-              "X": 22016,
-              "Y": 2048,
-              "Z": 93696,
-              "Room": 77,
-              "Angle": -16384
-            }
-          }
-        ],
-        [
-          {
-            "EMType": 41,
-            "Tags": [
-              1
-            ],
-            "EntityIndex": 96,
-            "Location": {
-              "X": 24064,
-              "Y": 2048,
-              "Z": 90624,
-              "Room": 85
-            }
-          }
-        ],
-        [
-          {
-            "EMType": 41,
-            "Tags": [
-              1
-            ],
-            "EntityIndex": 96,
-            "Location": {
-              "X": 32256,
-              "Y": 2048,
-              "Z": 90624,
-              "Room": 89,
-              "Angle": 16384
-            }
-          }
-        ],
-        [
-          {
-            "EMType": 41,
-            "Tags": [
-              1
-            ],
-            "EntityIndex": 96,
-            "Location": {
-              "X": 32256,
-              "Y": 2048,
-              "Z": 86528,
-              "Room": 89,
-              "Angle": 16384
-            }
-          }
-        ],
-        [
-          {
-            "EMType": 41,
-            "Tags": [
-              1
-            ],
-            "EntityIndex": 96,
-            "Location": {
-              "X": 32256,
-              "Y": 2048,
-              "Z": 82432,
-              "Room": 89,
-              "Angle": 16384
-            }
-          }
-        ]
-      ]
-    },
-    {
-      "Leader": [
-        {
           "Comments": "Remove the textures for the old ladder that leads outside.",
           "EMType": 21,
           "TextureMap": {
@@ -2081,6 +1471,624 @@
       ]
     }
   ],
-  "ConditionalOneOf": [],
+  "ConditionalOneOf": [
+    {
+      "Condition": {
+        "Comments": "If room 2 does not contain a secret, drain the plane area.",
+        "ConditionType": 1,
+        "RoomIndex": 2
+      },
+      "OnFalse": {
+        "Leader": [
+          {
+            "Comments": "Drain the rooms at the start.",
+            "EMType": 3,
+            "Tags": [
+              2
+            ],
+            "RoomNumbers": [
+              85,
+              86,
+              87,
+              88,
+              89,
+              6,
+              58,
+              77,
+              78,
+              79,
+              14
+            ],
+            "WaterTextures": [
+              1740,
+              1670,
+              1648,
+              1741
+            ]
+          },
+          {
+            "Comments": "Remove the water sound source for above.",
+            "EMType": 103,
+            "Source": {
+              "X": 39424,
+              "Y": -4992,
+              "Z": 85504
+            }
+          },
+          {
+            "Comments": "Remove the water sound source for above.",
+            "EMType": 103,
+            "Source": {
+              "X": 27136,
+              "Y": -6016,
+              "Z": 85504
+            }
+          },
+          {
+            "Comments": "Create some supports for the plane.",
+            "EMType": 1,
+            "Location": {
+              "X": 33266,
+              "Y": 2048,
+              "Z": 82309,
+              "Room": 89
+            },
+            "Clicks": -1,
+            "FloorTexture": 65535,
+            "SideTexture": 1668,
+            "Flags": 15
+          },
+          {
+            "EMType": 1,
+            "Location": {
+              "X": 33266,
+              "Y": 2304,
+              "Z": 82309,
+              "Room": 89
+            },
+            "Clicks": -5,
+            "FloorTexture": 65535,
+            "SideTexture": 1667,
+            "Flags": 15
+          },
+          {
+            "EMType": 1,
+            "Location": {
+              "X": 33266,
+              "Y": 3584,
+              "Z": 82309,
+              "Room": 89
+            },
+            "Clicks": -5,
+            "FloorTexture": 65535,
+            "SideTexture": 1667,
+            "Flags": 15
+          },
+          {
+            "Comments": "Make the support climbable.",
+            "EMType": 0,
+            "Tags": [
+              3
+            ],
+            "TextureMap": {
+              "1645": {
+                "89": {
+                  "Rectangles": [
+                    69,
+                    73
+                  ]
+                }
+              },
+              "1700": {
+                "89": {
+                  "Rectangles": [
+                    65
+                  ]
+                }
+              }
+            },
+            "Location": {
+              "X": 33292,
+              "Y": 2048,
+              "Z": 83469,
+              "Room": 89
+            },
+            "IsNegativeZ": true
+          },
+          {
+            "Comments": "Rotate the trapdoor so it doesn't open against the ladder.",
+            "EMType": 44,
+            "EntityIndex": 101,
+            "TargetLocation": {
+              "X": 33280,
+              "Y": -1280,
+              "Z": 83456,
+              "Room": 97,
+              "Angle": -32768
+            }
+          },
+          {
+            "Comments": "More plane supports.",
+            "EMType": 1,
+            "Location": {
+              "X": 33266,
+              "Y": 2048,
+              "Z": 86405,
+              "Room": 89
+            },
+            "Clicks": -1,
+            "FloorTexture": 65535,
+            "SideTexture": 1668,
+            "Flags": 15
+          },
+          {
+            "EMType": 1,
+            "Location": {
+              "X": 33266,
+              "Y": 2304,
+              "Z": 86405,
+              "Room": 89
+            },
+            "Clicks": -5,
+            "FloorTexture": 65535,
+            "SideTexture": 1667,
+            "Flags": 15
+          },
+          {
+            "EMType": 1,
+            "Location": {
+              "X": 33266,
+              "Y": 3584,
+              "Z": 86405,
+              "Room": 89
+            },
+            "Clicks": -5,
+            "FloorTexture": 65535,
+            "SideTexture": 1667,
+            "Flags": 15
+          },
+          {
+            "Comments": "More plane supports.",
+            "EMType": 1,
+            "Location": {
+              "X": 33266,
+              "Y": 2048,
+              "Z": 90501,
+              "Room": 89
+            },
+            "Clicks": -1,
+            "FloorTexture": 65535,
+            "SideTexture": 1668,
+            "Flags": 15
+          },
+          {
+            "EMType": 1,
+            "Location": {
+              "X": 33266,
+              "Y": 2304,
+              "Z": 90501,
+              "Room": 89
+            },
+            "Clicks": -5,
+            "FloorTexture": 65535,
+            "SideTexture": 1667,
+            "Flags": 15
+          },
+          {
+            "EMType": 1,
+            "Location": {
+              "X": 33266,
+              "Y": 3584,
+              "Z": 90501,
+              "Room": 89
+            },
+            "Clicks": -5,
+            "FloorTexture": 65535,
+            "SideTexture": 1667,
+            "Flags": 15
+          },
+          {
+            "Comments": "Make a ladder to get into the drained plane room.",
+            "EMType": 0,
+            "Tags": [
+              3
+            ],
+            "TextureMap": {
+              "1645": {
+                "88": {
+                  "Rectangles": [
+                    84,
+                    85
+                  ]
+                }
+              }
+            },
+            "Location": {
+              "X": 38363,
+              "Y": 2048,
+              "Z": 82241,
+              "Room": 88
+            },
+            "IsNegativeZ": true
+          },
+          {
+            "Comments": "Block for above ladder.",
+            "EMType": 1,
+            "Location": {
+              "X": 38363,
+              "Y": 2048,
+              "Z": 82241,
+              "Room": 88
+            },
+            "Clicks": -4,
+            "FloorTexture": 1673,
+            "SideTexture": 1694,
+            "Flags": 14
+          },
+          {
+            "Comments": "Put a block near the starting area to get into the plane pit.",
+            "EMType": 1,
+            "Location": {
+              "X": 42597,
+              "Y": 2048,
+              "Z": 95715,
+              "Room": 6
+            },
+            "Clicks": -7,
+            "FloorTexture": 1673,
+            "SideTexture": 1694,
+            "Flags": 3
+          },
+          {
+            "Comments": "Convert the lever next to the fan into a button.",
+            "EMType": 45,
+            "EntityIndex": 96,
+            "NewEntityType": 103
+          },
+          {
+            "Comments": "Shift the button up.",
+            "EMType": 41,
+            "Tags": [
+              1
+            ],
+            "EntityIndex": 96,
+            "Location": {
+              "X": 24064,
+              "Y": 2048,
+              "Z": 91648,
+              "Room": 85,
+              "Angle": -16384
+            }
+          },
+          {
+            "Comments": "Put a block where the button used to be for secret reasons.",
+            "EMType": 1,
+            "Location": {
+              "X": 23926,
+              "Y": 2048,
+              "Z": 91659,
+              "Room": 85
+            },
+            "Clicks": -4,
+            "FloorTexture": 1673,
+            "SideTexture": 1694,
+            "Flags": 13
+          },
+          {
+            "Comments": "Convert the underwater fan into a fire.",
+            "EMType": 45,
+            "EntityIndex": 93,
+            "NewEntityType": 253
+          },
+          {
+            "Comments": "Convert the lever for the fire room into something useful",
+            "EMType": 45,
+            "EntityIndex": 24,
+            "NewEntityType": 150
+          },
+          {
+            "Comments": "Shift the item above.",
+            "EMType": 44,
+            "EntityIndex": 24,
+            "TargetLocation": {
+              "X": 22038,
+              "Y": 3072,
+              "Z": 96766,
+              "Room": 58
+            }
+          },
+          {
+            "Comments": "Delete its old triggers.",
+            "EMType": 62,
+            "Locations": [
+              {
+                "X": 22020,
+                "Y": 768,
+                "Z": 77311,
+                "Room": 14
+              }
+            ]
+          },
+          {
+            "Comments": "Convert the trapdoor that used to lead to the secret to fire as it's now redundant.",
+            "EMType": 45,
+            "EntityIndex": 95,
+            "NewEntityType": 253
+          },
+          {
+            "Comments": "Shift the above fire down.",
+            "EMType": 44,
+            "EntityIndex": 95,
+            "TargetLocation": {
+              "X": 22016,
+              "Y": 3072,
+              "Z": 97792,
+              "Room": 58
+            }
+          },
+          {
+            "Comments": "Make a trigger for it.",
+            "EMType": 61,
+            "Locations": [
+              {
+                "X": 22016,
+                "Y": 3072,
+                "Z": 97792,
+                "Room": 58
+              }
+            ],
+            "Trigger": {
+              "Mask": 31,
+              "Actions": [
+                {
+                  "Parameter": 95
+                }
+              ]
+            },
+            "Replace": true
+          },
+          {
+            "Comments": "Make all this fire look intentional.",
+            "EMType": 21,
+            "TextureMap": {
+              "1710": {
+                "77": {
+                  "Rectangles": [
+                    20
+                  ]
+                },
+                "58": {
+                  "Rectangles": [
+                    9
+                  ]
+                }
+              },
+              "1667": {
+                "77": {
+                  "Rectangles": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10,
+                    11,
+                    12,
+                    13,
+                    14,
+                    15,
+                    16,
+                    17,
+                    18,
+                    19,
+                    21,
+                    22,
+                    23,
+                    24,
+                    25
+                  ]
+                },
+                "58": {
+                  "Rectangles": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    10,
+                    11,
+                    12,
+                    13,
+                    14,
+                    15
+                  ]
+                }
+              },
+              "1649": {
+                "77": {
+                  "Triangles": [
+                    0,
+                    1,
+                    2
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "Comments": "Make a ladder to get out of room 14.",
+            "EMType": 0,
+            "Tags": [
+              3
+            ],
+            "TextureMap": {
+              "1645": {
+                "14": {
+                  "Rectangles": [
+                    68,
+                    69,
+                    70
+                  ]
+                }
+              }
+            },
+            "Location": {
+              "X": 23185,
+              "Y": 768,
+              "Z": 76239,
+              "Room": 14
+            },
+            "IsPositiveX": true
+          },
+          {
+            "Comments": "Adjust any secrets in the drained areas.",
+            "EMType": 43,
+            "Types": [
+              190,
+              191,
+              192
+            ],
+            "SectorLocations": [
+              {
+                "X": 22139,
+                "Y": 2048,
+                "Z": 93731,
+                "Room": 77
+              }
+            ],
+            "TargetLocation": {
+              "X": 22488,
+              "Y": 2048,
+              "Z": 90084,
+              "Room": 14
+            }
+          }
+        ],
+        "Followers": [
+          [
+            {
+              "Comments": "Move the button for door 97.",
+              "EMType": 41,
+              "Tags": [
+                1
+              ],
+              "EntityIndex": 96,
+              "Location": {
+                "X": 25088,
+                "Y": 2048,
+                "Z": 91648,
+                "Room": 85,
+                "Angle": -16384
+              }
+            }
+          ],
+          [
+            {
+              "EMType": 41,
+              "Tags": [
+                1
+              ],
+              "EntityIndex": 96,
+              "Location": {
+                "X": 24064,
+                "Y": 2048,
+                "Z": 95744,
+                "Room": 85,
+                "Angle": -16384
+              }
+            }
+          ],
+          [
+            {
+              "EMType": 41,
+              "Tags": [
+                1
+              ],
+              "EntityIndex": 96,
+              "Location": {
+                "X": 22016,
+                "Y": 2048,
+                "Z": 93696,
+                "Room": 77,
+                "Angle": -16384
+              }
+            }
+          ],
+          [
+            {
+              "EMType": 41,
+              "Tags": [
+                1
+              ],
+              "EntityIndex": 96,
+              "Location": {
+                "X": 24064,
+                "Y": 2048,
+                "Z": 90624,
+                "Room": 85
+              }
+            }
+          ],
+          [
+            {
+              "EMType": 41,
+              "Tags": [
+                1
+              ],
+              "EntityIndex": 96,
+              "Location": {
+                "X": 32256,
+                "Y": 2048,
+                "Z": 90624,
+                "Room": 89,
+                "Angle": 16384
+              }
+            }
+          ],
+          [
+            {
+              "EMType": 41,
+              "Tags": [
+                1
+              ],
+              "EntityIndex": 96,
+              "Location": {
+                "X": 32256,
+                "Y": 2048,
+                "Z": 86528,
+                "Room": 89,
+                "Angle": 16384
+              }
+            }
+          ],
+          [
+            {
+              "EMType": 41,
+              "Tags": [
+                1
+              ],
+              "EntityIndex": 96,
+              "Location": {
+                "X": 32256,
+                "Y": 2048,
+                "Z": 82432,
+                "Room": 89,
+                "Angle": 16384
+              }
+            }
+          ]
+        ]
+      }
+    }
+  ],
   "Mirrored": []
 }

--- a/TRRandomizerCore/Resources/TR2/Environment/WALL.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR2/Environment/WALL.TR2-Environment.json
@@ -1035,6 +1035,40 @@
           }
         }
       ]
+    },
+    {
+      "Condition": {
+        "Comments": "Check if there is a secret in room 45.",
+        "ConditionType": 1,
+        "RoomIndex": 45
+      },
+      "OnTrue": [
+        {
+          "Comments": "Undo any draining that may have been performed.",
+          "EMType": 2,
+          "RoomNumbers": [
+            46
+          ],
+          "WaterTextures": [
+            1229,
+            1254,
+            1346,
+            1347
+          ]
+        },
+        {
+          "Comments": "Ensure there are flares in the level.",
+          "EMType": 51,
+          "TypeID": 151,
+          "Intensity": 7424,
+          "Location": {
+            "X": 55808,
+            "Y": -1536,
+            "Z": 32256,
+            "Room": 70
+          }
+        }
+      ]
     }
   ],
   "ConditionalOneOf": [],

--- a/TRRandomizerCore/Resources/TR2/Locations/locations.json
+++ b/TRRandomizerCore/Resources/TR2/Locations/locations.json
@@ -205,13 +205,6 @@
       "Room": 54
     },
     {
-      "X": 59780,
-      "Y": 11264,
-      "Z": 61854,
-      "Room": 56,
-      "RequiresDamage": true
-    },
-    {
       "X": 57822,
       "Y": 12816,
       "Z": 67036,
@@ -367,11 +360,13 @@
       "Difficulty": "Hard"
     },
     {
-      "X": 48549,
-      "Y": -4,
+      "X": 48640,
+      "Y": 0,
       "Z": 34816,
       "Room": 3,
-      "Difficulty": "Hard"
+      "Difficulty": "Hard",
+      "LevelState": "NotMirrored",
+      "PackID": "apel"
     },
     {
       "X": 60445,
@@ -462,10 +457,11 @@
       "RequiresGlitch": true
     },
     {
-      "X": 10239,
+      "X": 10240,
       "Y": 2304,
-      "Z": 48651,
+      "Z": 48640,
       "Room": 45,
+      "PackID": "apel",
       "RequiresGlitch": true
     },
     {
@@ -475,6 +471,15 @@
       "Room": 63,
       "Difficulty": "Hard",
       "RequiresGlitch": true
+    },
+    {
+      "X": 59904,
+      "Y": 11264,
+      "Z": 61952,
+      "Room": 56,
+      "LevelState": "NotMirrored",
+      "PackID": "apel",
+      "RequiresDamage": true
     },
     {
       "X": 91652,
@@ -619,12 +624,6 @@
       "Room": 74
     },
     {
-      "X": 25601,
-      "Y": 818,
-      "Z": 77925,
-      "Room": 154
-    },
-    {
       "X": 33764,
       "Y": 787,
       "Z": 37989,
@@ -725,11 +724,12 @@
       "Difficulty": "Hard"
     },
     {
-      "X": 58353,
-      "Y": -6158,
-      "Z": 21532,
+      "X": 58354,
+      "Y": -6168,
+      "Z": 21606,
       "Room": 4,
       "Difficulty": "Hard",
+      "PackID": "apel",
       "RequiresGlitch": true
     },
     {
@@ -1101,12 +1101,20 @@
       "RequiresGlitch": true
     },
     {
-      "X": 46181,
+      "X": 46643,
       "Y": 256,
       "Z": 47205,
       "Room": 152,
       "Difficulty": "Hard",
+      "PackID": "apel",
       "RequiresGlitch": true
+    },
+    {
+      "X": 25647,
+      "Y": 807,
+      "Z": 77925,
+      "Room": 154,
+      "PackID": "apel"
     }
   ],
   "VENICE.TR2": [
@@ -1115,6 +1123,16 @@
       "Y": 6144,
       "Z": 18533,
       "Room": 150
+    },
+    {
+      "X": 66292,
+      "Y": 512,
+      "Z": 22580,
+      "Room": 91,
+      "Difficulty": "Hard",
+      "EntityIndex": 79,
+      "PackID": "apel",
+      "RequiresGlitch": true
     },
     {
       "X": 56513,
@@ -1577,11 +1595,12 @@
       "RequiresGlitch": true
     },
     {
-      "X": 66592,
-      "Y": -792,
-      "Z": 25599,
+      "X": 66560,
+      "Y": -840,
+      "Z": 25692,
       "Room": 98,
       "Difficulty": "Hard",
+      "PackID": "apel",
       "RequiresGlitch": true
     },
     {
@@ -1615,10 +1634,11 @@
     },
     {
       "X": 41877,
-      "Y": -3759,
-      "Z": 31650,
+      "Y": -3761,
+      "Z": 31643,
       "Room": 130,
       "Difficulty": "Hard",
+      "PackID": "apel",
       "RequiresGlitch": true
     }
   ],
@@ -1794,9 +1814,25 @@
     },
     {
       "X": 79360,
-      "Y": -1462,
-      "Z": 25015,
-      "Room": 140
+      "Y": -1425,
+      "Z": 25065,
+      "Room": 140,
+      "PackID": "apel"
+    },
+    {
+      "X": 72163,
+      "Y": 5632,
+      "Z": 47463,
+      "Room": 144,
+      "PackID": "apel"
+    },
+    {
+      "X": 65117,
+      "Y": 3840,
+      "Z": 45421,
+      "Room": 123,
+      "PackID": "apel",
+      "RequiresDamage": true
     },
     {
       "X": 84932,
@@ -2301,11 +2337,12 @@
       "Room": 11
     },
     {
-      "X": 33224,
+      "X": 33280,
       "Y": -2560,
-      "Z": 95192,
+      "Z": 95232,
       "Room": 92,
-      "Difficulty": "Hard"
+      "Difficulty": "Hard",
+      "PackID": "apel"
     },
     {
       "X": 27776,
@@ -2380,13 +2417,6 @@
       "RequiresGlitch": true
     },
     {
-      "X": 35954,
-      "Y": -4352,
-      "Z": 65176,
-      "Room": 30,
-      "RequiresGlitch": true
-    },
-    {
       "X": 46108,
       "Y": -4096,
       "Z": 54298,
@@ -2431,11 +2461,20 @@
     },
     {
       "X": 24083,
-      "Y": -2028,
-      "Z": 92851,
+      "Y": -2029,
+      "Z": 92756,
       "Room": 2,
       "Difficulty": "Hard",
+      "PackID": "apel",
       "RequiresDamage": true,
+      "RequiresGlitch": true
+    },
+    {
+      "X": 35893,
+      "Y": -4352,
+      "Z": 64985,
+      "Room": 30,
+      "PackID": "apel",
       "RequiresGlitch": true
     }
   ],
@@ -2705,10 +2744,11 @@
       "Room": 43
     },
     {
-      "X": 32667,
-      "Y": 3946,
-      "Z": 66360,
-      "Room": 48
+      "X": 32655,
+      "Y": 4086,
+      "Z": 66461,
+      "Room": 48,
+      "PackID": "apel"
     },
     {
       "X": 45532,
@@ -2738,11 +2778,12 @@
       "Room": 80
     },
     {
-      "X": 20735,
-      "Y": -3581,
-      "Z": 73217,
+      "X": 20718,
+      "Y": -3569,
+      "Z": 73222,
       "Room": 52,
       "Difficulty": "Hard",
+      "PackID": "apel",
       "RequiresGlitch": true
     },
     {
@@ -2754,11 +2795,12 @@
       "RequiresGlitch": true
     },
     {
-      "X": 64490,
+      "X": 64411,
       "Y": -2816,
-      "Z": 90131,
+      "Z": 90118,
       "Room": 65,
       "Difficulty": "Hard",
+      "PackID": "apel",
       "RequiresGlitch": true
     }
   ],
@@ -3090,12 +3132,30 @@
       "RequiresGlitch": true
     },
     {
-      "X": 73349,
-      "Y": -4101,
-      "Z": 66544,
+      "X": 73356,
+      "Y": -4099,
+      "Z": 66560,
       "Room": 47,
       "Difficulty": "Hard",
+      "PackID": "apel",
       "RequiresGlitch": true
+    },
+    {
+      "X": 80924,
+      "Y": -10958,
+      "Z": 40988,
+      "Room": 36,
+      "Difficulty": "Hard",
+      "PackID": "apel"
+    },
+    {
+      "X": 80896,
+      "Y": -3584,
+      "Z": 45262,
+      "Room": 50,
+      "Difficulty": "Hard",
+      "LevelState": "NotMirrored",
+      "PackID": "apel"
     },
     {
       "X": 76959,
@@ -3440,13 +3500,6 @@
       "Room": 21
     },
     {
-      "X": 58267,
-      "Y": -7424,
-      "Z": 31845,
-      "Room": 20,
-      "Difficulty": "Hard"
-    },
-    {
       "X": 54373,
       "Y": -7424,
       "Z": 31853,
@@ -3522,11 +3575,12 @@
       "RequiresGlitch": true
     },
     {
-      "X": 74750,
+      "X": 74752,
       "Y": 1792,
-      "Z": 80960,
+      "Z": 80952,
       "Room": 57,
       "Difficulty": "Hard",
+      "PackID": "apel",
       "RequiresGlitch": true
     },
     {
@@ -3559,11 +3613,12 @@
       "RequiresGlitch": true
     },
     {
-      "X": 58867,
+      "X": 58880,
       "Y": -4096,
-      "Z": 39901,
+      "Z": 39936,
       "Room": 3,
       "Difficulty": "Hard",
+      "PackID": "apel",
       "RequiresGlitch": true
     },
     {
@@ -3573,6 +3628,14 @@
       "Room": 36,
       "Difficulty": "Hard",
       "RequiresGlitch": true
+    },
+    {
+      "X": 58267,
+      "Y": -7424,
+      "Z": 31845,
+      "Room": 20,
+      "Difficulty": "Hard",
+      "PackID": "apel"
     },
     {
       "X": 56469,
@@ -3600,6 +3663,15 @@
       "Y": 3602,
       "Z": 77177,
       "Room": 4
+    },
+    {
+      "X": 73829,
+      "Y": 461,
+      "Z": 86650,
+      "Room": 0,
+      "Difficulty": "Hard",
+      "EntityIndex": 4,
+      "PackID": "apel"
     },
     {
       "X": 68023,
@@ -3922,11 +3994,12 @@
       "RequiresGlitch": true
     },
     {
-      "X": 68578,
+      "X": 68507,
       "Y": -3840,
-      "Z": 83936,
+      "Z": 83867,
       "Room": 11,
       "Difficulty": "Hard",
+      "PackID": "apel",
       "RequiresGlitch": true
     },
     {
@@ -3960,8 +4033,9 @@
     {
       "X": 53349,
       "Y": -4352,
-      "Z": 19939,
+      "Z": 19557,
       "Room": 46,
+      "PackID": "apel",
       "RequiresGlitch": true
     },
     {
@@ -4212,11 +4286,26 @@
       "Room": 40
     },
     {
-      "X": 50567,
-      "Y": -5698,
-      "Z": 41782,
+      "X": 50659,
+      "Y": -5902,
+      "Z": 41861,
       "Room": 39,
-      "Difficulty": "Hard"
+      "Difficulty": "Hard",
+      "PackID": "apel"
+    },
+    {
+      "X": 28941,
+      "Y": -12818,
+      "Z": 79639,
+      "Room": 61,
+      "PackID": "apel"
+    },
+    {
+      "X": 39424,
+      "Y": -16512,
+      "Z": 73216,
+      "Room": 61,
+      "PackID": "apel"
     },
     {
       "X": 53147,
@@ -4283,12 +4372,6 @@
       "Y": -4864,
       "Z": 59493,
       "Room": 45
-    },
-    {
-      "X": 29134,
-      "Y": -12982,
-      "Z": 79771,
-      "Room": 61
     },
     {
       "X": 52325,
@@ -4526,6 +4609,14 @@
       "Z": 8100,
       "Room": 78,
       "Difficulty": "Hard"
+    },
+    {
+      "X": 86991,
+      "Y": -4108,
+      "Z": 7191,
+      "Room": 78,
+      "Difficulty": "Hard",
+      "PackID": "apel"
     },
     {
       "X": 83965,
@@ -4769,11 +4860,12 @@
       "RequiresGlitch": true
     },
     {
-      "X": 47301,
+      "X": 47390,
       "Y": 8192,
-      "Z": 94966,
+      "Z": 94906,
       "Room": 60,
       "Difficulty": "Hard",
+      "PackID": "apel",
       "RequiresGlitch": true
     },
     {
@@ -4800,11 +4892,12 @@
       "RequiresGlitch": true
     },
     {
-      "X": 25412,
+      "X": 25538,
       "Y": 3072,
-      "Z": 29082,
+      "Z": 29318,
       "Room": 121,
       "Difficulty": "Hard",
+      "PackID": "apel",
       "RequiresGlitch": true
     }
   ],
@@ -5047,11 +5140,12 @@
       "Room": 55
     },
     {
-      "X": 97765,
+      "X": 97774,
       "Y": 1024,
-      "Z": 18154,
+      "Z": 17932,
       "Room": 81,
       "Difficulty": "Hard",
+      "PackID": "apel",
       "RequiresGlitch": true
     },
     {
@@ -5119,19 +5213,21 @@
       "RequiresGlitch": true
     },
     {
-      "X": 68102,
+      "X": 68101,
       "Y": 0,
-      "Z": 55848,
+      "Z": 55801,
       "Room": 69,
       "Difficulty": "Hard",
+      "PackID": "apel",
       "RequiresGlitch": true
     },
     {
-      "X": 67558,
-      "Y": -5131,
-      "Z": 63162,
+      "X": 67575,
+      "Y": -5134,
+      "Z": 63166,
       "Room": 76,
       "Difficulty": "Hard",
+      "PackID": "apel",
       "RequiresGlitch": true
     },
     {
@@ -5292,11 +5388,28 @@
       "Room": 0
     },
     {
-      "X": 22502,
-      "Y": -251,
-      "Z": 45016,
+      "X": 22501,
+      "Y": -194,
+      "Z": 44939,
       "Room": 1,
-      "Difficulty": "Hard"
+      "Difficulty": "Hard",
+      "PackID": "apel"
+    },
+    {
+      "X": 43487,
+      "Y": 5632,
+      "Z": 50678,
+      "Room": 128,
+      "Difficulty": "Hard",
+      "PackID": "apel",
+      "RequiresGlitch": true
+    },
+    {
+      "X": 28160,
+      "Y": 5120,
+      "Z": 54786,
+      "Room": 65,
+      "PackID": "apel"
     },
     {
       "X": 16420,
@@ -5444,6 +5557,33 @@
       "Y": 9472,
       "Z": 27545,
       "Room": 103
+    },
+    {
+      "X": 64000,
+      "Y": 5632,
+      "Z": 70144,
+      "Room": 46,
+      "Difficulty": "Hard",
+      "PackID": "apel",
+      "RequiresGlitch": true
+    },
+    {
+      "X": 53272,
+      "Y": 1293,
+      "Z": 63513,
+      "Room": 68,
+      "Difficulty": "Hard",
+      "PackID": "apel",
+      "RequiresGlitch": true
+    },
+    {
+      "X": 60401,
+      "Y": 3083,
+      "Z": 28744,
+      "Room": 9,
+      "Difficulty": "Hard",
+      "PackID": "apel",
+      "RequiresGlitch": true
     },
     {
       "X": 62573,
@@ -6933,6 +7073,5 @@
       "Room": 85,
       "RequiresGlitch": true
     }
-  ],
-  "ASSAULT.TR2": []
+  ]
 }


### PR DESCRIPTION
Adds @makotocchi's rearranged secrets as an available secret pack. Most locations were already present, but have been adjusted slightly to match the original positions exactly.

Environment modifications will ensure the level state is as required in each case. For Venice and Offshore Rig, previous changes now become conditional based on the secrets, and for other cases we make individual modifications and manually undo others to suit.

Part of #510.