### PR TITLE
Cleanup model transport project

### DIFF
--- a/TRModelTransporter/Data/ITransportDataProvider.cs
+++ b/TRModelTransporter/Data/ITransportDataProvider.cs
@@ -1,108 +1,107 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace TRModelTransporter.Data
+namespace TRModelTransporter.Data;
+
+public interface ITransportDataProvider<E> where E : Enum
 {
-    public interface ITransportDataProvider<E> where E : Enum
-    {
-        int TextureTileLimit { get; set; }
-        int TextureObjectLimit { get; set; }
+    int TextureTileLimit { get; set; }
+    int TextureObjectLimit { get; set; }
 
-        /// <summary>
-        /// Return all other model types on which the given type depends.
-        /// </summary>
-        IEnumerable<E> GetModelDependencies(E entity);
+    /// <summary>
+    /// Return all other model types on which the given type depends.
+    /// </summary>
+    IEnumerable<E> GetModelDependencies(E entity);
 
-        /// <summary>
-        /// Null meshes that determine if the main entity can be removed from a level.
-        /// </summary>
-        IEnumerable<E> GetRemovalExclusions(E entity);
+    /// <summary>
+    /// Null meshes that determine if the main entity can be removed from a level.
+    /// </summary>
+    IEnumerable<E> GetRemovalExclusions(E entity);
 
-        /// <summary>
-        /// Return model types that have a cyclic depencency on the given type.
-        /// </summary>
-        IEnumerable<E> GetCyclicDependencies(E entity);
+    /// <summary>
+    /// Return model types that have a cyclic depencency on the given type.
+    /// </summary>
+    IEnumerable<E> GetCyclicDependencies(E entity);
 
-        /// <summary>
-        /// Return any sprite types on which the given type depends.
-        /// </summary>
-        IEnumerable<E> GetSpriteDependencies(E entity);
-        
-        /// <summary>
-        /// Determines which alias has the priority in a family during import if another alias already exists.
-        /// </summary>
-        Dictionary<E, E> AliasPriority { get; set; }
+    /// <summary>
+    /// Return any sprite types on which the given type depends.
+    /// </summary>
+    IEnumerable<E> GetSpriteDependencies(E entity);
+    
+    /// <summary>
+    /// Determines which alias has the priority in a family during import if another alias already exists.
+    /// </summary>
+    Dictionary<E, E> AliasPriority { get; set; }
 
-        /// <summary>
-        /// Return model types for which cinematic frames should be exported.
-        /// </summary>
-        IEnumerable<E> GetCinematicEntities();
+    /// <summary>
+    /// Return model types for which cinematic frames should be exported.
+    /// </summary>
+    IEnumerable<E> GetCinematicEntities();
 
-        /// <summary>
-        /// Return models that are dependent on Lara.
-        /// </summary>
-        IEnumerable<E> GetLaraDependants();
+    /// <summary>
+    /// Return models that are dependent on Lara.
+    /// </summary>
+    IEnumerable<E> GetLaraDependants();
 
-        /// <summary>
-        /// Whether or not the given entity is an alias of another.
-        /// </summary>
-        bool IsAlias(E entity);
+    /// <summary>
+    /// Whether or not the given entity is an alias of another.
+    /// </summary>
+    bool IsAlias(E entity);
 
-        /// <summary>
-        /// Whether or not the given entity has aliases.
-        /// </summary>
-        bool HasAliases(E entity);
+    /// <summary>
+    /// Whether or not the given entity has aliases.
+    /// </summary>
+    bool HasAliases(E entity);
 
-        /// <summary>
-        /// Convert the given alias into its normal type.
-        /// </summary>
-        E TranslateAlias(E entity);
+    /// <summary>
+    /// Convert the given alias into its normal type.
+    /// </summary>
+    E TranslateAlias(E entity);
 
-        /// <summary>
-        /// Returns all possible aliases for the given entity.
-        /// </summary>
-        IEnumerable<E> GetAliases(E entity);
+    /// <summary>
+    /// Returns all possible aliases for the given entity.
+    /// </summary>
+    IEnumerable<E> GetAliases(E entity);
 
-        /// <summary>
-        /// Return the specific alias for an alias type given a particular level ID.
-        /// </summary>
-        E GetLevelAlias(string level, E entity);
+    /// <summary>
+    /// Return the specific alias for an alias type given a particular level ID.
+    /// </summary>
+    E GetLevelAlias(string level, E entity);
 
-        /// <summary>
-        /// Duplicates on import will throw a TransportException unless they are permitted to replace existing models.
-        /// </summary>
-        bool IsAliasDuplicatePermitted(E entity);
+    /// <summary>
+    /// Duplicates on import will throw a TransportException unless they are permitted to replace existing models.
+    /// </summary>
+    bool IsAliasDuplicatePermitted(E entity);
 
-        /// <summary>
-        /// Similar to alias duplicates, but where we want to replace a non-aliased model with another.
-        /// </summary>
-        bool IsOverridePermitted(E entity);
+    /// <summary>
+    /// Similar to alias duplicates, but where we want to replace a non-aliased model with another.
+    /// </summary>
+    bool IsOverridePermitted(E entity);
 
-        /// <summary>
-        /// Models that cannot be replaced in the Model array and instead should be remapped to imported models.
-        /// </summary>
-        IEnumerable<E> GetUnsafeModelReplacements();
+    /// <summary>
+    /// Models that cannot be replaced in the Model array and instead should be remapped to imported models.
+    /// </summary>
+    IEnumerable<E> GetUnsafeModelReplacements();
 
-        /// <summary>
-        /// Determine if the given type's graphics should be ignored on import.
-        /// </summary>
-        bool IsNonGraphicsDependency(E entity);
+    /// <summary>
+    /// Determine if the given type's graphics should be ignored on import.
+    /// </summary>
+    bool IsNonGraphicsDependency(E entity);
 
-        /// <summary>
-        /// Determine if the the given type's sound alone should be imported.
-        /// </summary>
-        bool IsSoundOnlyDependency(E entity);
+    /// <summary>
+    /// Determine if the the given type's sound alone should be imported.
+    /// </summary>
+    bool IsSoundOnlyDependency(E entity);
 
-        /// <summary>
-        /// Returns any hardcoded internal sound IDs for the given entity.
-        /// </summary>
-        short[] GetHardcodedSounds(E entity);
+    /// <summary>
+    /// Returns any hardcoded internal sound IDs for the given entity.
+    /// </summary>
+    short[] GetHardcodedSounds(E entity);
 
-        /// <summary>
-        /// Returns a list of texture indices that should be ignored for a given entity.
-        /// An emtpy list is translated as meaning all indices should be ignored. Null
-        /// indicates that no indices should be ignored.
-        /// </summary>
-        IEnumerable<int> GetIgnorableTextureIndices(E entity, string level);
-    }
+    /// <summary>
+    /// Returns a list of texture indices that should be ignored for a given entity.
+    /// An emtpy list is translated as meaning all indices should be ignored. Null
+    /// indicates that no indices should be ignored.
+    /// </summary>
+    IEnumerable<int> GetIgnorableTextureIndices(E entity, string level);
 }

--- a/TRModelTransporter/Data/ITransportDataProvider.cs
+++ b/TRModelTransporter/Data/ITransportDataProvider.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace TRModelTransporter.Data;
+﻿namespace TRModelTransporter.Data;
 
 public interface ITransportDataProvider<E> where E : Enum
 {

--- a/TRModelTransporter/Data/TR1DefaultDataProvider.cs
+++ b/TRModelTransporter/Data/TR1DefaultDataProvider.cs
@@ -125,7 +125,7 @@ public class TR1DefaultDataProvider : ITransportDataProvider<TREntities>
 
     private static readonly IEnumerable<TREntities> _emptyEntities = new List<TREntities>();
 
-    private static readonly Dictionary<TREntities, TREntities[]> _entityDependencies = new Dictionary<TREntities, TREntities[]>
+    private static readonly Dictionary<TREntities, TREntities[]> _entityDependencies = new()
     {
         [TREntities.Adam]
             = new TREntities[] { TREntities.LaraMiscAnim_H_Pyramid },
@@ -167,7 +167,7 @@ public class TR1DefaultDataProvider : ITransportDataProvider<TREntities>
             = new TREntities[] { TREntities.LaraMiscAnim_H_Valley }
     };
 
-    private static readonly Dictionary<TREntities, TREntities[]> _cyclicDependencies = new Dictionary<TREntities, TREntities[]>
+    private static readonly Dictionary<TREntities, TREntities[]> _cyclicDependencies = new()
     {
         [TREntities.CrocodileLand]
             = new TREntities[] { TREntities.CrocodileWater },
@@ -181,13 +181,13 @@ public class TR1DefaultDataProvider : ITransportDataProvider<TREntities>
             = new TREntities[] { TREntities.ScionPiece_M_H },
     };
 
-    private static readonly Dictionary<TREntities, List<TREntities>> _removalExclusions = new Dictionary<TREntities, List<TREntities>>
+    private static readonly Dictionary<TREntities, List<TREntities>> _removalExclusions = new()
     {
         [TREntities.FlyingAtlantean]
             = new List<TREntities> { TREntities.NonShootingAtlantean_N, TREntities.ShootingAtlantean_N }
     };
 
-    private static readonly Dictionary<TREntities, List<TREntities>> _spriteDependencies = new Dictionary<TREntities, List<TREntities>>
+    private static readonly Dictionary<TREntities, List<TREntities>> _spriteDependencies = new()
     {
         [TREntities.SecretScion_M_H]
             = new List<TREntities> { TREntities.ScionPiece4_S_P },
@@ -218,17 +218,17 @@ public class TR1DefaultDataProvider : ITransportDataProvider<TREntities>
             = new List<TREntities> { TREntities.Explosion1_S_H },
     };
 
-    private static readonly List<TREntities> _cinematicEntities = new List<TREntities>
+    private static readonly List<TREntities> _cinematicEntities = new()
     {
     };
 
     // These are models that use Lara's hips as placeholders
-    private static readonly List<TREntities> _laraDependentModels = new List<TREntities>
+    private static readonly List<TREntities> _laraDependentModels = new()
     {
         TREntities.NonShootingAtlantean_N, TREntities.ShootingAtlantean_N
     };
 
-    private static readonly Dictionary<TREntities, List<TREntities>> _entityAliases = new Dictionary<TREntities, List<TREntities>>
+    private static readonly Dictionary<TREntities, List<TREntities>> _entityAliases = new()
     {
         [TREntities.FlyingAtlantean] = new List<TREntities>
         {
@@ -249,30 +249,30 @@ public class TR1DefaultDataProvider : ITransportDataProvider<TREntities>
         }
     };
 
-    private static readonly List<TREntities> _permittedAliasDuplicates = new List<TREntities>
+    private static readonly List<TREntities> _permittedAliasDuplicates = new()
     {
         TREntities.LaraMiscAnim_H
     };
 
-    private static readonly List<TREntities> _permittedOverrides = new List<TREntities>
+    private static readonly List<TREntities> _permittedOverrides = new()
     {
         TREntities.LaraPonytail_H_U, TREntities.ScionPiece_M_H
     };
 
-    private static readonly List<TREntities> _unsafeModelReplacements = new List<TREntities>
+    private static readonly List<TREntities> _unsafeModelReplacements = new()
     {
     };
 
-    private static readonly List<TREntities> _nonGraphicsDependencies = new List<TREntities>
+    private static readonly List<TREntities> _nonGraphicsDependencies = new()
     {
     };
 
     // If these are imported into levels that already have another alias for them, only their hardcoded sounds will be imported
-    protected static readonly List<TREntities> _soundOnlyDependencies = new List<TREntities>
+    protected static readonly List<TREntities> _soundOnlyDependencies = new()
     {
     };
 
-    private static readonly Dictionary<TREntities, short[]> _hardcodedSoundIndices = new Dictionary<TREntities, short[]>
+    private static readonly Dictionary<TREntities, short[]> _hardcodedSoundIndices = new()
     {
         [TREntities.Adam] = new short[] { 104, 137, 138, 140, 141, 142 },
         [TREntities.BandagedFlyer] = new short[] { 104 },
@@ -297,7 +297,7 @@ public class TR1DefaultDataProvider : ITransportDataProvider<TREntities>
         [TREntities.Wolf] = new short[] { 20 }
     };
 
-    private static readonly Dictionary<TREntities, List<int>> _ignoreEntityTextures = new Dictionary<TREntities, List<int>>
+    private static readonly Dictionary<TREntities, List<int>> _ignoreEntityTextures = new()
     {
         [TREntities.LaraMiscAnim_H]
             = new List<int>(), // empty list indicates to ignore everything

--- a/TRModelTransporter/Data/TR1DefaultDataProvider.cs
+++ b/TRModelTransporter/Data/TR1DefaultDataProvider.cs
@@ -141,8 +141,6 @@ public class TR1DefaultDataProvider : ITransportDataProvider<TREntities>
             = new TREntities[] { TREntities.CrocodileWater },
         [TREntities.CrocodileWater]
             = new TREntities[] { TREntities.CrocodileLand },
-        [TREntities.CentaurStatue]
-            = new TREntities[] { TREntities.Centaur },
         [TREntities.DartEmitter]
             = new TREntities[] { TREntities.Dart_H },
         [TREntities.MeatyAtlantean]

--- a/TRModelTransporter/Data/TR1DefaultDataProvider.cs
+++ b/TRModelTransporter/Data/TR1DefaultDataProvider.cs
@@ -2,316 +2,315 @@
 using TRLevelControl.Helpers;
 using TRLevelControl.Model.Enums;
 
-namespace TRModelTransporter.Data
+namespace TRModelTransporter.Data;
+
+public class TR1DefaultDataProvider : ITransportDataProvider<TREntities>
 {
-    public class TR1DefaultDataProvider : ITransportDataProvider<TREntities>
+    public int TextureTileLimit { get; set; } = 16;
+    public int TextureObjectLimit { get; set; } = 2048;
+
+    public Dictionary<TREntities, TREntities> AliasPriority { get; set; }
+
+    public IEnumerable<TREntities> GetModelDependencies(TREntities entity)
     {
-        public int TextureTileLimit { get; set; } = 16;
-        public int TextureObjectLimit { get; set; } = 2048;
-
-        public Dictionary<TREntities, TREntities> AliasPriority { get; set; }
-
-        public IEnumerable<TREntities> GetModelDependencies(TREntities entity)
-        {
-            return _entityDependencies.ContainsKey(entity) ? _entityDependencies[entity] : _emptyEntities;
-        }
-
-        public IEnumerable<TREntities> GetRemovalExclusions(TREntities entity)
-        {
-            return _removalExclusions.ContainsKey(entity) ? _removalExclusions[entity] : _emptyEntities;
-        }
-
-        public IEnumerable<TREntities> GetCyclicDependencies(TREntities entity)
-        {
-            return _cyclicDependencies.ContainsKey(entity) ? _cyclicDependencies[entity] : _emptyEntities;
-        }
-
-        public IEnumerable<TREntities> GetSpriteDependencies(TREntities entity)
-        {
-            return _spriteDependencies.ContainsKey(entity) ? _spriteDependencies[entity] : _emptyEntities;
-        }
-
-        public IEnumerable<TREntities> GetCinematicEntities()
-        {
-            return _cinematicEntities;
-        }
-
-        public IEnumerable<TREntities> GetLaraDependants()
-        {
-            return _laraDependentModels;
-        }
-
-        public bool IsAlias(TREntities entity)
-        {
-            foreach (List<TREntities> aliases in _entityAliases.Values)
-            {
-                if (aliases.Contains(entity))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        public bool HasAliases(TREntities entity)
-        {
-            return _entityAliases.ContainsKey(entity);
-        }
-
-        public TREntities TranslateAlias(TREntities entity)
-        {
-            foreach (TREntities root in _entityAliases.Keys)
-            {
-                if (_entityAliases[root].Contains(entity))
-                {
-                    return root;
-                }
-            }
-
-            return entity;
-        }
-
-        public IEnumerable<TREntities> GetAliases(TREntities entity)
-        {
-            return _entityAliases.ContainsKey(entity) ? _entityAliases[entity] : _emptyEntities;
-        }
-
-        public TREntities GetLevelAlias(string level, TREntities entity)
-        {
-            return TR1EntityUtilities.GetAliasForLevel(level, entity);
-        }
-
-        public bool IsAliasDuplicatePermitted(TREntities entity)
-        {
-            return _permittedAliasDuplicates.Contains(entity);
-        }
-
-        public bool IsOverridePermitted(TREntities entity)
-        {
-            return _permittedOverrides.Contains(entity);
-        }
-
-        public IEnumerable<TREntities> GetUnsafeModelReplacements()
-        {
-            return _unsafeModelReplacements;
-        }
-
-        public bool IsNonGraphicsDependency(TREntities entity)
-        {
-            return _nonGraphicsDependencies.Contains(entity);
-        }
-
-        public bool IsSoundOnlyDependency(TREntities entity)
-        {
-            return _soundOnlyDependencies.Contains(entity);
-        }
-
-        public short[] GetHardcodedSounds(TREntities entity)
-        {
-            return _hardcodedSoundIndices.ContainsKey(entity) ? _hardcodedSoundIndices[entity] : null;
-        }
-
-        public IEnumerable<int> GetIgnorableTextureIndices(TREntities entity, string level)
-        {
-            if (entity == TREntities.LaraMiscAnim_H && level == TR1LevelNames.VALLEY)
-            {
-                // Mesh swap when Lara is killed by T-Rex
-                return null;
-            }
-            return _ignoreEntityTextures.ContainsKey(entity) ? _ignoreEntityTextures[entity] : null;
-        }
-
-        #region Data
-
-        private static readonly IEnumerable<TREntities> _emptyEntities = new List<TREntities>();
-
-        private static readonly Dictionary<TREntities, TREntities[]> _entityDependencies = new Dictionary<TREntities, TREntities[]>
-        {
-            [TREntities.Adam]
-                = new TREntities[] { TREntities.LaraMiscAnim_H_Pyramid },
-            [TREntities.BandagedAtlantean]
-                = new TREntities[] { TREntities.BandagedFlyer },
-            [TREntities.BandagedFlyer]
-                = new TREntities[] { TREntities.Missile2_H, TREntities.Missile3_H },
-            [TREntities.Centaur]
-                = new TREntities[] { TREntities.Missile3_H },
-            [TREntities.CentaurStatue]
-                = new TREntities[] { TREntities.Centaur },
-            [TREntities.CrocodileLand]
-                = new TREntities[] { TREntities.CrocodileWater },
-            [TREntities.CrocodileWater]
-                = new TREntities[] { TREntities.CrocodileLand },
-            [TREntities.CentaurStatue]
-                = new TREntities[] { TREntities.Centaur },
-            [TREntities.DartEmitter]
-                = new TREntities[] { TREntities.Dart_H },
-            [TREntities.MeatyAtlantean]
-                = new TREntities[] { TREntities.MeatyFlyer },
-            [TREntities.MeatyFlyer]
-                = new TREntities[] { TREntities.Missile2_H, TREntities.Missile3_H },
-            [TREntities.Natla]
-                = new TREntities[] { TREntities.Missile2_H, TREntities.Missile3_H },
-            [TREntities.Pierre]
-                = new TREntities[] { TREntities.Key1_M_H, TREntities.ScionPiece_M_H },
-            [TREntities.RatLand]
-                = new TREntities[] { TREntities.RatWater },
-            [TREntities.RatWater]
-                = new TREntities[] { TREntities.RatLand },
-            [TREntities.ShootingAtlantean_N]
-                = new TREntities[] { TREntities.MeatyFlyer },
-            [TREntities.SkateboardKid]
-                = new TREntities[] { TREntities.Skateboard },
-            [TREntities.ThorHammerHandle]
-                = new TREntities[] { TREntities.ThorHammerBlock },
-            [TREntities.TRex]
-                = new TREntities[] { TREntities.LaraMiscAnim_H_Valley }
-        };
-
-        private static readonly Dictionary<TREntities, TREntities[]> _cyclicDependencies = new Dictionary<TREntities, TREntities[]>
-        {
-            [TREntities.CrocodileLand]
-                = new TREntities[] { TREntities.CrocodileWater },
-            [TREntities.CrocodileWater]
-                = new TREntities[] { TREntities.CrocodileLand },
-            [TREntities.RatLand]
-                = new TREntities[] { TREntities.RatWater },
-            [TREntities.RatWater]
-                = new TREntities[] { TREntities.RatLand },
-            [TREntities.Pierre]
-                = new TREntities[] { TREntities.ScionPiece_M_H },
-        };
-
-        private static readonly Dictionary<TREntities, List<TREntities>> _removalExclusions = new Dictionary<TREntities, List<TREntities>>
-        {
-            [TREntities.FlyingAtlantean]
-                = new List<TREntities> { TREntities.NonShootingAtlantean_N, TREntities.ShootingAtlantean_N }
-        };
-
-        private static readonly Dictionary<TREntities, List<TREntities>> _spriteDependencies = new Dictionary<TREntities, List<TREntities>>
-        {
-            [TREntities.SecretScion_M_H]
-                = new List<TREntities> { TREntities.ScionPiece4_S_P },
-            [TREntities.SecretGoldIdol_M_H]
-                = new List<TREntities> { TREntities.ScionPiece4_S_P },
-            [TREntities.SecretLeadBar_M_H]
-                = new List<TREntities> { TREntities.ScionPiece4_S_P },
-            [TREntities.SecretGoldBar_M_H]
-                = new List<TREntities> { TREntities.ScionPiece4_S_P },
-            [TREntities.SecretAnkh_M_H]
-                = new List<TREntities> { TREntities.ScionPiece4_S_P },
-
-            [TREntities.Adam]
-                = new List<TREntities> { TREntities.Explosion1_S_H },
-            [TREntities.Centaur]
-                = new List<TREntities> { TREntities.Explosion1_S_H },
-            [TREntities.FlyingAtlantean]
-                = new List<TREntities> { TREntities.Explosion1_S_H },
-            [TREntities.Key1_M_H]
-                = new List<TREntities> { TREntities.Key1_S_P },
-            [TREntities.Natla]
-                = new List<TREntities> { TREntities.Explosion1_S_H },
-            [TREntities.ScionPiece_M_H]
-                = new List<TREntities> { TREntities.ScionPiece2_S_P },
-            [TREntities.ShootingAtlantean_N]
-                = new List<TREntities> { TREntities.Explosion1_S_H },
-            [TREntities.Missile3_H]
-                = new List<TREntities> { TREntities.Explosion1_S_H },
-        };
-
-        private static readonly List<TREntities> _cinematicEntities = new List<TREntities>
-        {
-        };
-
-        // These are models that use Lara's hips as placeholders
-        private static readonly List<TREntities> _laraDependentModels = new List<TREntities>
-        {
-            TREntities.NonShootingAtlantean_N, TREntities.ShootingAtlantean_N
-        };
-
-        private static readonly Dictionary<TREntities, List<TREntities>> _entityAliases = new Dictionary<TREntities, List<TREntities>>
-        {
-            [TREntities.FlyingAtlantean] = new List<TREntities>
-            {
-                TREntities.BandagedFlyer, TREntities.MeatyFlyer
-            },
-            [TREntities.LaraMiscAnim_H] = new List<TREntities>
-            {
-                TREntities.LaraMiscAnim_H_General, TREntities.LaraMiscAnim_H_Valley, TREntities.LaraMiscAnim_H_Qualopec, TREntities.LaraMiscAnim_H_Midas,
-                TREntities.LaraMiscAnim_H_Sanctuary, TREntities.LaraMiscAnim_H_Atlantis, TREntities.LaraMiscAnim_H_Pyramid
-            },
-            [TREntities.NonShootingAtlantean_N] = new List<TREntities>
-            {
-                TREntities.BandagedAtlantean, TREntities.MeatyAtlantean
-            },
-            [TREntities.Cowboy] = new List<TREntities>
-            {
-                TREntities.CowboyOG, TREntities.CowboyHeadless
-            }
-        };
-
-        private static readonly List<TREntities> _permittedAliasDuplicates = new List<TREntities>
-        {
-            TREntities.LaraMiscAnim_H
-        };
-
-        private static readonly List<TREntities> _permittedOverrides = new List<TREntities>
-        {
-            TREntities.LaraPonytail_H_U, TREntities.ScionPiece_M_H
-        };
-
-        private static readonly List<TREntities> _unsafeModelReplacements = new List<TREntities>
-        {
-        };
-
-        private static readonly List<TREntities> _nonGraphicsDependencies = new List<TREntities>
-        {
-        };
-
-        // If these are imported into levels that already have another alias for them, only their hardcoded sounds will be imported
-        protected static readonly List<TREntities> _soundOnlyDependencies = new List<TREntities>
-        {
-        };
-
-        private static readonly Dictionary<TREntities, short[]> _hardcodedSoundIndices = new Dictionary<TREntities, short[]>
-        {
-            [TREntities.Adam] = new short[] { 104, 137, 138, 140, 141, 142 },
-            [TREntities.BandagedFlyer] = new short[] { 104 },
-            [TREntities.Bear] = new short[] { 12, 16 },
-            [TREntities.Centaur] = new short[] { 104 },
-            [TREntities.DamoclesSword] = new short[] { 103 },
-            [TREntities.DartEmitter] = new short[] { 151 },
-            [TREntities.Gorilla] = new short[] { 90, 91, 101 },
-            [TREntities.Larson] = new short[] { 78 },
-            [TREntities.Lion] = new short[] { 85, 86, 87 },
-            [TREntities.Lioness] = new short[] { 85, 86, 87 },
-            [TREntities.MeatyAtlantean] = new short[] { 104 },
-            [TREntities.MeatyFlyer] = new short[] { 104, 120, 121, 122, 123, 124, 125, 126 },
-            [TREntities.Missile3_H] = new short[] { 104 },
-            [TREntities.Natla] = new short[] { 104, 123, 124, 202 },
-            [TREntities.ShootingAtlantean_N] = new short[] { 104 },
-            [TREntities.SkateboardKid] = new short[] { 132, 204 },
-            [TREntities.TeethSpikes] = new short[] { 145 },
-            [TREntities.ThorHammerHandle] = new short[] { 70 },
-            [TREntities.ThorLightning] = new short[] { 98 },
-            [TREntities.UnderwaterSwitch] = new short[] { 61 },
-            [TREntities.Wolf] = new short[] { 20 }
-        };
-
-        private static readonly Dictionary<TREntities, List<int>> _ignoreEntityTextures = new Dictionary<TREntities, List<int>>
-        {
-            [TREntities.LaraMiscAnim_H]
-                = new List<int>(), // empty list indicates to ignore everything
-            [TREntities.NonShootingAtlantean_N]
-                = new List<int>(),
-            [TREntities.ShootingAtlantean_N]
-                = new List<int>(),
-            [TREntities.Mummy]
-                = new List<int> { 130, 131, 132, 133, 134, 135, 136, 137, 140, 141 },
-            [TREntities.ThorLightning]
-                = new List<int> { 150, 151, 154, 155, 156, 157, 158, 159, 160, 161 }
-        };
-
-        #endregion
+        return _entityDependencies.ContainsKey(entity) ? _entityDependencies[entity] : _emptyEntities;
     }
+
+    public IEnumerable<TREntities> GetRemovalExclusions(TREntities entity)
+    {
+        return _removalExclusions.ContainsKey(entity) ? _removalExclusions[entity] : _emptyEntities;
+    }
+
+    public IEnumerable<TREntities> GetCyclicDependencies(TREntities entity)
+    {
+        return _cyclicDependencies.ContainsKey(entity) ? _cyclicDependencies[entity] : _emptyEntities;
+    }
+
+    public IEnumerable<TREntities> GetSpriteDependencies(TREntities entity)
+    {
+        return _spriteDependencies.ContainsKey(entity) ? _spriteDependencies[entity] : _emptyEntities;
+    }
+
+    public IEnumerable<TREntities> GetCinematicEntities()
+    {
+        return _cinematicEntities;
+    }
+
+    public IEnumerable<TREntities> GetLaraDependants()
+    {
+        return _laraDependentModels;
+    }
+
+    public bool IsAlias(TREntities entity)
+    {
+        foreach (List<TREntities> aliases in _entityAliases.Values)
+        {
+            if (aliases.Contains(entity))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public bool HasAliases(TREntities entity)
+    {
+        return _entityAliases.ContainsKey(entity);
+    }
+
+    public TREntities TranslateAlias(TREntities entity)
+    {
+        foreach (TREntities root in _entityAliases.Keys)
+        {
+            if (_entityAliases[root].Contains(entity))
+            {
+                return root;
+            }
+        }
+
+        return entity;
+    }
+
+    public IEnumerable<TREntities> GetAliases(TREntities entity)
+    {
+        return _entityAliases.ContainsKey(entity) ? _entityAliases[entity] : _emptyEntities;
+    }
+
+    public TREntities GetLevelAlias(string level, TREntities entity)
+    {
+        return TR1EntityUtilities.GetAliasForLevel(level, entity);
+    }
+
+    public bool IsAliasDuplicatePermitted(TREntities entity)
+    {
+        return _permittedAliasDuplicates.Contains(entity);
+    }
+
+    public bool IsOverridePermitted(TREntities entity)
+    {
+        return _permittedOverrides.Contains(entity);
+    }
+
+    public IEnumerable<TREntities> GetUnsafeModelReplacements()
+    {
+        return _unsafeModelReplacements;
+    }
+
+    public bool IsNonGraphicsDependency(TREntities entity)
+    {
+        return _nonGraphicsDependencies.Contains(entity);
+    }
+
+    public bool IsSoundOnlyDependency(TREntities entity)
+    {
+        return _soundOnlyDependencies.Contains(entity);
+    }
+
+    public short[] GetHardcodedSounds(TREntities entity)
+    {
+        return _hardcodedSoundIndices.ContainsKey(entity) ? _hardcodedSoundIndices[entity] : null;
+    }
+
+    public IEnumerable<int> GetIgnorableTextureIndices(TREntities entity, string level)
+    {
+        if (entity == TREntities.LaraMiscAnim_H && level == TR1LevelNames.VALLEY)
+        {
+            // Mesh swap when Lara is killed by T-Rex
+            return null;
+        }
+        return _ignoreEntityTextures.ContainsKey(entity) ? _ignoreEntityTextures[entity] : null;
+    }
+
+    #region Data
+
+    private static readonly IEnumerable<TREntities> _emptyEntities = new List<TREntities>();
+
+    private static readonly Dictionary<TREntities, TREntities[]> _entityDependencies = new Dictionary<TREntities, TREntities[]>
+    {
+        [TREntities.Adam]
+            = new TREntities[] { TREntities.LaraMiscAnim_H_Pyramid },
+        [TREntities.BandagedAtlantean]
+            = new TREntities[] { TREntities.BandagedFlyer },
+        [TREntities.BandagedFlyer]
+            = new TREntities[] { TREntities.Missile2_H, TREntities.Missile3_H },
+        [TREntities.Centaur]
+            = new TREntities[] { TREntities.Missile3_H },
+        [TREntities.CentaurStatue]
+            = new TREntities[] { TREntities.Centaur },
+        [TREntities.CrocodileLand]
+            = new TREntities[] { TREntities.CrocodileWater },
+        [TREntities.CrocodileWater]
+            = new TREntities[] { TREntities.CrocodileLand },
+        [TREntities.CentaurStatue]
+            = new TREntities[] { TREntities.Centaur },
+        [TREntities.DartEmitter]
+            = new TREntities[] { TREntities.Dart_H },
+        [TREntities.MeatyAtlantean]
+            = new TREntities[] { TREntities.MeatyFlyer },
+        [TREntities.MeatyFlyer]
+            = new TREntities[] { TREntities.Missile2_H, TREntities.Missile3_H },
+        [TREntities.Natla]
+            = new TREntities[] { TREntities.Missile2_H, TREntities.Missile3_H },
+        [TREntities.Pierre]
+            = new TREntities[] { TREntities.Key1_M_H, TREntities.ScionPiece_M_H },
+        [TREntities.RatLand]
+            = new TREntities[] { TREntities.RatWater },
+        [TREntities.RatWater]
+            = new TREntities[] { TREntities.RatLand },
+        [TREntities.ShootingAtlantean_N]
+            = new TREntities[] { TREntities.MeatyFlyer },
+        [TREntities.SkateboardKid]
+            = new TREntities[] { TREntities.Skateboard },
+        [TREntities.ThorHammerHandle]
+            = new TREntities[] { TREntities.ThorHammerBlock },
+        [TREntities.TRex]
+            = new TREntities[] { TREntities.LaraMiscAnim_H_Valley }
+    };
+
+    private static readonly Dictionary<TREntities, TREntities[]> _cyclicDependencies = new Dictionary<TREntities, TREntities[]>
+    {
+        [TREntities.CrocodileLand]
+            = new TREntities[] { TREntities.CrocodileWater },
+        [TREntities.CrocodileWater]
+            = new TREntities[] { TREntities.CrocodileLand },
+        [TREntities.RatLand]
+            = new TREntities[] { TREntities.RatWater },
+        [TREntities.RatWater]
+            = new TREntities[] { TREntities.RatLand },
+        [TREntities.Pierre]
+            = new TREntities[] { TREntities.ScionPiece_M_H },
+    };
+
+    private static readonly Dictionary<TREntities, List<TREntities>> _removalExclusions = new Dictionary<TREntities, List<TREntities>>
+    {
+        [TREntities.FlyingAtlantean]
+            = new List<TREntities> { TREntities.NonShootingAtlantean_N, TREntities.ShootingAtlantean_N }
+    };
+
+    private static readonly Dictionary<TREntities, List<TREntities>> _spriteDependencies = new Dictionary<TREntities, List<TREntities>>
+    {
+        [TREntities.SecretScion_M_H]
+            = new List<TREntities> { TREntities.ScionPiece4_S_P },
+        [TREntities.SecretGoldIdol_M_H]
+            = new List<TREntities> { TREntities.ScionPiece4_S_P },
+        [TREntities.SecretLeadBar_M_H]
+            = new List<TREntities> { TREntities.ScionPiece4_S_P },
+        [TREntities.SecretGoldBar_M_H]
+            = new List<TREntities> { TREntities.ScionPiece4_S_P },
+        [TREntities.SecretAnkh_M_H]
+            = new List<TREntities> { TREntities.ScionPiece4_S_P },
+
+        [TREntities.Adam]
+            = new List<TREntities> { TREntities.Explosion1_S_H },
+        [TREntities.Centaur]
+            = new List<TREntities> { TREntities.Explosion1_S_H },
+        [TREntities.FlyingAtlantean]
+            = new List<TREntities> { TREntities.Explosion1_S_H },
+        [TREntities.Key1_M_H]
+            = new List<TREntities> { TREntities.Key1_S_P },
+        [TREntities.Natla]
+            = new List<TREntities> { TREntities.Explosion1_S_H },
+        [TREntities.ScionPiece_M_H]
+            = new List<TREntities> { TREntities.ScionPiece2_S_P },
+        [TREntities.ShootingAtlantean_N]
+            = new List<TREntities> { TREntities.Explosion1_S_H },
+        [TREntities.Missile3_H]
+            = new List<TREntities> { TREntities.Explosion1_S_H },
+    };
+
+    private static readonly List<TREntities> _cinematicEntities = new List<TREntities>
+    {
+    };
+
+    // These are models that use Lara's hips as placeholders
+    private static readonly List<TREntities> _laraDependentModels = new List<TREntities>
+    {
+        TREntities.NonShootingAtlantean_N, TREntities.ShootingAtlantean_N
+    };
+
+    private static readonly Dictionary<TREntities, List<TREntities>> _entityAliases = new Dictionary<TREntities, List<TREntities>>
+    {
+        [TREntities.FlyingAtlantean] = new List<TREntities>
+        {
+            TREntities.BandagedFlyer, TREntities.MeatyFlyer
+        },
+        [TREntities.LaraMiscAnim_H] = new List<TREntities>
+        {
+            TREntities.LaraMiscAnim_H_General, TREntities.LaraMiscAnim_H_Valley, TREntities.LaraMiscAnim_H_Qualopec, TREntities.LaraMiscAnim_H_Midas,
+            TREntities.LaraMiscAnim_H_Sanctuary, TREntities.LaraMiscAnim_H_Atlantis, TREntities.LaraMiscAnim_H_Pyramid
+        },
+        [TREntities.NonShootingAtlantean_N] = new List<TREntities>
+        {
+            TREntities.BandagedAtlantean, TREntities.MeatyAtlantean
+        },
+        [TREntities.Cowboy] = new List<TREntities>
+        {
+            TREntities.CowboyOG, TREntities.CowboyHeadless
+        }
+    };
+
+    private static readonly List<TREntities> _permittedAliasDuplicates = new List<TREntities>
+    {
+        TREntities.LaraMiscAnim_H
+    };
+
+    private static readonly List<TREntities> _permittedOverrides = new List<TREntities>
+    {
+        TREntities.LaraPonytail_H_U, TREntities.ScionPiece_M_H
+    };
+
+    private static readonly List<TREntities> _unsafeModelReplacements = new List<TREntities>
+    {
+    };
+
+    private static readonly List<TREntities> _nonGraphicsDependencies = new List<TREntities>
+    {
+    };
+
+    // If these are imported into levels that already have another alias for them, only their hardcoded sounds will be imported
+    protected static readonly List<TREntities> _soundOnlyDependencies = new List<TREntities>
+    {
+    };
+
+    private static readonly Dictionary<TREntities, short[]> _hardcodedSoundIndices = new Dictionary<TREntities, short[]>
+    {
+        [TREntities.Adam] = new short[] { 104, 137, 138, 140, 141, 142 },
+        [TREntities.BandagedFlyer] = new short[] { 104 },
+        [TREntities.Bear] = new short[] { 12, 16 },
+        [TREntities.Centaur] = new short[] { 104 },
+        [TREntities.DamoclesSword] = new short[] { 103 },
+        [TREntities.DartEmitter] = new short[] { 151 },
+        [TREntities.Gorilla] = new short[] { 90, 91, 101 },
+        [TREntities.Larson] = new short[] { 78 },
+        [TREntities.Lion] = new short[] { 85, 86, 87 },
+        [TREntities.Lioness] = new short[] { 85, 86, 87 },
+        [TREntities.MeatyAtlantean] = new short[] { 104 },
+        [TREntities.MeatyFlyer] = new short[] { 104, 120, 121, 122, 123, 124, 125, 126 },
+        [TREntities.Missile3_H] = new short[] { 104 },
+        [TREntities.Natla] = new short[] { 104, 123, 124, 202 },
+        [TREntities.ShootingAtlantean_N] = new short[] { 104 },
+        [TREntities.SkateboardKid] = new short[] { 132, 204 },
+        [TREntities.TeethSpikes] = new short[] { 145 },
+        [TREntities.ThorHammerHandle] = new short[] { 70 },
+        [TREntities.ThorLightning] = new short[] { 98 },
+        [TREntities.UnderwaterSwitch] = new short[] { 61 },
+        [TREntities.Wolf] = new short[] { 20 }
+    };
+
+    private static readonly Dictionary<TREntities, List<int>> _ignoreEntityTextures = new Dictionary<TREntities, List<int>>
+    {
+        [TREntities.LaraMiscAnim_H]
+            = new List<int>(), // empty list indicates to ignore everything
+        [TREntities.NonShootingAtlantean_N]
+            = new List<int>(),
+        [TREntities.ShootingAtlantean_N]
+            = new List<int>(),
+        [TREntities.Mummy]
+            = new List<int> { 130, 131, 132, 133, 134, 135, 136, 137, 140, 141 },
+        [TREntities.ThorLightning]
+            = new List<int> { 150, 151, 154, 155, 156, 157, 158, 159, 160, 161 }
+    };
+
+    #endregion
 }

--- a/TRModelTransporter/Data/TR1DefaultDataProvider.cs
+++ b/TRModelTransporter/Data/TR1DefaultDataProvider.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using TRLevelControl.Helpers;
+﻿using TRLevelControl.Helpers;
 using TRLevelControl.Model.Enums;
 
 namespace TRModelTransporter.Data;

--- a/TRModelTransporter/Data/TR2DefaultDataProvider.cs
+++ b/TRModelTransporter/Data/TR2DefaultDataProvider.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using TRLevelControl.Helpers;
+﻿using TRLevelControl.Helpers;
 using TRLevelControl.Model.Enums;
 
 namespace TRModelTransporter.Data;

--- a/TRModelTransporter/Data/TR2DefaultDataProvider.cs
+++ b/TRModelTransporter/Data/TR2DefaultDataProvider.cs
@@ -2,414 +2,413 @@
 using TRLevelControl.Helpers;
 using TRLevelControl.Model.Enums;
 
-namespace TRModelTransporter.Data
+namespace TRModelTransporter.Data;
+
+public class TR2DefaultDataProvider : ITransportDataProvider<TR2Entities>
 {
-    public class TR2DefaultDataProvider : ITransportDataProvider<TR2Entities>
+    public int TextureTileLimit { get; set; } = 16;
+    public int TextureObjectLimit { get; set; } = 2048;
+
+    public Dictionary<TR2Entities, TR2Entities> AliasPriority { get; set; }
+
+    public IEnumerable<TR2Entities> GetModelDependencies(TR2Entities entity)
     {
-        public int TextureTileLimit { get; set; } = 16;
-        public int TextureObjectLimit { get; set; } = 2048;
-
-        public Dictionary<TR2Entities, TR2Entities> AliasPriority { get; set; }
-
-        public IEnumerable<TR2Entities> GetModelDependencies(TR2Entities entity)
-        {
-            return _entityDependencies.ContainsKey(entity) ? _entityDependencies[entity] : _emptyEntities;
-        }
-
-        public IEnumerable<TR2Entities> GetRemovalExclusions(TR2Entities entity)
-        {
-            return _emptyEntities;
-        }
-
-        public IEnumerable<TR2Entities> GetCyclicDependencies(TR2Entities entity)
-        {
-            return _emptyEntities;
-        }
-
-        public IEnumerable<TR2Entities> GetSpriteDependencies(TR2Entities entity)
-        {
-            return _spriteDependencies.ContainsKey(entity) ? _spriteDependencies[entity] : _emptyEntities;
-        }
-
-        public IEnumerable<TR2Entities> GetCinematicEntities()
-        {
-            return _cinematicEntities;
-        }
-
-        public IEnumerable<TR2Entities> GetLaraDependants()
-        {
-            return _laraDependentModels;
-        }
-
-        public bool IsAlias(TR2Entities entity)
-        {
-            foreach (List<TR2Entities> aliases in _entityAliases.Values)
-            {
-                if (aliases.Contains(entity))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        public bool HasAliases(TR2Entities entity)
-        {
-            return _entityAliases.ContainsKey(entity);
-        }
-
-        public TR2Entities TranslateAlias(TR2Entities entity)
-        {
-            foreach (TR2Entities root in _entityAliases.Keys)
-            {
-                if (_entityAliases[root].Contains(entity))
-                {
-                    return root;
-                }
-            }
-
-            return entity;
-        }
-
-        public IEnumerable<TR2Entities> GetAliases(TR2Entities entity)
-        {
-            return _entityAliases.ContainsKey(entity) ? _entityAliases[entity] : _emptyEntities;
-        }
-
-        public TR2Entities GetLevelAlias(string level, TR2Entities entity)
-        {
-            return TR2EntityUtilities.GetAliasForLevel(level, entity);
-        }
-
-        public bool IsAliasDuplicatePermitted(TR2Entities entity)
-        {
-            return _permittedAliasDuplicates.Contains(entity);
-        }
-
-        public bool IsOverridePermitted(TR2Entities entity)
-        {
-            return _permittedOverrides.Contains(entity);
-        }
-
-        public IEnumerable<TR2Entities> GetUnsafeModelReplacements()
-        {
-            return _unsafeModelReplacements;
-        }
-
-        public bool IsNonGraphicsDependency(TR2Entities entity)
-        {
-            return _nonGraphicsDependencies.Contains(entity);
-        }
-
-        public bool IsSoundOnlyDependency(TR2Entities entity)
-        {
-            return _soundOnlyDependencies.Contains(entity);
-        }
-
-        public short[] GetHardcodedSounds(TR2Entities entity)
-        {
-            return _hardcodedSoundIndices.ContainsKey(entity) ? _hardcodedSoundIndices[entity] : null;
-        }
-
-        public IEnumerable<int> GetIgnorableTextureIndices(TR2Entities entity, string level)
-        {
-            return _ignoreEntityTextures.ContainsKey(entity) ? _ignoreEntityTextures[entity] : null;
-        }
-
-        #region Data
-
-        private static readonly IEnumerable<TR2Entities> _emptyEntities = new List<TR2Entities>();
-
-        private static readonly Dictionary<TR2Entities, TR2Entities[]> _entityDependencies = new Dictionary<TR2Entities, TR2Entities[]>
-        {
-            [TR2Entities.LaraSun] =
-                new TR2Entities[] { TR2Entities.LaraPistolAnim_H_Sun, TR2Entities.LaraAutoAnim_H_Sun, TR2Entities.LaraUziAnim_H_Sun },
-            [TR2Entities.LaraUnwater] =
-                new TR2Entities[] { TR2Entities.LaraPistolAnim_H_Unwater, TR2Entities.LaraAutoAnim_H_Unwater, TR2Entities.LaraUziAnim_H_Unwater },
-            [TR2Entities.LaraSnow] =
-                new TR2Entities[] { TR2Entities.LaraPistolAnim_H_Snow, TR2Entities.LaraAutoAnim_H_Snow, TR2Entities.LaraUziAnim_H_Snow },
-            [TR2Entities.LaraHome] =
-                new TR2Entities[] { TR2Entities.LaraPistolAnim_H_Home, TR2Entities.LaraAutoAnim_H_Home, TR2Entities.LaraUziAnim_H_Home },
-
-            [TR2Entities.Pistols_M_H] =
-                new TR2Entities[] { TR2Entities.LaraPistolAnim_H, TR2Entities.Gunflare_H },
-            [TR2Entities.Shotgun_M_H] =
-                new TR2Entities[] { TR2Entities.LaraShotgunAnim_H, TR2Entities.Gunflare_H },
-            [TR2Entities.Autos_M_H] =
-                new TR2Entities[] { TR2Entities.LaraAutoAnim_H, TR2Entities.Gunflare_H },
-            [TR2Entities.Uzi_M_H] =
-                new TR2Entities[] { TR2Entities.LaraUziAnim_H, TR2Entities.Gunflare_H },
-            [TR2Entities.M16_M_H] =
-                new TR2Entities[] { TR2Entities.LaraM16Anim_H, TR2Entities.M16Gunflare_H },
-            [TR2Entities.Harpoon_M_H] =
-                new TR2Entities[] { TR2Entities.LaraHarpoonAnim_H, TR2Entities.HarpoonProjectile_H },
-            [TR2Entities.GrenadeLauncher_M_H] =
-                new TR2Entities[] { TR2Entities.LaraGrenadeAnim_H, TR2Entities.GrenadeProjectile_H },
-
-            [TR2Entities.TRex] =
-                new TR2Entities[] { TR2Entities.LaraMiscAnim_H_Wall },
-            [TR2Entities.MaskedGoon2] =
-                new TR2Entities[] { TR2Entities.MaskedGoon1 },
-            [TR2Entities.MaskedGoon3] =
-                new TR2Entities[] { TR2Entities.MaskedGoon1 },
-            [TR2Entities.ScubaDiver] =
-                new TR2Entities[] { TR2Entities.ScubaHarpoonProjectile_H },
-            [TR2Entities.Shark] =
-                new TR2Entities[] { TR2Entities.LaraMiscAnim_H_Unwater },
-            [TR2Entities.StickWieldingGoon2] =
-                new TR2Entities[] { TR2Entities.StickWieldingGoon1GreenVest },
-            [TR2Entities.MercSnowmobDriver] =
-                new TR2Entities[] { TR2Entities.BlackSnowmob },
-            [TR2Entities.BlackSnowmob] =
-                new TR2Entities[] { TR2Entities.RedSnowmobile },
-            [TR2Entities.RedSnowmobile] =
-                new TR2Entities[] { TR2Entities.SnowmobileBelt, TR2Entities.LaraSnowmobAnim_H },
-            [TR2Entities.Boat] =
-                new TR2Entities[] { TR2Entities.LaraBoatAnim_H },
-            [TR2Entities.Mercenary3] =
-                new TR2Entities[] { TR2Entities.Mercenary2 },
-            [TR2Entities.Yeti] =
-                new TR2Entities[] { TR2Entities.LaraMiscAnim_H_Ice },
-            [TR2Entities.XianGuardSpear] =
-                new TR2Entities[] { TR2Entities.LaraMiscAnim_H_Xian, TR2Entities.XianGuardSpearStatue },
-            [TR2Entities.XianGuardSword] =
-                new TR2Entities[] { TR2Entities.XianGuardSwordStatue },
-            [TR2Entities.Knifethrower] =
-                new TR2Entities[] { TR2Entities.KnifeProjectile_H },
-            [TR2Entities.MarcoBartoli] =
-                new TR2Entities[]
-                {
-                    TR2Entities.DragonExplosionEmitter_N, TR2Entities.DragonExplosion1_H, TR2Entities.DragonExplosion2_H, TR2Entities.DragonExplosion3_H,
-                    TR2Entities.DragonFront_H, TR2Entities.DragonBack_H, TR2Entities.DragonBonesFront_H, TR2Entities.DragonBonesBack_H, TR2Entities.LaraMiscAnim_H_Xian,
-                    TR2Entities.Puzzle2_M_H_Dagger
-                }
-        };
-
-        private static readonly Dictionary<TR2Entities, List<TR2Entities>> _spriteDependencies = new Dictionary<TR2Entities, List<TR2Entities>>
-        {
-            [TR2Entities.FlamethrowerGoon] 
-                = new List<TR2Entities> { TR2Entities.Flame_S_H },
-            [TR2Entities.MarcoBartoli] 
-                = new List<TR2Entities> { TR2Entities.Flame_S_H },
-            [TR2Entities.Boat] 
-                = new List<TR2Entities> { TR2Entities.BoatWake_S_H },
-            [TR2Entities.RedSnowmobile] 
-                = new List<TR2Entities> { TR2Entities.SnowmobileWake_S_H },
-            [TR2Entities.XianGuardSword] 
-                = new List<TR2Entities> { TR2Entities.XianGuardSparkles_S_H },
-            [TR2Entities.WaterfallMist_N]
-                = new List<TR2Entities> { TR2Entities.WaterRipples_S_H },
-            [TR2Entities.Key2_M_H]
-                = new List<TR2Entities> { TR2Entities.Key2_S_P }
-        };
-
-        private static readonly List<TR2Entities> _cinematicEntities = new List<TR2Entities>
-        {
-            TR2Entities.DragonExplosionEmitter_N
-        };
-
-        // These are models that use Lara's hips as placeholders
-        private static readonly List<TR2Entities> _laraDependentModels = new List<TR2Entities>
-        {
-            TR2Entities.CameraTarget_N, TR2Entities.FlameEmitter_N, TR2Entities.LaraCutscenePlacement_N,
-            TR2Entities.DragonExplosionEmitter_N, TR2Entities.BartoliHideoutClock_N, TR2Entities.SingingBirds_N,
-            TR2Entities.WaterfallMist_N, TR2Entities.DrippingWater_N, TR2Entities.LavaAirParticleEmitter_N,
-            TR2Entities.AlarmBell_N, TR2Entities.DoorBell_N
-        };
-
-        private static readonly Dictionary<TR2Entities, List<TR2Entities>> _entityAliases = new Dictionary<TR2Entities, List<TR2Entities>>
-        {
-            [TR2Entities.Lara] = new List<TR2Entities>
-            {
-                TR2Entities.LaraSun, TR2Entities.LaraUnwater, TR2Entities.LaraSnow, TR2Entities.LaraHome
-            },
-
-            [TR2Entities.LaraPistolAnim_H] = new List<TR2Entities>
-            {
-                TR2Entities.LaraPistolAnim_H_Sun, TR2Entities.LaraPistolAnim_H_Unwater, TR2Entities.LaraPistolAnim_H_Snow, TR2Entities.LaraPistolAnim_H_Home
-            },
-            [TR2Entities.LaraAutoAnim_H] = new List<TR2Entities>
-            {
-                TR2Entities.LaraAutoAnim_H_Sun, TR2Entities.LaraAutoAnim_H_Unwater, TR2Entities.LaraAutoAnim_H_Snow, TR2Entities.LaraAutoAnim_H_Home
-            },
-            [TR2Entities.LaraUziAnim_H] = new List<TR2Entities>
-            {
-                TR2Entities.LaraUziAnim_H_Sun, TR2Entities.LaraUziAnim_H_Unwater, TR2Entities.LaraUziAnim_H_Snow, TR2Entities.LaraUziAnim_H_Home
-            },
-
-            [TR2Entities.LaraMiscAnim_H] = new List<TR2Entities>
-            {
-                TR2Entities.LaraMiscAnim_H_Wall, TR2Entities.LaraMiscAnim_H_Unwater, TR2Entities.LaraMiscAnim_H_Ice, TR2Entities.LaraMiscAnim_H_Xian, TR2Entities.LaraMiscAnim_H_HSH, TR2Entities.LaraMiscAnim_H_Venice
-            },
-
-            [TR2Entities.TigerOrSnowLeopard] = new List<TR2Entities>
-            {
-                TR2Entities.BengalTiger, TR2Entities.SnowLeopard, TR2Entities.WhiteTiger
-            },
-
-            [TR2Entities.StickWieldingGoon1] = new List<TR2Entities>
-            {
-                TR2Entities.StickWieldingGoon1Bandana, TR2Entities.StickWieldingGoon1BlackJacket, TR2Entities.StickWieldingGoon1BodyWarmer, TR2Entities.StickWieldingGoon1GreenVest, TR2Entities.StickWieldingGoon1WhiteVest
-            },
-
-            [TR2Entities.FlamethrowerGoon] = new List<TR2Entities>
-            {
-                TR2Entities.FlamethrowerGoonOG, TR2Entities.FlamethrowerGoonTopixtor
-            },
-
-            [TR2Entities.Gunman1] = new List<TR2Entities>
-            {
-                TR2Entities.Gunman1OG, TR2Entities.Gunman1TopixtorORC, TR2Entities.Gunman1TopixtorCAC
-            },
-
-            [TR2Entities.Barracuda] = new List<TR2Entities>
-            {
-                TR2Entities.BarracudaIce, TR2Entities.BarracudaUnwater, TR2Entities.BarracudaXian
-            },
-
-            [TR2Entities.Puzzle1_M_H] = new List<TR2Entities>
-            {
-                TR2Entities.Puzzle1_M_H_CircuitBoard, TR2Entities.Puzzle1_M_H_CircuitBreaker, TR2Entities.Puzzle1_M_H_Dagger, TR2Entities.Puzzle1_M_H_DragonSeal, TR2Entities.Puzzle1_M_H_MysticPlaque,
-                TR2Entities.Puzzle1_M_H_PrayerWheel, TR2Entities.Puzzle1_M_H_RelayBox, TR2Entities.Puzzle1_M_H_TibetanMask
-            },
-            [TR2Entities.Puzzle2_M_H] = new List<TR2Entities>
-            {
-                TR2Entities.Puzzle2_M_H_CircuitBoard, TR2Entities.Puzzle2_M_H_Dagger, TR2Entities.Puzzle2_M_H_GemStone, TR2Entities.Puzzle2_M_H_MysticPlaque
-            },
-            [TR2Entities.Puzzle4_M_H] = new List<TR2Entities>
-            {
-                TR2Entities.Puzzle4_M_H_Seraph
-            }
-        };
-
-        private static readonly List<TR2Entities> _permittedAliasDuplicates = new List<TR2Entities>
-        {
-            TR2Entities.LaraMiscAnim_H
-        };
-
-        private static readonly List<TR2Entities> _permittedOverrides = new List<TR2Entities>
-        {
-            TR2Entities.MarcoBartoli
-        };
-
-        private static readonly List<TR2Entities> _unsafeModelReplacements = new List<TR2Entities>
-        {
-        };
-
-        private static readonly List<TR2Entities> _nonGraphicsDependencies = new List<TR2Entities>
-        {
-            TR2Entities.StickWieldingGoon1GreenVest, TR2Entities.MaskedGoon1, TR2Entities.Mercenary2
-        };
-
-        // If these are imported into levels that already have another alias for them, only their hardcoded sounds will be imported
-        protected static readonly List<TR2Entities> _soundOnlyDependencies = new List<TR2Entities>
-        {
-            TR2Entities.StickWieldingGoon1GreenVest
-        };
-
-        private static readonly Dictionary<TR2Entities, short[]> _hardcodedSoundIndices = new Dictionary<TR2Entities, short[]>
-        {
-            [TR2Entities.DragonExplosionEmitter_N] = new short[]
-            {
-                341  // Explosion when dragon spawns
-            },
-            [TR2Entities.DragonFront_H] = new short[]
-            {
-                298, // Footstep
-                299, // Growl 1
-                300, // Growl 2
-                301, // Body falling
-                302, // Dying breath
-                303, // Growl 3
-                304, // Grunt
-                305, // Fire-breathing
-                306, // Leg lift
-                307  // Leg hit
-            },
-            [TR2Entities.Boat] = new short[]
-            {
-                194, // Start
-                195, // Idling
-                196, // Accelerating
-                197, // High RPM
-                198, // Shut off
-                199, // Engine hit
-                200, // Body hit
-                336  // Dry land
-            },
-            [TR2Entities.LaraSnowmobAnim_H] = new short[]
-            {
-                153, // Snowmobile idling
-                155  // Snowmobile accelerating
-            },
-            [TR2Entities.StickWieldingGoon1Bandana] = new short[]
-            {
-                71,  // Thump 1
-                72,  // Thump 2
-            },
-            [TR2Entities.StickWieldingGoon1BlackJacket] = new short[]
-            {
-                71,  // Thump 1
-                72,  // Thump 2
-            },
-            [TR2Entities.StickWieldingGoon1BodyWarmer] = new short[]
-            {
-                69,  // Footstep
-                70,  // Grunt
-                71,  // Thump 1
-                72,  // Thump 2
-                121  // Thump 3
-            },
-            [TR2Entities.StickWieldingGoon1GreenVest] = new short[]
-            {
-                71,  // Thump 1
-                72,  // Thump 2
-            },
-            [TR2Entities.StickWieldingGoon1WhiteVest] = new short[]
-            {
-                71,  // Thump 1
-                72,  // Thump 2,
-                121  // Thump 3
-            },
-            [TR2Entities.StickWieldingGoon2] = new short[]
-            {
-                69,  // Footstep
-                70,  // Grunt
-                71,  // Thump 1
-                72,  // Thump 2
-                180, // Chains
-                181, // Chains
-                182, // Footstep?
-                183  // Another thump?
-            },
-            [TR2Entities.XianGuardSword] = new short[]
-            {
-                312  // Hovering
-            },
-            [TR2Entities.Winston] = new short[]
-            {
-                344, // Scared
-                345, // Huff
-                346, // Bumped
-                347  // Cups clattering
-            }
-        };
-
-        private static readonly Dictionary<TR2Entities, List<int>> _ignoreEntityTextures = new Dictionary<TR2Entities, List<int>>
-        {
-            [TR2Entities.LaraMiscAnim_H] 
-                = new List<int>(), // empty list indicates to ignore everything
-            [TR2Entities.WaterfallMist_N]
-                = new List<int> { 0, 1, 2, 3, 4, 5, 6, 11, 15, 20, 22 },
-            [TR2Entities.LaraSnowmobAnim_H] 
-                = new List<int> { 0, 1, 2, 4, 5, 6, 7, 8, 9, 10, 20, 21, 23 },
-            [TR2Entities.SnowmobileBelt] 
-                = new List<int> { 0, 1, 2, 4, 5, 6, 7, 8, 9, 10, 20, 21, 23 },
-            [TR2Entities.DragonExplosionEmitter_N] 
-                = new List<int> { 0, 1, 2, 3, 4, 5, 6, 8, 13, 14, 16, 17, 19 }
-        };
-
-        #endregion
+        return _entityDependencies.ContainsKey(entity) ? _entityDependencies[entity] : _emptyEntities;
     }
+
+    public IEnumerable<TR2Entities> GetRemovalExclusions(TR2Entities entity)
+    {
+        return _emptyEntities;
+    }
+
+    public IEnumerable<TR2Entities> GetCyclicDependencies(TR2Entities entity)
+    {
+        return _emptyEntities;
+    }
+
+    public IEnumerable<TR2Entities> GetSpriteDependencies(TR2Entities entity)
+    {
+        return _spriteDependencies.ContainsKey(entity) ? _spriteDependencies[entity] : _emptyEntities;
+    }
+
+    public IEnumerable<TR2Entities> GetCinematicEntities()
+    {
+        return _cinematicEntities;
+    }
+
+    public IEnumerable<TR2Entities> GetLaraDependants()
+    {
+        return _laraDependentModels;
+    }
+
+    public bool IsAlias(TR2Entities entity)
+    {
+        foreach (List<TR2Entities> aliases in _entityAliases.Values)
+        {
+            if (aliases.Contains(entity))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public bool HasAliases(TR2Entities entity)
+    {
+        return _entityAliases.ContainsKey(entity);
+    }
+
+    public TR2Entities TranslateAlias(TR2Entities entity)
+    {
+        foreach (TR2Entities root in _entityAliases.Keys)
+        {
+            if (_entityAliases[root].Contains(entity))
+            {
+                return root;
+            }
+        }
+
+        return entity;
+    }
+
+    public IEnumerable<TR2Entities> GetAliases(TR2Entities entity)
+    {
+        return _entityAliases.ContainsKey(entity) ? _entityAliases[entity] : _emptyEntities;
+    }
+
+    public TR2Entities GetLevelAlias(string level, TR2Entities entity)
+    {
+        return TR2EntityUtilities.GetAliasForLevel(level, entity);
+    }
+
+    public bool IsAliasDuplicatePermitted(TR2Entities entity)
+    {
+        return _permittedAliasDuplicates.Contains(entity);
+    }
+
+    public bool IsOverridePermitted(TR2Entities entity)
+    {
+        return _permittedOverrides.Contains(entity);
+    }
+
+    public IEnumerable<TR2Entities> GetUnsafeModelReplacements()
+    {
+        return _unsafeModelReplacements;
+    }
+
+    public bool IsNonGraphicsDependency(TR2Entities entity)
+    {
+        return _nonGraphicsDependencies.Contains(entity);
+    }
+
+    public bool IsSoundOnlyDependency(TR2Entities entity)
+    {
+        return _soundOnlyDependencies.Contains(entity);
+    }
+
+    public short[] GetHardcodedSounds(TR2Entities entity)
+    {
+        return _hardcodedSoundIndices.ContainsKey(entity) ? _hardcodedSoundIndices[entity] : null;
+    }
+
+    public IEnumerable<int> GetIgnorableTextureIndices(TR2Entities entity, string level)
+    {
+        return _ignoreEntityTextures.ContainsKey(entity) ? _ignoreEntityTextures[entity] : null;
+    }
+
+    #region Data
+
+    private static readonly IEnumerable<TR2Entities> _emptyEntities = new List<TR2Entities>();
+
+    private static readonly Dictionary<TR2Entities, TR2Entities[]> _entityDependencies = new Dictionary<TR2Entities, TR2Entities[]>
+    {
+        [TR2Entities.LaraSun] =
+            new TR2Entities[] { TR2Entities.LaraPistolAnim_H_Sun, TR2Entities.LaraAutoAnim_H_Sun, TR2Entities.LaraUziAnim_H_Sun },
+        [TR2Entities.LaraUnwater] =
+            new TR2Entities[] { TR2Entities.LaraPistolAnim_H_Unwater, TR2Entities.LaraAutoAnim_H_Unwater, TR2Entities.LaraUziAnim_H_Unwater },
+        [TR2Entities.LaraSnow] =
+            new TR2Entities[] { TR2Entities.LaraPistolAnim_H_Snow, TR2Entities.LaraAutoAnim_H_Snow, TR2Entities.LaraUziAnim_H_Snow },
+        [TR2Entities.LaraHome] =
+            new TR2Entities[] { TR2Entities.LaraPistolAnim_H_Home, TR2Entities.LaraAutoAnim_H_Home, TR2Entities.LaraUziAnim_H_Home },
+
+        [TR2Entities.Pistols_M_H] =
+            new TR2Entities[] { TR2Entities.LaraPistolAnim_H, TR2Entities.Gunflare_H },
+        [TR2Entities.Shotgun_M_H] =
+            new TR2Entities[] { TR2Entities.LaraShotgunAnim_H, TR2Entities.Gunflare_H },
+        [TR2Entities.Autos_M_H] =
+            new TR2Entities[] { TR2Entities.LaraAutoAnim_H, TR2Entities.Gunflare_H },
+        [TR2Entities.Uzi_M_H] =
+            new TR2Entities[] { TR2Entities.LaraUziAnim_H, TR2Entities.Gunflare_H },
+        [TR2Entities.M16_M_H] =
+            new TR2Entities[] { TR2Entities.LaraM16Anim_H, TR2Entities.M16Gunflare_H },
+        [TR2Entities.Harpoon_M_H] =
+            new TR2Entities[] { TR2Entities.LaraHarpoonAnim_H, TR2Entities.HarpoonProjectile_H },
+        [TR2Entities.GrenadeLauncher_M_H] =
+            new TR2Entities[] { TR2Entities.LaraGrenadeAnim_H, TR2Entities.GrenadeProjectile_H },
+
+        [TR2Entities.TRex] =
+            new TR2Entities[] { TR2Entities.LaraMiscAnim_H_Wall },
+        [TR2Entities.MaskedGoon2] =
+            new TR2Entities[] { TR2Entities.MaskedGoon1 },
+        [TR2Entities.MaskedGoon3] =
+            new TR2Entities[] { TR2Entities.MaskedGoon1 },
+        [TR2Entities.ScubaDiver] =
+            new TR2Entities[] { TR2Entities.ScubaHarpoonProjectile_H },
+        [TR2Entities.Shark] =
+            new TR2Entities[] { TR2Entities.LaraMiscAnim_H_Unwater },
+        [TR2Entities.StickWieldingGoon2] =
+            new TR2Entities[] { TR2Entities.StickWieldingGoon1GreenVest },
+        [TR2Entities.MercSnowmobDriver] =
+            new TR2Entities[] { TR2Entities.BlackSnowmob },
+        [TR2Entities.BlackSnowmob] =
+            new TR2Entities[] { TR2Entities.RedSnowmobile },
+        [TR2Entities.RedSnowmobile] =
+            new TR2Entities[] { TR2Entities.SnowmobileBelt, TR2Entities.LaraSnowmobAnim_H },
+        [TR2Entities.Boat] =
+            new TR2Entities[] { TR2Entities.LaraBoatAnim_H },
+        [TR2Entities.Mercenary3] =
+            new TR2Entities[] { TR2Entities.Mercenary2 },
+        [TR2Entities.Yeti] =
+            new TR2Entities[] { TR2Entities.LaraMiscAnim_H_Ice },
+        [TR2Entities.XianGuardSpear] =
+            new TR2Entities[] { TR2Entities.LaraMiscAnim_H_Xian, TR2Entities.XianGuardSpearStatue },
+        [TR2Entities.XianGuardSword] =
+            new TR2Entities[] { TR2Entities.XianGuardSwordStatue },
+        [TR2Entities.Knifethrower] =
+            new TR2Entities[] { TR2Entities.KnifeProjectile_H },
+        [TR2Entities.MarcoBartoli] =
+            new TR2Entities[]
+            {
+                TR2Entities.DragonExplosionEmitter_N, TR2Entities.DragonExplosion1_H, TR2Entities.DragonExplosion2_H, TR2Entities.DragonExplosion3_H,
+                TR2Entities.DragonFront_H, TR2Entities.DragonBack_H, TR2Entities.DragonBonesFront_H, TR2Entities.DragonBonesBack_H, TR2Entities.LaraMiscAnim_H_Xian,
+                TR2Entities.Puzzle2_M_H_Dagger
+            }
+    };
+
+    private static readonly Dictionary<TR2Entities, List<TR2Entities>> _spriteDependencies = new Dictionary<TR2Entities, List<TR2Entities>>
+    {
+        [TR2Entities.FlamethrowerGoon] 
+            = new List<TR2Entities> { TR2Entities.Flame_S_H },
+        [TR2Entities.MarcoBartoli] 
+            = new List<TR2Entities> { TR2Entities.Flame_S_H },
+        [TR2Entities.Boat] 
+            = new List<TR2Entities> { TR2Entities.BoatWake_S_H },
+        [TR2Entities.RedSnowmobile] 
+            = new List<TR2Entities> { TR2Entities.SnowmobileWake_S_H },
+        [TR2Entities.XianGuardSword] 
+            = new List<TR2Entities> { TR2Entities.XianGuardSparkles_S_H },
+        [TR2Entities.WaterfallMist_N]
+            = new List<TR2Entities> { TR2Entities.WaterRipples_S_H },
+        [TR2Entities.Key2_M_H]
+            = new List<TR2Entities> { TR2Entities.Key2_S_P }
+    };
+
+    private static readonly List<TR2Entities> _cinematicEntities = new List<TR2Entities>
+    {
+        TR2Entities.DragonExplosionEmitter_N
+    };
+
+    // These are models that use Lara's hips as placeholders
+    private static readonly List<TR2Entities> _laraDependentModels = new List<TR2Entities>
+    {
+        TR2Entities.CameraTarget_N, TR2Entities.FlameEmitter_N, TR2Entities.LaraCutscenePlacement_N,
+        TR2Entities.DragonExplosionEmitter_N, TR2Entities.BartoliHideoutClock_N, TR2Entities.SingingBirds_N,
+        TR2Entities.WaterfallMist_N, TR2Entities.DrippingWater_N, TR2Entities.LavaAirParticleEmitter_N,
+        TR2Entities.AlarmBell_N, TR2Entities.DoorBell_N
+    };
+
+    private static readonly Dictionary<TR2Entities, List<TR2Entities>> _entityAliases = new Dictionary<TR2Entities, List<TR2Entities>>
+    {
+        [TR2Entities.Lara] = new List<TR2Entities>
+        {
+            TR2Entities.LaraSun, TR2Entities.LaraUnwater, TR2Entities.LaraSnow, TR2Entities.LaraHome
+        },
+
+        [TR2Entities.LaraPistolAnim_H] = new List<TR2Entities>
+        {
+            TR2Entities.LaraPistolAnim_H_Sun, TR2Entities.LaraPistolAnim_H_Unwater, TR2Entities.LaraPistolAnim_H_Snow, TR2Entities.LaraPistolAnim_H_Home
+        },
+        [TR2Entities.LaraAutoAnim_H] = new List<TR2Entities>
+        {
+            TR2Entities.LaraAutoAnim_H_Sun, TR2Entities.LaraAutoAnim_H_Unwater, TR2Entities.LaraAutoAnim_H_Snow, TR2Entities.LaraAutoAnim_H_Home
+        },
+        [TR2Entities.LaraUziAnim_H] = new List<TR2Entities>
+        {
+            TR2Entities.LaraUziAnim_H_Sun, TR2Entities.LaraUziAnim_H_Unwater, TR2Entities.LaraUziAnim_H_Snow, TR2Entities.LaraUziAnim_H_Home
+        },
+
+        [TR2Entities.LaraMiscAnim_H] = new List<TR2Entities>
+        {
+            TR2Entities.LaraMiscAnim_H_Wall, TR2Entities.LaraMiscAnim_H_Unwater, TR2Entities.LaraMiscAnim_H_Ice, TR2Entities.LaraMiscAnim_H_Xian, TR2Entities.LaraMiscAnim_H_HSH, TR2Entities.LaraMiscAnim_H_Venice
+        },
+
+        [TR2Entities.TigerOrSnowLeopard] = new List<TR2Entities>
+        {
+            TR2Entities.BengalTiger, TR2Entities.SnowLeopard, TR2Entities.WhiteTiger
+        },
+
+        [TR2Entities.StickWieldingGoon1] = new List<TR2Entities>
+        {
+            TR2Entities.StickWieldingGoon1Bandana, TR2Entities.StickWieldingGoon1BlackJacket, TR2Entities.StickWieldingGoon1BodyWarmer, TR2Entities.StickWieldingGoon1GreenVest, TR2Entities.StickWieldingGoon1WhiteVest
+        },
+
+        [TR2Entities.FlamethrowerGoon] = new List<TR2Entities>
+        {
+            TR2Entities.FlamethrowerGoonOG, TR2Entities.FlamethrowerGoonTopixtor
+        },
+
+        [TR2Entities.Gunman1] = new List<TR2Entities>
+        {
+            TR2Entities.Gunman1OG, TR2Entities.Gunman1TopixtorORC, TR2Entities.Gunman1TopixtorCAC
+        },
+
+        [TR2Entities.Barracuda] = new List<TR2Entities>
+        {
+            TR2Entities.BarracudaIce, TR2Entities.BarracudaUnwater, TR2Entities.BarracudaXian
+        },
+
+        [TR2Entities.Puzzle1_M_H] = new List<TR2Entities>
+        {
+            TR2Entities.Puzzle1_M_H_CircuitBoard, TR2Entities.Puzzle1_M_H_CircuitBreaker, TR2Entities.Puzzle1_M_H_Dagger, TR2Entities.Puzzle1_M_H_DragonSeal, TR2Entities.Puzzle1_M_H_MysticPlaque,
+            TR2Entities.Puzzle1_M_H_PrayerWheel, TR2Entities.Puzzle1_M_H_RelayBox, TR2Entities.Puzzle1_M_H_TibetanMask
+        },
+        [TR2Entities.Puzzle2_M_H] = new List<TR2Entities>
+        {
+            TR2Entities.Puzzle2_M_H_CircuitBoard, TR2Entities.Puzzle2_M_H_Dagger, TR2Entities.Puzzle2_M_H_GemStone, TR2Entities.Puzzle2_M_H_MysticPlaque
+        },
+        [TR2Entities.Puzzle4_M_H] = new List<TR2Entities>
+        {
+            TR2Entities.Puzzle4_M_H_Seraph
+        }
+    };
+
+    private static readonly List<TR2Entities> _permittedAliasDuplicates = new List<TR2Entities>
+    {
+        TR2Entities.LaraMiscAnim_H
+    };
+
+    private static readonly List<TR2Entities> _permittedOverrides = new List<TR2Entities>
+    {
+        TR2Entities.MarcoBartoli
+    };
+
+    private static readonly List<TR2Entities> _unsafeModelReplacements = new List<TR2Entities>
+    {
+    };
+
+    private static readonly List<TR2Entities> _nonGraphicsDependencies = new List<TR2Entities>
+    {
+        TR2Entities.StickWieldingGoon1GreenVest, TR2Entities.MaskedGoon1, TR2Entities.Mercenary2
+    };
+
+    // If these are imported into levels that already have another alias for them, only their hardcoded sounds will be imported
+    protected static readonly List<TR2Entities> _soundOnlyDependencies = new List<TR2Entities>
+    {
+        TR2Entities.StickWieldingGoon1GreenVest
+    };
+
+    private static readonly Dictionary<TR2Entities, short[]> _hardcodedSoundIndices = new Dictionary<TR2Entities, short[]>
+    {
+        [TR2Entities.DragonExplosionEmitter_N] = new short[]
+        {
+            341  // Explosion when dragon spawns
+        },
+        [TR2Entities.DragonFront_H] = new short[]
+        {
+            298, // Footstep
+            299, // Growl 1
+            300, // Growl 2
+            301, // Body falling
+            302, // Dying breath
+            303, // Growl 3
+            304, // Grunt
+            305, // Fire-breathing
+            306, // Leg lift
+            307  // Leg hit
+        },
+        [TR2Entities.Boat] = new short[]
+        {
+            194, // Start
+            195, // Idling
+            196, // Accelerating
+            197, // High RPM
+            198, // Shut off
+            199, // Engine hit
+            200, // Body hit
+            336  // Dry land
+        },
+        [TR2Entities.LaraSnowmobAnim_H] = new short[]
+        {
+            153, // Snowmobile idling
+            155  // Snowmobile accelerating
+        },
+        [TR2Entities.StickWieldingGoon1Bandana] = new short[]
+        {
+            71,  // Thump 1
+            72,  // Thump 2
+        },
+        [TR2Entities.StickWieldingGoon1BlackJacket] = new short[]
+        {
+            71,  // Thump 1
+            72,  // Thump 2
+        },
+        [TR2Entities.StickWieldingGoon1BodyWarmer] = new short[]
+        {
+            69,  // Footstep
+            70,  // Grunt
+            71,  // Thump 1
+            72,  // Thump 2
+            121  // Thump 3
+        },
+        [TR2Entities.StickWieldingGoon1GreenVest] = new short[]
+        {
+            71,  // Thump 1
+            72,  // Thump 2
+        },
+        [TR2Entities.StickWieldingGoon1WhiteVest] = new short[]
+        {
+            71,  // Thump 1
+            72,  // Thump 2,
+            121  // Thump 3
+        },
+        [TR2Entities.StickWieldingGoon2] = new short[]
+        {
+            69,  // Footstep
+            70,  // Grunt
+            71,  // Thump 1
+            72,  // Thump 2
+            180, // Chains
+            181, // Chains
+            182, // Footstep?
+            183  // Another thump?
+        },
+        [TR2Entities.XianGuardSword] = new short[]
+        {
+            312  // Hovering
+        },
+        [TR2Entities.Winston] = new short[]
+        {
+            344, // Scared
+            345, // Huff
+            346, // Bumped
+            347  // Cups clattering
+        }
+    };
+
+    private static readonly Dictionary<TR2Entities, List<int>> _ignoreEntityTextures = new Dictionary<TR2Entities, List<int>>
+    {
+        [TR2Entities.LaraMiscAnim_H] 
+            = new List<int>(), // empty list indicates to ignore everything
+        [TR2Entities.WaterfallMist_N]
+            = new List<int> { 0, 1, 2, 3, 4, 5, 6, 11, 15, 20, 22 },
+        [TR2Entities.LaraSnowmobAnim_H] 
+            = new List<int> { 0, 1, 2, 4, 5, 6, 7, 8, 9, 10, 20, 21, 23 },
+        [TR2Entities.SnowmobileBelt] 
+            = new List<int> { 0, 1, 2, 4, 5, 6, 7, 8, 9, 10, 20, 21, 23 },
+        [TR2Entities.DragonExplosionEmitter_N] 
+            = new List<int> { 0, 1, 2, 3, 4, 5, 6, 8, 13, 14, 16, 17, 19 }
+    };
+
+    #endregion
 }

--- a/TRModelTransporter/Data/TR2DefaultDataProvider.cs
+++ b/TRModelTransporter/Data/TR2DefaultDataProvider.cs
@@ -120,7 +120,7 @@ public class TR2DefaultDataProvider : ITransportDataProvider<TR2Entities>
 
     private static readonly IEnumerable<TR2Entities> _emptyEntities = new List<TR2Entities>();
 
-    private static readonly Dictionary<TR2Entities, TR2Entities[]> _entityDependencies = new Dictionary<TR2Entities, TR2Entities[]>
+    private static readonly Dictionary<TR2Entities, TR2Entities[]> _entityDependencies = new()
     {
         [TR2Entities.LaraSun] =
             new TR2Entities[] { TR2Entities.LaraPistolAnim_H_Sun, TR2Entities.LaraAutoAnim_H_Sun, TR2Entities.LaraUziAnim_H_Sun },
@@ -185,7 +185,7 @@ public class TR2DefaultDataProvider : ITransportDataProvider<TR2Entities>
             }
     };
 
-    private static readonly Dictionary<TR2Entities, List<TR2Entities>> _spriteDependencies = new Dictionary<TR2Entities, List<TR2Entities>>
+    private static readonly Dictionary<TR2Entities, List<TR2Entities>> _spriteDependencies = new()
     {
         [TR2Entities.FlamethrowerGoon] 
             = new List<TR2Entities> { TR2Entities.Flame_S_H },
@@ -203,13 +203,13 @@ public class TR2DefaultDataProvider : ITransportDataProvider<TR2Entities>
             = new List<TR2Entities> { TR2Entities.Key2_S_P }
     };
 
-    private static readonly List<TR2Entities> _cinematicEntities = new List<TR2Entities>
+    private static readonly List<TR2Entities> _cinematicEntities = new()
     {
         TR2Entities.DragonExplosionEmitter_N
     };
 
     // These are models that use Lara's hips as placeholders
-    private static readonly List<TR2Entities> _laraDependentModels = new List<TR2Entities>
+    private static readonly List<TR2Entities> _laraDependentModels = new()
     {
         TR2Entities.CameraTarget_N, TR2Entities.FlameEmitter_N, TR2Entities.LaraCutscenePlacement_N,
         TR2Entities.DragonExplosionEmitter_N, TR2Entities.BartoliHideoutClock_N, TR2Entities.SingingBirds_N,
@@ -217,7 +217,7 @@ public class TR2DefaultDataProvider : ITransportDataProvider<TR2Entities>
         TR2Entities.AlarmBell_N, TR2Entities.DoorBell_N
     };
 
-    private static readonly Dictionary<TR2Entities, List<TR2Entities>> _entityAliases = new Dictionary<TR2Entities, List<TR2Entities>>
+    private static readonly Dictionary<TR2Entities, List<TR2Entities>> _entityAliases = new()
     {
         [TR2Entities.Lara] = new List<TR2Entities>
         {
@@ -282,32 +282,32 @@ public class TR2DefaultDataProvider : ITransportDataProvider<TR2Entities>
         }
     };
 
-    private static readonly List<TR2Entities> _permittedAliasDuplicates = new List<TR2Entities>
+    private static readonly List<TR2Entities> _permittedAliasDuplicates = new()
     {
         TR2Entities.LaraMiscAnim_H
     };
 
-    private static readonly List<TR2Entities> _permittedOverrides = new List<TR2Entities>
+    private static readonly List<TR2Entities> _permittedOverrides = new()
     {
         TR2Entities.MarcoBartoli
     };
 
-    private static readonly List<TR2Entities> _unsafeModelReplacements = new List<TR2Entities>
+    private static readonly List<TR2Entities> _unsafeModelReplacements = new()
     {
     };
 
-    private static readonly List<TR2Entities> _nonGraphicsDependencies = new List<TR2Entities>
+    private static readonly List<TR2Entities> _nonGraphicsDependencies = new()
     {
         TR2Entities.StickWieldingGoon1GreenVest, TR2Entities.MaskedGoon1, TR2Entities.Mercenary2
     };
 
     // If these are imported into levels that already have another alias for them, only their hardcoded sounds will be imported
-    protected static readonly List<TR2Entities> _soundOnlyDependencies = new List<TR2Entities>
+    protected static readonly List<TR2Entities> _soundOnlyDependencies = new()
     {
         TR2Entities.StickWieldingGoon1GreenVest
     };
 
-    private static readonly Dictionary<TR2Entities, short[]> _hardcodedSoundIndices = new Dictionary<TR2Entities, short[]>
+    private static readonly Dictionary<TR2Entities, short[]> _hardcodedSoundIndices = new()
     {
         [TR2Entities.DragonExplosionEmitter_N] = new short[]
         {
@@ -395,7 +395,7 @@ public class TR2DefaultDataProvider : ITransportDataProvider<TR2Entities>
         }
     };
 
-    private static readonly Dictionary<TR2Entities, List<int>> _ignoreEntityTextures = new Dictionary<TR2Entities, List<int>>
+    private static readonly Dictionary<TR2Entities, List<int>> _ignoreEntityTextures = new()
     {
         [TR2Entities.LaraMiscAnim_H] 
             = new List<int>(), // empty list indicates to ignore everything

--- a/TRModelTransporter/Data/TR3DefaultDataProvider.cs
+++ b/TRModelTransporter/Data/TR3DefaultDataProvider.cs
@@ -2,371 +2,370 @@
 using TRLevelControl.Helpers;
 using TRLevelControl.Model.Enums;
 
-namespace TRModelTransporter.Data
+namespace TRModelTransporter.Data;
+
+public class TR3DefaultDataProvider : ITransportDataProvider<TR3Entities>
 {
-    public class TR3DefaultDataProvider : ITransportDataProvider<TR3Entities>
+    public int TextureTileLimit { get; set; } = 32;
+    public int TextureObjectLimit { get; set; } = 4096;
+
+    public Dictionary<TR3Entities, TR3Entities> AliasPriority { get; set; }
+
+    public IEnumerable<TR3Entities> GetModelDependencies(TR3Entities entity)
     {
-        public int TextureTileLimit { get; set; } = 32;
-        public int TextureObjectLimit { get; set; } = 4096;
-
-        public Dictionary<TR3Entities, TR3Entities> AliasPriority { get; set; }
-
-        public IEnumerable<TR3Entities> GetModelDependencies(TR3Entities entity)
-        {
-            return _entityDependencies.ContainsKey(entity) ? _entityDependencies[entity] : _emptyEntities;
-        }
-
-        public IEnumerable<TR3Entities> GetRemovalExclusions(TR3Entities entity)
-        {
-            return _emptyEntities;
-        }
-
-        public IEnumerable<TR3Entities> GetCyclicDependencies(TR3Entities entity)
-        {
-            return _emptyEntities;
-        }
-
-        public IEnumerable<TR3Entities> GetSpriteDependencies(TR3Entities entity)
-        {
-            return _spriteDependencies.ContainsKey(entity) ? _spriteDependencies[entity] : _emptyEntities;
-        }
-
-        public IEnumerable<TR3Entities> GetCinematicEntities()
-        {
-            return _cinematicEntities;
-        }
-
-        public IEnumerable<TR3Entities> GetLaraDependants()
-        {
-            return _laraDependentModels;
-        }
-
-        public bool IsAlias(TR3Entities entity)
-        {
-            foreach (List<TR3Entities> aliases in _entityAliases.Values)
-            {
-                if (aliases.Contains(entity))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        public bool HasAliases(TR3Entities entity)
-        {
-            return _entityAliases.ContainsKey(entity);
-        }
-
-        public TR3Entities TranslateAlias(TR3Entities entity)
-        {
-            foreach (TR3Entities root in _entityAliases.Keys)
-            {
-                if (_entityAliases[root].Contains(entity))
-                {
-                    return root;
-                }
-            }
-
-            return entity;
-        }
-
-        public IEnumerable<TR3Entities> GetAliases(TR3Entities entity)
-        {
-            return _entityAliases.ContainsKey(entity) ? _entityAliases[entity] : _emptyEntities;
-        }
-
-        public TR3Entities GetLevelAlias(string level, TR3Entities entity)
-        {
-            return TR3EntityUtilities.GetAliasForLevel(level, entity);
-        }
-
-        public bool IsAliasDuplicatePermitted(TR3Entities entity)
-        {
-            return _permittedAliasDuplicates.Contains(entity);
-        }
-
-        public bool IsOverridePermitted(TR3Entities entity)
-        {
-            return _permittedOverrides.Contains(entity);
-        }
-
-        public IEnumerable<TR3Entities> GetUnsafeModelReplacements()
-        {
-            return _unsafeModelReplacements;
-        }
-
-        public bool IsNonGraphicsDependency(TR3Entities entity)
-        {
-            return _nonGraphicsDependencies.Contains(entity);
-        }
-
-        public bool IsSoundOnlyDependency(TR3Entities entity)
-        {
-            return _soundOnlyDependencies.Contains(entity);
-        }
-
-        public short[] GetHardcodedSounds(TR3Entities entity)
-        {
-            return _hardcodedSoundIndices.ContainsKey(entity) ? _hardcodedSoundIndices[entity] : null;
-        }
-
-        public IEnumerable<int> GetIgnorableTextureIndices(TR3Entities entity, string level)
-        {
-            return _ignoreEntityTextures.ContainsKey(entity) ? _ignoreEntityTextures[entity] : null;
-        }
-
-        #region Data
-
-        private static readonly IEnumerable<TR3Entities> _emptyEntities = new List<TR3Entities>();
-
-        private static readonly Dictionary<TR3Entities, TR3Entities[]> _entityDependencies = new Dictionary<TR3Entities, TR3Entities[]>
-        {
-            [TR3Entities.LaraIndia]
-                = new TR3Entities[] { TR3Entities.LaraSkin_H_India, TR3Entities.LaraPistolAnimation_H_India, TR3Entities.LaraDeagleAnimation_H_India, TR3Entities.LaraUziAnimation_H_India },
-
-            [TR3Entities.LaraCoastal]
-                = new TR3Entities[] { TR3Entities.LaraSkin_H_Coastal, TR3Entities.LaraPistolAnimation_H_Coastal, TR3Entities.LaraDeagleAnimation_H_Coastal, TR3Entities.LaraUziAnimation_H_Coastal },
-
-            [TR3Entities.LaraLondon]
-                = new TR3Entities[] { TR3Entities.LaraSkin_H_London, TR3Entities.LaraPistolAnimation_H_London, TR3Entities.LaraDeagleAnimation_H_London, TR3Entities.LaraUziAnimation_H_London },
-
-            [TR3Entities.LaraNevada]
-                = new TR3Entities[] { TR3Entities.LaraSkin_H_Nevada, TR3Entities.LaraPistolAnimation_H_Nevada, TR3Entities.LaraDeagleAnimation_H_Nevada, TR3Entities.LaraUziAnimation_H_Nevada },
-
-            [TR3Entities.LaraAntarc]
-                = new TR3Entities[] { TR3Entities.LaraSkin_H_Antarc, TR3Entities.LaraPistolAnimation_H_Antarc, TR3Entities.LaraDeagleAnimation_H_Antarc, TR3Entities.LaraUziAnimation_H_Antarc },
-
-            [TR3Entities.LaraHome]
-                = new TR3Entities[] { TR3Entities.LaraSkin_H_Home, TR3Entities.LaraPistolAnimation_H_Home/*, TR3Entities.LaraDeagleAnimation_H_Home, TR3Entities.LaraUziAnimation_H_Home*/ },
-
-            [TR3Entities.Monkey]
-                = new TR3Entities[] { TR3Entities.MonkeyMedMeshswap, TR3Entities.MonkeyKeyMeshswap },
-
-            [TR3Entities.Shiva]
-                = new TR3Entities[] { TR3Entities.ShivaStatue, TR3Entities.LaraExtraAnimation_H, TR3Entities.Monkey },
-
-            [TR3Entities.Quad]
-                = new TR3Entities[] { TR3Entities.LaraVehicleAnimation_H_Quad },
-
-            [TR3Entities.Kayak]
-                = new TR3Entities[] { TR3Entities.LaraVehicleAnimation_H_Kayak },
-
-            [TR3Entities.UPV]
-                = new TR3Entities[] { TR3Entities.LaraVehicleAnimation_H_UPV },
-
-            [TR3Entities.Boat]
-                = new TR3Entities[] { TR3Entities.LaraVehicleAnimation_H_Boat },
-
-            [TR3Entities.Tyrannosaur]
-                 = new TR3Entities[] { TR3Entities.LaraExtraAnimation_H },
-
-            [TR3Entities.Willie]
-                 = new TR3Entities[] { TR3Entities.LaraExtraAnimation_H, TR3Entities.AIPath_N },
-
-            [TR3Entities.Infada_P]
-                 = new TR3Entities[] { TR3Entities.Infada_M_H },
-            [TR3Entities.OraDagger_P]
-                 = new TR3Entities[] { TR3Entities.OraDagger_M_H },
-            [TR3Entities.EyeOfIsis_P]
-                 = new TR3Entities[] { TR3Entities.EyeOfIsis_M_H },
-            [TR3Entities.Element115_P]
-                 = new TR3Entities[] { TR3Entities.Element115_M_H },
-
-            [TR3Entities.Quest1_P]
-                = new TR3Entities[] { TR3Entities.Quest1_M_H },
-            [TR3Entities.Quest2_P]
-                = new TR3Entities[] { TR3Entities.Quest2_M_H },
-
-            [TR3Entities.MP5_P]
-                = new TR3Entities[] { TR3Entities.GunflareMP5_H },
-            [TR3Entities.RocketLauncher_P]
-                = new TR3Entities[] { TR3Entities.RocketSingle },
-            [TR3Entities.GrenadeLauncher_P]
-                = new TR3Entities[] { TR3Entities.GrenadeSingle },
-            [TR3Entities.Harpoon_P]
-                = new TR3Entities[] { TR3Entities.HarpoonSingle2 }
-        };
-
-        private static readonly Dictionary<TR3Entities, List<TR3Entities>> _spriteDependencies = new Dictionary<TR3Entities, List<TR3Entities>>
-        {
-            
-        };
-
-        private static readonly List<TR3Entities> _cinematicEntities = new List<TR3Entities>
-        {
-            
-        };
-
-        private static readonly List<TR3Entities> _laraDependentModels = new List<TR3Entities>
-        {
-            
-        };
-
-        private static readonly Dictionary<TR3Entities, List<TR3Entities>> _entityAliases = new Dictionary<TR3Entities, List<TR3Entities>>
-        {
-            [TR3Entities.Lara] = new List<TR3Entities>
-            {
-                TR3Entities.LaraIndia, TR3Entities.LaraCoastal, TR3Entities.LaraLondon, TR3Entities.LaraNevada, TR3Entities.LaraAntarc, TR3Entities.LaraHome
-            },
-            [TR3Entities.LaraSkin_H] = new List<TR3Entities>
-            {
-                TR3Entities.LaraSkin_H_India, TR3Entities.LaraSkin_H_Coastal, TR3Entities.LaraSkin_H_London, TR3Entities.LaraSkin_H_Nevada, TR3Entities.LaraSkin_H_Antarc, TR3Entities.LaraSkin_H_Home
-            },
-
-            [TR3Entities.LaraPistolAnimation_H] = new List<TR3Entities>
-            {
-                TR3Entities.LaraPistolAnimation_H_India, TR3Entities.LaraPistolAnimation_H_Coastal, TR3Entities.LaraPistolAnimation_H_London, TR3Entities.LaraPistolAnimation_H_Nevada, TR3Entities.LaraPistolAnimation_H_Antarc, TR3Entities.LaraPistolAnimation_H_Home
-            },
-            [TR3Entities.LaraDeagleAnimation_H] = new List<TR3Entities>
-            {
-                TR3Entities.LaraDeagleAnimation_H_India, TR3Entities.LaraDeagleAnimation_H_Coastal, TR3Entities.LaraDeagleAnimation_H_London, TR3Entities.LaraDeagleAnimation_H_Nevada, TR3Entities.LaraDeagleAnimation_H_Antarc, TR3Entities.LaraDeagleAnimation_H_Home
-            },
-            [TR3Entities.LaraUziAnimation_H] = new List<TR3Entities>
-            {
-                TR3Entities.LaraUziAnimation_H_India, TR3Entities.LaraUziAnimation_H_Coastal, TR3Entities.LaraUziAnimation_H_London, TR3Entities.LaraUziAnimation_H_Nevada, TR3Entities.LaraUziAnimation_H_Antarc, TR3Entities.LaraUziAnimation_H_Home
-            },
-
-            [TR3Entities.LaraVehicleAnimation_H] = new List<TR3Entities>
-            {
-                TR3Entities.LaraVehicleAnimation_H_Quad, TR3Entities.LaraVehicleAnimation_H_BigGun, TR3Entities.LaraVehicleAnimation_H_Kayak, TR3Entities.LaraVehicleAnimation_H_UPV, TR3Entities.LaraVehicleAnimation_H_Boat
-            },
-
-            [TR3Entities.Cobra] = new List<TR3Entities>
-            {
-                TR3Entities.CobraIndia, TR3Entities.CobraNevada
-            },
-
-            [TR3Entities.Dog] = new List<TR3Entities>
-            {
-                TR3Entities.DogLondon, TR3Entities.DogNevada
-            }
-        };
-
-        private static readonly List<TR3Entities> _permittedAliasDuplicates = new List<TR3Entities>
-        {
-            TR3Entities.LaraVehicleAnimation_H
-        };
-
-        private static readonly List<TR3Entities> _permittedOverrides = new List<TR3Entities>
-        {
-            TR3Entities.Infada_M_H, TR3Entities.EyeOfIsis_M_H, TR3Entities.OraDagger_M_H, TR3Entities.Element115_M_H
-        };
-
-        private static readonly List<TR3Entities> _unsafeModelReplacements = new List<TR3Entities>
-        {
-             TR3Entities.Lara, TR3Entities.LaraSkin_H, TR3Entities.LaraPistolAnimation_H, TR3Entities.LaraUziAnimation_H, TR3Entities.LaraDeagleAnimation_H
-        };
-
-        private static readonly List<TR3Entities> _nonGraphicsDependencies = new List<TR3Entities>
-        {
-            TR3Entities.Monkey
-        };
-
-        // If these are imported into levels that already have another alias for them, only their hardcoded sounds will be imported
-        protected static readonly List<TR3Entities> _soundOnlyDependencies = new List<TR3Entities>
-        {
-            
-        };
-
-        private static readonly Dictionary<TR3Entities, short[]> _hardcodedSoundIndices = new Dictionary<TR3Entities, short[]>
-        {
-            [TR3Entities.Quad] = new short[]
-            {
-                152, // Starting
-                153, // Idling
-                154, // Switch off 1
-                155, // High RPM,
-                156  // Switch off 2
-            },
-            [TR3Entities.TonyFirehands] = new short[]
-            {
-                76,  // Powering down
-                234, // Dying
-                235, // Dying
-                236, // Laughing
-                366, // Fireball1
-                367, // Fireball2
-                368  // Fireball3
-            },
-            [TR3Entities.Puna] = new short[]
-            {
-                359  // Hoo-uh!
-            },
-            [TR3Entities.LondonMerc] = new short[]
-            {
-                299  // Hey/Oi!
-            },
-            [TR3Entities.LondonGuard] = new short[]
-            {
-                299, // Hey/Oi!
-                305  // Gunshot
-            },
-            [TR3Entities.Punk] = new short[]
-            {
-                299  // Hey/Oi!
-            },
-            [TR3Entities.UPV] = new short[]
-            {
-                346, // Starting
-                347, // Running
-                348  // Stopping
-            },
-            [TR3Entities.MPWithStick] = new short[]
-            {
-                300  // Hey!
-            },
-            [TR3Entities.MPWithGun] = new short[]
-            {
-                300  // Hey!
-            },
-            [TR3Entities.MPWithMP5] = new short[]
-            {
-                137, // Gunshot
-                300  // Hey!
-            },
-            [TR3Entities.DamGuard] = new short[]
-            {
-                300  // Hey!
-            },
-            [TR3Entities.Prisoner] = new short[]
-            {
-                300  // Hey!
-            },
-            [TR3Entities.RXRedBoi] = new short[]
-            {
-                300  // Hey!
-            },
-            [TR3Entities.RXGunLad] = new short[]
-            {
-                300  // Hey!
-            },
-            [TR3Entities.Boat] = new short[]
-            {
-                194, // Starting
-                195, // Idling
-                196, // Accelerating
-                197, // High RPM
-                198, // Stopping
-                199  // Hitting something
-            },
-            [TR3Entities.Winston] = new short[]
-            {
-                308, // Shuffle
-                311, // Hit by shield
-                314  // General grunt
-            }
-        };
-
-        private static readonly Dictionary<TR3Entities, List<int>> _ignoreEntityTextures = new Dictionary<TR3Entities, List<int>>
-        {
-            [TR3Entities.LaraVehicleAnimation_H]
-                = new List<int>(), // empty list indicates to ignore everything
-            [TR3Entities.LaraExtraAnimation_H]
-                = new List<int>()
-        };
-
-        #endregion
+        return _entityDependencies.ContainsKey(entity) ? _entityDependencies[entity] : _emptyEntities;
     }
+
+    public IEnumerable<TR3Entities> GetRemovalExclusions(TR3Entities entity)
+    {
+        return _emptyEntities;
+    }
+
+    public IEnumerable<TR3Entities> GetCyclicDependencies(TR3Entities entity)
+    {
+        return _emptyEntities;
+    }
+
+    public IEnumerable<TR3Entities> GetSpriteDependencies(TR3Entities entity)
+    {
+        return _spriteDependencies.ContainsKey(entity) ? _spriteDependencies[entity] : _emptyEntities;
+    }
+
+    public IEnumerable<TR3Entities> GetCinematicEntities()
+    {
+        return _cinematicEntities;
+    }
+
+    public IEnumerable<TR3Entities> GetLaraDependants()
+    {
+        return _laraDependentModels;
+    }
+
+    public bool IsAlias(TR3Entities entity)
+    {
+        foreach (List<TR3Entities> aliases in _entityAliases.Values)
+        {
+            if (aliases.Contains(entity))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public bool HasAliases(TR3Entities entity)
+    {
+        return _entityAliases.ContainsKey(entity);
+    }
+
+    public TR3Entities TranslateAlias(TR3Entities entity)
+    {
+        foreach (TR3Entities root in _entityAliases.Keys)
+        {
+            if (_entityAliases[root].Contains(entity))
+            {
+                return root;
+            }
+        }
+
+        return entity;
+    }
+
+    public IEnumerable<TR3Entities> GetAliases(TR3Entities entity)
+    {
+        return _entityAliases.ContainsKey(entity) ? _entityAliases[entity] : _emptyEntities;
+    }
+
+    public TR3Entities GetLevelAlias(string level, TR3Entities entity)
+    {
+        return TR3EntityUtilities.GetAliasForLevel(level, entity);
+    }
+
+    public bool IsAliasDuplicatePermitted(TR3Entities entity)
+    {
+        return _permittedAliasDuplicates.Contains(entity);
+    }
+
+    public bool IsOverridePermitted(TR3Entities entity)
+    {
+        return _permittedOverrides.Contains(entity);
+    }
+
+    public IEnumerable<TR3Entities> GetUnsafeModelReplacements()
+    {
+        return _unsafeModelReplacements;
+    }
+
+    public bool IsNonGraphicsDependency(TR3Entities entity)
+    {
+        return _nonGraphicsDependencies.Contains(entity);
+    }
+
+    public bool IsSoundOnlyDependency(TR3Entities entity)
+    {
+        return _soundOnlyDependencies.Contains(entity);
+    }
+
+    public short[] GetHardcodedSounds(TR3Entities entity)
+    {
+        return _hardcodedSoundIndices.ContainsKey(entity) ? _hardcodedSoundIndices[entity] : null;
+    }
+
+    public IEnumerable<int> GetIgnorableTextureIndices(TR3Entities entity, string level)
+    {
+        return _ignoreEntityTextures.ContainsKey(entity) ? _ignoreEntityTextures[entity] : null;
+    }
+
+    #region Data
+
+    private static readonly IEnumerable<TR3Entities> _emptyEntities = new List<TR3Entities>();
+
+    private static readonly Dictionary<TR3Entities, TR3Entities[]> _entityDependencies = new Dictionary<TR3Entities, TR3Entities[]>
+    {
+        [TR3Entities.LaraIndia]
+            = new TR3Entities[] { TR3Entities.LaraSkin_H_India, TR3Entities.LaraPistolAnimation_H_India, TR3Entities.LaraDeagleAnimation_H_India, TR3Entities.LaraUziAnimation_H_India },
+
+        [TR3Entities.LaraCoastal]
+            = new TR3Entities[] { TR3Entities.LaraSkin_H_Coastal, TR3Entities.LaraPistolAnimation_H_Coastal, TR3Entities.LaraDeagleAnimation_H_Coastal, TR3Entities.LaraUziAnimation_H_Coastal },
+
+        [TR3Entities.LaraLondon]
+            = new TR3Entities[] { TR3Entities.LaraSkin_H_London, TR3Entities.LaraPistolAnimation_H_London, TR3Entities.LaraDeagleAnimation_H_London, TR3Entities.LaraUziAnimation_H_London },
+
+        [TR3Entities.LaraNevada]
+            = new TR3Entities[] { TR3Entities.LaraSkin_H_Nevada, TR3Entities.LaraPistolAnimation_H_Nevada, TR3Entities.LaraDeagleAnimation_H_Nevada, TR3Entities.LaraUziAnimation_H_Nevada },
+
+        [TR3Entities.LaraAntarc]
+            = new TR3Entities[] { TR3Entities.LaraSkin_H_Antarc, TR3Entities.LaraPistolAnimation_H_Antarc, TR3Entities.LaraDeagleAnimation_H_Antarc, TR3Entities.LaraUziAnimation_H_Antarc },
+
+        [TR3Entities.LaraHome]
+            = new TR3Entities[] { TR3Entities.LaraSkin_H_Home, TR3Entities.LaraPistolAnimation_H_Home/*, TR3Entities.LaraDeagleAnimation_H_Home, TR3Entities.LaraUziAnimation_H_Home*/ },
+
+        [TR3Entities.Monkey]
+            = new TR3Entities[] { TR3Entities.MonkeyMedMeshswap, TR3Entities.MonkeyKeyMeshswap },
+
+        [TR3Entities.Shiva]
+            = new TR3Entities[] { TR3Entities.ShivaStatue, TR3Entities.LaraExtraAnimation_H, TR3Entities.Monkey },
+
+        [TR3Entities.Quad]
+            = new TR3Entities[] { TR3Entities.LaraVehicleAnimation_H_Quad },
+
+        [TR3Entities.Kayak]
+            = new TR3Entities[] { TR3Entities.LaraVehicleAnimation_H_Kayak },
+
+        [TR3Entities.UPV]
+            = new TR3Entities[] { TR3Entities.LaraVehicleAnimation_H_UPV },
+
+        [TR3Entities.Boat]
+            = new TR3Entities[] { TR3Entities.LaraVehicleAnimation_H_Boat },
+
+        [TR3Entities.Tyrannosaur]
+             = new TR3Entities[] { TR3Entities.LaraExtraAnimation_H },
+
+        [TR3Entities.Willie]
+             = new TR3Entities[] { TR3Entities.LaraExtraAnimation_H, TR3Entities.AIPath_N },
+
+        [TR3Entities.Infada_P]
+             = new TR3Entities[] { TR3Entities.Infada_M_H },
+        [TR3Entities.OraDagger_P]
+             = new TR3Entities[] { TR3Entities.OraDagger_M_H },
+        [TR3Entities.EyeOfIsis_P]
+             = new TR3Entities[] { TR3Entities.EyeOfIsis_M_H },
+        [TR3Entities.Element115_P]
+             = new TR3Entities[] { TR3Entities.Element115_M_H },
+
+        [TR3Entities.Quest1_P]
+            = new TR3Entities[] { TR3Entities.Quest1_M_H },
+        [TR3Entities.Quest2_P]
+            = new TR3Entities[] { TR3Entities.Quest2_M_H },
+
+        [TR3Entities.MP5_P]
+            = new TR3Entities[] { TR3Entities.GunflareMP5_H },
+        [TR3Entities.RocketLauncher_P]
+            = new TR3Entities[] { TR3Entities.RocketSingle },
+        [TR3Entities.GrenadeLauncher_P]
+            = new TR3Entities[] { TR3Entities.GrenadeSingle },
+        [TR3Entities.Harpoon_P]
+            = new TR3Entities[] { TR3Entities.HarpoonSingle2 }
+    };
+
+    private static readonly Dictionary<TR3Entities, List<TR3Entities>> _spriteDependencies = new Dictionary<TR3Entities, List<TR3Entities>>
+    {
+        
+    };
+
+    private static readonly List<TR3Entities> _cinematicEntities = new List<TR3Entities>
+    {
+        
+    };
+
+    private static readonly List<TR3Entities> _laraDependentModels = new List<TR3Entities>
+    {
+        
+    };
+
+    private static readonly Dictionary<TR3Entities, List<TR3Entities>> _entityAliases = new Dictionary<TR3Entities, List<TR3Entities>>
+    {
+        [TR3Entities.Lara] = new List<TR3Entities>
+        {
+            TR3Entities.LaraIndia, TR3Entities.LaraCoastal, TR3Entities.LaraLondon, TR3Entities.LaraNevada, TR3Entities.LaraAntarc, TR3Entities.LaraHome
+        },
+        [TR3Entities.LaraSkin_H] = new List<TR3Entities>
+        {
+            TR3Entities.LaraSkin_H_India, TR3Entities.LaraSkin_H_Coastal, TR3Entities.LaraSkin_H_London, TR3Entities.LaraSkin_H_Nevada, TR3Entities.LaraSkin_H_Antarc, TR3Entities.LaraSkin_H_Home
+        },
+
+        [TR3Entities.LaraPistolAnimation_H] = new List<TR3Entities>
+        {
+            TR3Entities.LaraPistolAnimation_H_India, TR3Entities.LaraPistolAnimation_H_Coastal, TR3Entities.LaraPistolAnimation_H_London, TR3Entities.LaraPistolAnimation_H_Nevada, TR3Entities.LaraPistolAnimation_H_Antarc, TR3Entities.LaraPistolAnimation_H_Home
+        },
+        [TR3Entities.LaraDeagleAnimation_H] = new List<TR3Entities>
+        {
+            TR3Entities.LaraDeagleAnimation_H_India, TR3Entities.LaraDeagleAnimation_H_Coastal, TR3Entities.LaraDeagleAnimation_H_London, TR3Entities.LaraDeagleAnimation_H_Nevada, TR3Entities.LaraDeagleAnimation_H_Antarc, TR3Entities.LaraDeagleAnimation_H_Home
+        },
+        [TR3Entities.LaraUziAnimation_H] = new List<TR3Entities>
+        {
+            TR3Entities.LaraUziAnimation_H_India, TR3Entities.LaraUziAnimation_H_Coastal, TR3Entities.LaraUziAnimation_H_London, TR3Entities.LaraUziAnimation_H_Nevada, TR3Entities.LaraUziAnimation_H_Antarc, TR3Entities.LaraUziAnimation_H_Home
+        },
+
+        [TR3Entities.LaraVehicleAnimation_H] = new List<TR3Entities>
+        {
+            TR3Entities.LaraVehicleAnimation_H_Quad, TR3Entities.LaraVehicleAnimation_H_BigGun, TR3Entities.LaraVehicleAnimation_H_Kayak, TR3Entities.LaraVehicleAnimation_H_UPV, TR3Entities.LaraVehicleAnimation_H_Boat
+        },
+
+        [TR3Entities.Cobra] = new List<TR3Entities>
+        {
+            TR3Entities.CobraIndia, TR3Entities.CobraNevada
+        },
+
+        [TR3Entities.Dog] = new List<TR3Entities>
+        {
+            TR3Entities.DogLondon, TR3Entities.DogNevada
+        }
+    };
+
+    private static readonly List<TR3Entities> _permittedAliasDuplicates = new List<TR3Entities>
+    {
+        TR3Entities.LaraVehicleAnimation_H
+    };
+
+    private static readonly List<TR3Entities> _permittedOverrides = new List<TR3Entities>
+    {
+        TR3Entities.Infada_M_H, TR3Entities.EyeOfIsis_M_H, TR3Entities.OraDagger_M_H, TR3Entities.Element115_M_H
+    };
+
+    private static readonly List<TR3Entities> _unsafeModelReplacements = new List<TR3Entities>
+    {
+         TR3Entities.Lara, TR3Entities.LaraSkin_H, TR3Entities.LaraPistolAnimation_H, TR3Entities.LaraUziAnimation_H, TR3Entities.LaraDeagleAnimation_H
+    };
+
+    private static readonly List<TR3Entities> _nonGraphicsDependencies = new List<TR3Entities>
+    {
+        TR3Entities.Monkey
+    };
+
+    // If these are imported into levels that already have another alias for them, only their hardcoded sounds will be imported
+    protected static readonly List<TR3Entities> _soundOnlyDependencies = new List<TR3Entities>
+    {
+        
+    };
+
+    private static readonly Dictionary<TR3Entities, short[]> _hardcodedSoundIndices = new Dictionary<TR3Entities, short[]>
+    {
+        [TR3Entities.Quad] = new short[]
+        {
+            152, // Starting
+            153, // Idling
+            154, // Switch off 1
+            155, // High RPM,
+            156  // Switch off 2
+        },
+        [TR3Entities.TonyFirehands] = new short[]
+        {
+            76,  // Powering down
+            234, // Dying
+            235, // Dying
+            236, // Laughing
+            366, // Fireball1
+            367, // Fireball2
+            368  // Fireball3
+        },
+        [TR3Entities.Puna] = new short[]
+        {
+            359  // Hoo-uh!
+        },
+        [TR3Entities.LondonMerc] = new short[]
+        {
+            299  // Hey/Oi!
+        },
+        [TR3Entities.LondonGuard] = new short[]
+        {
+            299, // Hey/Oi!
+            305  // Gunshot
+        },
+        [TR3Entities.Punk] = new short[]
+        {
+            299  // Hey/Oi!
+        },
+        [TR3Entities.UPV] = new short[]
+        {
+            346, // Starting
+            347, // Running
+            348  // Stopping
+        },
+        [TR3Entities.MPWithStick] = new short[]
+        {
+            300  // Hey!
+        },
+        [TR3Entities.MPWithGun] = new short[]
+        {
+            300  // Hey!
+        },
+        [TR3Entities.MPWithMP5] = new short[]
+        {
+            137, // Gunshot
+            300  // Hey!
+        },
+        [TR3Entities.DamGuard] = new short[]
+        {
+            300  // Hey!
+        },
+        [TR3Entities.Prisoner] = new short[]
+        {
+            300  // Hey!
+        },
+        [TR3Entities.RXRedBoi] = new short[]
+        {
+            300  // Hey!
+        },
+        [TR3Entities.RXGunLad] = new short[]
+        {
+            300  // Hey!
+        },
+        [TR3Entities.Boat] = new short[]
+        {
+            194, // Starting
+            195, // Idling
+            196, // Accelerating
+            197, // High RPM
+            198, // Stopping
+            199  // Hitting something
+        },
+        [TR3Entities.Winston] = new short[]
+        {
+            308, // Shuffle
+            311, // Hit by shield
+            314  // General grunt
+        }
+    };
+
+    private static readonly Dictionary<TR3Entities, List<int>> _ignoreEntityTextures = new Dictionary<TR3Entities, List<int>>
+    {
+        [TR3Entities.LaraVehicleAnimation_H]
+            = new List<int>(), // empty list indicates to ignore everything
+        [TR3Entities.LaraExtraAnimation_H]
+            = new List<int>()
+    };
+
+    #endregion
 }

--- a/TRModelTransporter/Data/TR3DefaultDataProvider.cs
+++ b/TRModelTransporter/Data/TR3DefaultDataProvider.cs
@@ -120,7 +120,7 @@ public class TR3DefaultDataProvider : ITransportDataProvider<TR3Entities>
 
     private static readonly IEnumerable<TR3Entities> _emptyEntities = new List<TR3Entities>();
 
-    private static readonly Dictionary<TR3Entities, TR3Entities[]> _entityDependencies = new Dictionary<TR3Entities, TR3Entities[]>
+    private static readonly Dictionary<TR3Entities, TR3Entities[]> _entityDependencies = new()
     {
         [TR3Entities.LaraIndia]
             = new TR3Entities[] { TR3Entities.LaraSkin_H_India, TR3Entities.LaraPistolAnimation_H_India, TR3Entities.LaraDeagleAnimation_H_India, TR3Entities.LaraUziAnimation_H_India },
@@ -188,22 +188,22 @@ public class TR3DefaultDataProvider : ITransportDataProvider<TR3Entities>
             = new TR3Entities[] { TR3Entities.HarpoonSingle2 }
     };
 
-    private static readonly Dictionary<TR3Entities, List<TR3Entities>> _spriteDependencies = new Dictionary<TR3Entities, List<TR3Entities>>
+    private static readonly Dictionary<TR3Entities, List<TR3Entities>> _spriteDependencies = new()
     {
         
     };
 
-    private static readonly List<TR3Entities> _cinematicEntities = new List<TR3Entities>
+    private static readonly List<TR3Entities> _cinematicEntities = new()
     {
         
     };
 
-    private static readonly List<TR3Entities> _laraDependentModels = new List<TR3Entities>
+    private static readonly List<TR3Entities> _laraDependentModels = new()
     {
         
     };
 
-    private static readonly Dictionary<TR3Entities, List<TR3Entities>> _entityAliases = new Dictionary<TR3Entities, List<TR3Entities>>
+    private static readonly Dictionary<TR3Entities, List<TR3Entities>> _entityAliases = new()
     {
         [TR3Entities.Lara] = new List<TR3Entities>
         {
@@ -243,33 +243,33 @@ public class TR3DefaultDataProvider : ITransportDataProvider<TR3Entities>
         }
     };
 
-    private static readonly List<TR3Entities> _permittedAliasDuplicates = new List<TR3Entities>
+    private static readonly List<TR3Entities> _permittedAliasDuplicates = new()
     {
         TR3Entities.LaraVehicleAnimation_H
     };
 
-    private static readonly List<TR3Entities> _permittedOverrides = new List<TR3Entities>
+    private static readonly List<TR3Entities> _permittedOverrides = new()
     {
         TR3Entities.Infada_M_H, TR3Entities.EyeOfIsis_M_H, TR3Entities.OraDagger_M_H, TR3Entities.Element115_M_H
     };
 
-    private static readonly List<TR3Entities> _unsafeModelReplacements = new List<TR3Entities>
+    private static readonly List<TR3Entities> _unsafeModelReplacements = new()
     {
          TR3Entities.Lara, TR3Entities.LaraSkin_H, TR3Entities.LaraPistolAnimation_H, TR3Entities.LaraUziAnimation_H, TR3Entities.LaraDeagleAnimation_H
     };
 
-    private static readonly List<TR3Entities> _nonGraphicsDependencies = new List<TR3Entities>
+    private static readonly List<TR3Entities> _nonGraphicsDependencies = new()
     {
         TR3Entities.Monkey
     };
 
     // If these are imported into levels that already have another alias for them, only their hardcoded sounds will be imported
-    protected static readonly List<TR3Entities> _soundOnlyDependencies = new List<TR3Entities>
+    protected static readonly List<TR3Entities> _soundOnlyDependencies = new()
     {
         
     };
 
-    private static readonly Dictionary<TR3Entities, short[]> _hardcodedSoundIndices = new Dictionary<TR3Entities, short[]>
+    private static readonly Dictionary<TR3Entities, short[]> _hardcodedSoundIndices = new()
     {
         [TR3Entities.Quad] = new short[]
         {
@@ -358,7 +358,7 @@ public class TR3DefaultDataProvider : ITransportDataProvider<TR3Entities>
         }
     };
 
-    private static readonly Dictionary<TR3Entities, List<int>> _ignoreEntityTextures = new Dictionary<TR3Entities, List<int>>
+    private static readonly Dictionary<TR3Entities, List<int>> _ignoreEntityTextures = new()
     {
         [TR3Entities.LaraVehicleAnimation_H]
             = new List<int>(), // empty list indicates to ignore everything

--- a/TRModelTransporter/Data/TR3DefaultDataProvider.cs
+++ b/TRModelTransporter/Data/TR3DefaultDataProvider.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using TRLevelControl.Helpers;
+﻿using TRLevelControl.Helpers;
 using TRLevelControl.Model.Enums;
 
 namespace TRModelTransporter.Data;

--- a/TRModelTransporter/Events/SegmentEventArgs.cs
+++ b/TRModelTransporter/Events/SegmentEventArgs.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.Drawing;
 
-namespace TRModelTransporter.Events
+namespace TRModelTransporter.Events;
+
+public class SegmentEventArgs : EventArgs
 {
-    public class SegmentEventArgs : EventArgs
-    {
-        public int SegmentIndex { get; set; }
-        public Bitmap Bitmap { get; set; }
-    }
+    public int SegmentIndex { get; set; }
+    public Bitmap Bitmap { get; set; }
 }

--- a/TRModelTransporter/Events/SegmentEventArgs.cs
+++ b/TRModelTransporter/Events/SegmentEventArgs.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Drawing;
+﻿using System.Drawing;
 
 namespace TRModelTransporter.Events;
 

--- a/TRModelTransporter/Handlers/Animations/AnimationTransportHandler.cs
+++ b/TRModelTransporter/Handlers/Animations/AnimationTransportHandler.cs
@@ -14,7 +14,7 @@ public class AnimationTransportHandler
         for (int animationIndex = definition.Model.Animation; animationIndex < endAnimation; animationIndex++)
         {
             TRAnimation animation = level.Animations[animationIndex];
-            TR1PackedAnimation packedAnimation = new TR1PackedAnimation
+            TR1PackedAnimation packedAnimation = new()
             {
                 Animation = animation,
             };
@@ -40,7 +40,7 @@ public class AnimationTransportHandler
         for (int animationIndex = definition.Model.Animation; animationIndex < endAnimation; animationIndex++)
         {
             TRAnimation animation = level.Animations[animationIndex];
-            TR2PackedAnimation packedAnimation = new TR2PackedAnimation
+            TR2PackedAnimation packedAnimation = new()
             {
                 Animation = animation,
             };
@@ -66,7 +66,7 @@ public class AnimationTransportHandler
         for (int animationIndex = definition.Model.Animation; animationIndex < endAnimation; animationIndex++)
         {
             TRAnimation animation = level.Animations[animationIndex];
-            TR3PackedAnimation packedAnimation = new TR3PackedAnimation
+            TR3PackedAnimation packedAnimation = new()
             {
                 Animation = animation,
             };
@@ -88,7 +88,7 @@ public class AnimationTransportHandler
     {
         Dictionary<int, TR1PackedAnimation> animations = definition.Animations;
         bool firstAnimationConfigured = false;
-        Dictionary<int, int> indexMap = new Dictionary<int, int>();
+        Dictionary<int, int> indexMap = new();
 
         List<TRAnimDispatch> animDispatches = level.AnimDispatches.ToList();
         List<TRStateChange> stateChanges = level.StateChanges.ToList();
@@ -143,7 +143,7 @@ public class AnimationTransportHandler
     {
         Dictionary<int, TR2PackedAnimation> animations = definition.Animations;
         bool firstAnimationConfigured = false;
-        Dictionary<int, int> indexMap = new Dictionary<int, int>();
+        Dictionary<int, int> indexMap = new();
 
         List<TRAnimDispatch> animDispatches = level.AnimDispatches.ToList();
         List<TRStateChange> stateChanges = level.StateChanges.ToList();
@@ -198,7 +198,7 @@ public class AnimationTransportHandler
     {
         Dictionary<int, TR3PackedAnimation> animations = definition.Animations;
         bool firstAnimationConfigured = false;
-        Dictionary<int, int> indexMap = new Dictionary<int, int>();
+        Dictionary<int, int> indexMap = new();
 
         List<TRAnimDispatch> animDispatches = level.AnimDispatches.ToList();
         List<TRStateChange> stateChanges = level.StateChanges.ToList();

--- a/TRModelTransporter/Handlers/Animations/AnimationTransportHandler.cs
+++ b/TRModelTransporter/Handlers/Animations/AnimationTransportHandler.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using TRLevelControl.Model;
+﻿using TRLevelControl.Model;
 using TRModelTransporter.Model.Animations;
 using TRModelTransporter.Model.Definitions;
 

--- a/TRModelTransporter/Handlers/Animations/AnimationTransportHandler.cs
+++ b/TRModelTransporter/Handlers/Animations/AnimationTransportHandler.cs
@@ -4,252 +4,251 @@ using TRLevelControl.Model;
 using TRModelTransporter.Model.Animations;
 using TRModelTransporter.Model.Definitions;
 
-namespace TRModelTransporter.Handlers
+namespace TRModelTransporter.Handlers;
+
+public class AnimationTransportHandler
 {
-    public class AnimationTransportHandler
+    public void Export(TR1Level level, TR1ModelDefinition definition)
     {
-        public void Export(TR1Level level, TR1ModelDefinition definition)
+        definition.Animations = new Dictionary<int, TR1PackedAnimation>();
+
+        int endAnimation = AnimationUtilities.GetModelAnimationCount(level, definition.Model) + definition.Model.Animation;
+        for (int animationIndex = definition.Model.Animation; animationIndex < endAnimation; animationIndex++)
         {
-            definition.Animations = new Dictionary<int, TR1PackedAnimation>();
-
-            int endAnimation = AnimationUtilities.GetModelAnimationCount(level, definition.Model) + definition.Model.Animation;
-            for (int animationIndex = definition.Model.Animation; animationIndex < endAnimation; animationIndex++)
+            TRAnimation animation = level.Animations[animationIndex];
+            TR1PackedAnimation packedAnimation = new TR1PackedAnimation
             {
-                TRAnimation animation = level.Animations[animationIndex];
-                TR1PackedAnimation packedAnimation = new TR1PackedAnimation
-                {
-                    Animation = animation,
-                };
-                definition.Animations[animationIndex] = packedAnimation;
+                Animation = animation,
+            };
+            definition.Animations[animationIndex] = packedAnimation;
 
-                AnimationUtilities.PackStateChanges(level, animation, packedAnimation);
-                AnimationUtilities.PackAnimCommands(level, animation, packedAnimation);
-                AnimationUtilities.PackAnimSounds(level, packedAnimation);
-            }
-
-            foreach (TR1PackedAnimation anim in definition.Animations.Values)
-            {
-                anim.Animation.FrameOffset -= definition.Model.FrameOffset;
-            }
-            definition.AnimationFrames = AnimationUtilities.GetAnimationFrames(level, definition.Model);
+            AnimationUtilities.PackStateChanges(level, animation, packedAnimation);
+            AnimationUtilities.PackAnimCommands(level, animation, packedAnimation);
+            AnimationUtilities.PackAnimSounds(level, packedAnimation);
         }
 
-        public void Export(TR2Level level, TR2ModelDefinition definition)
+        foreach (TR1PackedAnimation anim in definition.Animations.Values)
         {
-            definition.Animations = new Dictionary<int, TR2PackedAnimation>();
+            anim.Animation.FrameOffset -= definition.Model.FrameOffset;
+        }
+        definition.AnimationFrames = AnimationUtilities.GetAnimationFrames(level, definition.Model);
+    }
 
-            int endAnimation = AnimationUtilities.GetModelAnimationCount(level, definition.Model) + definition.Model.Animation;
-            for (int animationIndex = definition.Model.Animation; animationIndex < endAnimation; animationIndex++)
+    public void Export(TR2Level level, TR2ModelDefinition definition)
+    {
+        definition.Animations = new Dictionary<int, TR2PackedAnimation>();
+
+        int endAnimation = AnimationUtilities.GetModelAnimationCount(level, definition.Model) + definition.Model.Animation;
+        for (int animationIndex = definition.Model.Animation; animationIndex < endAnimation; animationIndex++)
+        {
+            TRAnimation animation = level.Animations[animationIndex];
+            TR2PackedAnimation packedAnimation = new TR2PackedAnimation
             {
-                TRAnimation animation = level.Animations[animationIndex];
-                TR2PackedAnimation packedAnimation = new TR2PackedAnimation
-                {
-                    Animation = animation,
-                };
-                definition.Animations[animationIndex] = packedAnimation;
+                Animation = animation,
+            };
+            definition.Animations[animationIndex] = packedAnimation;
 
-                AnimationUtilities.PackStateChanges(level, animation, packedAnimation);
-                AnimationUtilities.PackAnimCommands(level, animation, packedAnimation);
-                AnimationUtilities.PackAnimSounds(level, packedAnimation);
-            }
-
-            foreach (TR2PackedAnimation anim in definition.Animations.Values)
-            {
-                anim.Animation.FrameOffset -= definition.Model.FrameOffset;
-            }
-            definition.AnimationFrames = AnimationUtilities.GetAnimationFrames(level, definition.Model);
+            AnimationUtilities.PackStateChanges(level, animation, packedAnimation);
+            AnimationUtilities.PackAnimCommands(level, animation, packedAnimation);
+            AnimationUtilities.PackAnimSounds(level, packedAnimation);
         }
 
-        public void Export(TR3Level level, TR3ModelDefinition definition)
+        foreach (TR2PackedAnimation anim in definition.Animations.Values)
         {
-            definition.Animations = new Dictionary<int, TR3PackedAnimation>();
+            anim.Animation.FrameOffset -= definition.Model.FrameOffset;
+        }
+        definition.AnimationFrames = AnimationUtilities.GetAnimationFrames(level, definition.Model);
+    }
 
-            int endAnimation = AnimationUtilities.GetModelAnimationCount(level, definition.Model) + definition.Model.Animation;
-            for (int animationIndex = definition.Model.Animation; animationIndex < endAnimation; animationIndex++)
+    public void Export(TR3Level level, TR3ModelDefinition definition)
+    {
+        definition.Animations = new Dictionary<int, TR3PackedAnimation>();
+
+        int endAnimation = AnimationUtilities.GetModelAnimationCount(level, definition.Model) + definition.Model.Animation;
+        for (int animationIndex = definition.Model.Animation; animationIndex < endAnimation; animationIndex++)
+        {
+            TRAnimation animation = level.Animations[animationIndex];
+            TR3PackedAnimation packedAnimation = new TR3PackedAnimation
             {
-                TRAnimation animation = level.Animations[animationIndex];
-                TR3PackedAnimation packedAnimation = new TR3PackedAnimation
-                {
-                    Animation = animation,
-                };
-                definition.Animations[animationIndex] = packedAnimation;
+                Animation = animation,
+            };
+            definition.Animations[animationIndex] = packedAnimation;
 
-                AnimationUtilities.PackStateChanges(level, animation, packedAnimation);
-                AnimationUtilities.PackAnimCommands(level, animation, packedAnimation);
-                AnimationUtilities.PackAnimSounds(level, packedAnimation);
-            }
-
-            foreach (TR3PackedAnimation anim in definition.Animations.Values)
-            {
-                anim.Animation.FrameOffset -= definition.Model.FrameOffset;
-            }
-            definition.AnimationFrames = AnimationUtilities.GetAnimationFrames(level, definition.Model);
+            AnimationUtilities.PackStateChanges(level, animation, packedAnimation);
+            AnimationUtilities.PackAnimCommands(level, animation, packedAnimation);
+            AnimationUtilities.PackAnimSounds(level, packedAnimation);
         }
 
-        public void Import(TR1Level level, TR1ModelDefinition definition)
+        foreach (TR3PackedAnimation anim in definition.Animations.Values)
         {
-            Dictionary<int, TR1PackedAnimation> animations = definition.Animations;
-            bool firstAnimationConfigured = false;
-            Dictionary<int, int> indexMap = new Dictionary<int, int>();
+            anim.Animation.FrameOffset -= definition.Model.FrameOffset;
+        }
+        definition.AnimationFrames = AnimationUtilities.GetAnimationFrames(level, definition.Model);
+    }
 
-            List<TRAnimDispatch> animDispatches = level.AnimDispatches.ToList();
-            List<TRStateChange> stateChanges = level.StateChanges.ToList();
-            List<TRAnimCommand> animCommands = level.AnimCommands.ToList();
+    public void Import(TR1Level level, TR1ModelDefinition definition)
+    {
+        Dictionary<int, TR1PackedAnimation> animations = definition.Animations;
+        bool firstAnimationConfigured = false;
+        Dictionary<int, int> indexMap = new Dictionary<int, int>();
 
-            foreach (int oldAnimationIndex in animations.Keys)
+        List<TRAnimDispatch> animDispatches = level.AnimDispatches.ToList();
+        List<TRStateChange> stateChanges = level.StateChanges.ToList();
+        List<TRAnimCommand> animCommands = level.AnimCommands.ToList();
+
+        foreach (int oldAnimationIndex in animations.Keys)
+        {
+            TR1PackedAnimation packedAnimation = animations[oldAnimationIndex];
+            AnimationUtilities.UnpackStateChanges(animDispatches, stateChanges, packedAnimation);
+            AnimationUtilities.UnpackAnimSounds(level, packedAnimation);
+            AnimationUtilities.UnpackAnimCommands(animCommands, packedAnimation);
+
+            int newAnimationIndex = AnimationUtilities.UnpackAnimation(level, packedAnimation);
+            indexMap[oldAnimationIndex] = newAnimationIndex;
+
+            if (!firstAnimationConfigured)
             {
-                TR1PackedAnimation packedAnimation = animations[oldAnimationIndex];
-                AnimationUtilities.UnpackStateChanges(animDispatches, stateChanges, packedAnimation);
-                AnimationUtilities.UnpackAnimSounds(level, packedAnimation);
-                AnimationUtilities.UnpackAnimCommands(animCommands, packedAnimation);
+                definition.Model.Animation = (ushort)newAnimationIndex;
+                firstAnimationConfigured = true;
+            }
+        }
 
-                int newAnimationIndex = AnimationUtilities.UnpackAnimation(level, packedAnimation);
-                indexMap[oldAnimationIndex] = newAnimationIndex;
+        level.AnimDispatches = animDispatches.ToArray();
+        level.NumAnimDispatches = (uint)animDispatches.Count;
 
-                if (!firstAnimationConfigured)
+        level.StateChanges = stateChanges.ToArray();
+        level.NumStateChanges = (uint)stateChanges.Count;
+
+        level.AnimCommands = animCommands.ToArray();
+        level.NumAnimCommands = (uint)animCommands.Count;
+
+        // Re-map the NextAnimations of each of the animation and dispatches
+        // now we know the indices of each of the newly inserted animations.
+        foreach (TR1PackedAnimation packedAnimation in animations.Values)
+        {
+            packedAnimation.Animation.NextAnimation = (ushort)indexMap[packedAnimation.Animation.NextAnimation];
+            foreach (TRAnimDispatch dispatch in packedAnimation.AnimationDispatches.Values)
+            {
+                if (indexMap.ContainsKey(dispatch.NextAnimation))
                 {
-                    definition.Model.Animation = (ushort)newAnimationIndex;
-                    firstAnimationConfigured = true;
+                    dispatch.NextAnimation = (short)indexMap[dispatch.NextAnimation];
                 }
             }
+        }
 
-            level.AnimDispatches = animDispatches.ToArray();
-            level.NumAnimDispatches = (uint)animDispatches.Count;
+        SoundUtilities.ResortSoundIndices(level);
 
-            level.StateChanges = stateChanges.ToArray();
-            level.NumStateChanges = (uint)stateChanges.Count;
+        AnimationUtilities.ImportAnimationFrames(level, definition);
+    }
 
-            level.AnimCommands = animCommands.ToArray();
-            level.NumAnimCommands = (uint)animCommands.Count;
+    public void Import(TR2Level level, TR2ModelDefinition definition)
+    {
+        Dictionary<int, TR2PackedAnimation> animations = definition.Animations;
+        bool firstAnimationConfigured = false;
+        Dictionary<int, int> indexMap = new Dictionary<int, int>();
 
-            // Re-map the NextAnimations of each of the animation and dispatches
-            // now we know the indices of each of the newly inserted animations.
-            foreach (TR1PackedAnimation packedAnimation in animations.Values)
+        List<TRAnimDispatch> animDispatches = level.AnimDispatches.ToList();
+        List<TRStateChange> stateChanges = level.StateChanges.ToList();
+        List<TRAnimCommand> animCommands = level.AnimCommands.ToList();
+
+        foreach (int oldAnimationIndex in animations.Keys)
+        {
+            TR2PackedAnimation packedAnimation = animations[oldAnimationIndex];
+            AnimationUtilities.UnpackStateChanges(animDispatches, stateChanges, packedAnimation);
+            AnimationUtilities.UnpackAnimSounds(level, packedAnimation);
+            AnimationUtilities.UnpackAnimCommands(animCommands, packedAnimation);
+
+            int newAnimationIndex = AnimationUtilities.UnpackAnimation(level, packedAnimation);
+            indexMap[oldAnimationIndex] = newAnimationIndex;
+
+            if (!firstAnimationConfigured)
+            {
+                definition.Model.Animation = (ushort)newAnimationIndex;
+                firstAnimationConfigured = true;
+            }
+        }
+
+        level.AnimDispatches = animDispatches.ToArray();
+        level.NumAnimDispatches = (uint)animDispatches.Count;
+
+        level.StateChanges = stateChanges.ToArray();
+        level.NumStateChanges = (uint)stateChanges.Count;
+
+        level.AnimCommands = animCommands.ToArray();
+        level.NumAnimCommands = (uint)animCommands.Count;
+
+        foreach (TR2PackedAnimation packedAnimation in animations.Values)
+        {
+            packedAnimation.Animation.NextAnimation = (ushort)indexMap[packedAnimation.Animation.NextAnimation];
+            foreach (TRAnimDispatch dispatch in packedAnimation.AnimationDispatches.Values)
+            {
+                if (indexMap.ContainsKey(dispatch.NextAnimation))
+                {
+                    dispatch.NextAnimation = (short)indexMap[dispatch.NextAnimation];
+                }
+            }
+        }
+
+        // Inserting SampleIndices will break the game unless they are sorted numerically
+        // so handle this outwith the main animation insertion loop for ease.
+        SoundUtilities.ResortSoundIndices(level);
+
+        AnimationUtilities.ImportAnimationFrames(level, definition);
+    }
+
+    public void Import(TR3Level level, TR3ModelDefinition definition)
+    {
+        Dictionary<int, TR3PackedAnimation> animations = definition.Animations;
+        bool firstAnimationConfigured = false;
+        Dictionary<int, int> indexMap = new Dictionary<int, int>();
+
+        List<TRAnimDispatch> animDispatches = level.AnimDispatches.ToList();
+        List<TRStateChange> stateChanges = level.StateChanges.ToList();
+        List<TRAnimCommand> animCommands = level.AnimCommands.ToList();
+
+        foreach (int oldAnimationIndex in animations.Keys)
+        {
+            TR3PackedAnimation packedAnimation = animations[oldAnimationIndex];
+            AnimationUtilities.UnpackStateChanges(animDispatches, stateChanges, packedAnimation);
+            AnimationUtilities.UnpackAnimSounds(level, packedAnimation);
+            AnimationUtilities.UnpackAnimCommands(animCommands, packedAnimation);
+
+            int newAnimationIndex = AnimationUtilities.UnpackAnimation(level, packedAnimation);
+            indexMap[oldAnimationIndex] = newAnimationIndex;
+
+            if (!firstAnimationConfigured)
+            {
+                definition.Model.Animation = (ushort)newAnimationIndex;
+                firstAnimationConfigured = true;
+            }
+        }
+
+        level.AnimDispatches = animDispatches.ToArray();
+        level.NumAnimDispatches = (uint)animDispatches.Count;
+
+        level.StateChanges = stateChanges.ToArray();
+        level.NumStateChanges = (uint)stateChanges.Count;
+
+        level.AnimCommands = animCommands.ToArray();
+        level.NumAnimCommands = (uint)animCommands.Count;
+
+        foreach (TR3PackedAnimation packedAnimation in animations.Values)
+        {
+            if (indexMap.ContainsKey(packedAnimation.Animation.NextAnimation))
             {
                 packedAnimation.Animation.NextAnimation = (ushort)indexMap[packedAnimation.Animation.NextAnimation];
-                foreach (TRAnimDispatch dispatch in packedAnimation.AnimationDispatches.Values)
+            }
+            foreach (TRAnimDispatch dispatch in packedAnimation.AnimationDispatches.Values)
+            {
+                if (indexMap.ContainsKey(dispatch.NextAnimation))
                 {
-                    if (indexMap.ContainsKey(dispatch.NextAnimation))
-                    {
-                        dispatch.NextAnimation = (short)indexMap[dispatch.NextAnimation];
-                    }
+                    dispatch.NextAnimation = (short)indexMap[dispatch.NextAnimation];
                 }
             }
-
-            SoundUtilities.ResortSoundIndices(level);
-
-            AnimationUtilities.ImportAnimationFrames(level, definition);
         }
 
-        public void Import(TR2Level level, TR2ModelDefinition definition)
-        {
-            Dictionary<int, TR2PackedAnimation> animations = definition.Animations;
-            bool firstAnimationConfigured = false;
-            Dictionary<int, int> indexMap = new Dictionary<int, int>();
+        SoundUtilities.ResortSoundIndices(level);
 
-            List<TRAnimDispatch> animDispatches = level.AnimDispatches.ToList();
-            List<TRStateChange> stateChanges = level.StateChanges.ToList();
-            List<TRAnimCommand> animCommands = level.AnimCommands.ToList();
-
-            foreach (int oldAnimationIndex in animations.Keys)
-            {
-                TR2PackedAnimation packedAnimation = animations[oldAnimationIndex];
-                AnimationUtilities.UnpackStateChanges(animDispatches, stateChanges, packedAnimation);
-                AnimationUtilities.UnpackAnimSounds(level, packedAnimation);
-                AnimationUtilities.UnpackAnimCommands(animCommands, packedAnimation);
-
-                int newAnimationIndex = AnimationUtilities.UnpackAnimation(level, packedAnimation);
-                indexMap[oldAnimationIndex] = newAnimationIndex;
-
-                if (!firstAnimationConfigured)
-                {
-                    definition.Model.Animation = (ushort)newAnimationIndex;
-                    firstAnimationConfigured = true;
-                }
-            }
-
-            level.AnimDispatches = animDispatches.ToArray();
-            level.NumAnimDispatches = (uint)animDispatches.Count;
-
-            level.StateChanges = stateChanges.ToArray();
-            level.NumStateChanges = (uint)stateChanges.Count;
-
-            level.AnimCommands = animCommands.ToArray();
-            level.NumAnimCommands = (uint)animCommands.Count;
-
-            foreach (TR2PackedAnimation packedAnimation in animations.Values)
-            {
-                packedAnimation.Animation.NextAnimation = (ushort)indexMap[packedAnimation.Animation.NextAnimation];
-                foreach (TRAnimDispatch dispatch in packedAnimation.AnimationDispatches.Values)
-                {
-                    if (indexMap.ContainsKey(dispatch.NextAnimation))
-                    {
-                        dispatch.NextAnimation = (short)indexMap[dispatch.NextAnimation];
-                    }
-                }
-            }
-
-            // Inserting SampleIndices will break the game unless they are sorted numerically
-            // so handle this outwith the main animation insertion loop for ease.
-            SoundUtilities.ResortSoundIndices(level);
-
-            AnimationUtilities.ImportAnimationFrames(level, definition);
-        }
-
-        public void Import(TR3Level level, TR3ModelDefinition definition)
-        {
-            Dictionary<int, TR3PackedAnimation> animations = definition.Animations;
-            bool firstAnimationConfigured = false;
-            Dictionary<int, int> indexMap = new Dictionary<int, int>();
-
-            List<TRAnimDispatch> animDispatches = level.AnimDispatches.ToList();
-            List<TRStateChange> stateChanges = level.StateChanges.ToList();
-            List<TRAnimCommand> animCommands = level.AnimCommands.ToList();
-
-            foreach (int oldAnimationIndex in animations.Keys)
-            {
-                TR3PackedAnimation packedAnimation = animations[oldAnimationIndex];
-                AnimationUtilities.UnpackStateChanges(animDispatches, stateChanges, packedAnimation);
-                AnimationUtilities.UnpackAnimSounds(level, packedAnimation);
-                AnimationUtilities.UnpackAnimCommands(animCommands, packedAnimation);
-
-                int newAnimationIndex = AnimationUtilities.UnpackAnimation(level, packedAnimation);
-                indexMap[oldAnimationIndex] = newAnimationIndex;
-
-                if (!firstAnimationConfigured)
-                {
-                    definition.Model.Animation = (ushort)newAnimationIndex;
-                    firstAnimationConfigured = true;
-                }
-            }
-
-            level.AnimDispatches = animDispatches.ToArray();
-            level.NumAnimDispatches = (uint)animDispatches.Count;
-
-            level.StateChanges = stateChanges.ToArray();
-            level.NumStateChanges = (uint)stateChanges.Count;
-
-            level.AnimCommands = animCommands.ToArray();
-            level.NumAnimCommands = (uint)animCommands.Count;
-
-            foreach (TR3PackedAnimation packedAnimation in animations.Values)
-            {
-                if (indexMap.ContainsKey(packedAnimation.Animation.NextAnimation))
-                {
-                    packedAnimation.Animation.NextAnimation = (ushort)indexMap[packedAnimation.Animation.NextAnimation];
-                }
-                foreach (TRAnimDispatch dispatch in packedAnimation.AnimationDispatches.Values)
-                {
-                    if (indexMap.ContainsKey(dispatch.NextAnimation))
-                    {
-                        dispatch.NextAnimation = (short)indexMap[dispatch.NextAnimation];
-                    }
-                }
-            }
-
-            SoundUtilities.ResortSoundIndices(level);
-
-            AnimationUtilities.ImportAnimationFrames(level, definition);
-        }
+        AnimationUtilities.ImportAnimationFrames(level, definition);
     }
 }

--- a/TRModelTransporter/Handlers/Animations/AnimationTransportHandler.cs
+++ b/TRModelTransporter/Handlers/Animations/AnimationTransportHandler.cs
@@ -6,7 +6,7 @@ namespace TRModelTransporter.Handlers;
 
 public class AnimationTransportHandler
 {
-    public void Export(TR1Level level, TR1ModelDefinition definition)
+    public static void Export(TR1Level level, TR1ModelDefinition definition)
     {
         definition.Animations = new Dictionary<int, TR1PackedAnimation>();
 
@@ -32,7 +32,7 @@ public class AnimationTransportHandler
         definition.AnimationFrames = AnimationUtilities.GetAnimationFrames(level, definition.Model);
     }
 
-    public void Export(TR2Level level, TR2ModelDefinition definition)
+    public static void Export(TR2Level level, TR2ModelDefinition definition)
     {
         definition.Animations = new Dictionary<int, TR2PackedAnimation>();
 
@@ -58,7 +58,7 @@ public class AnimationTransportHandler
         definition.AnimationFrames = AnimationUtilities.GetAnimationFrames(level, definition.Model);
     }
 
-    public void Export(TR3Level level, TR3ModelDefinition definition)
+    public static void Export(TR3Level level, TR3ModelDefinition definition)
     {
         definition.Animations = new Dictionary<int, TR3PackedAnimation>();
 
@@ -84,7 +84,7 @@ public class AnimationTransportHandler
         definition.AnimationFrames = AnimationUtilities.GetAnimationFrames(level, definition.Model);
     }
 
-    public void Import(TR1Level level, TR1ModelDefinition definition)
+    public static void Import(TR1Level level, TR1ModelDefinition definition)
     {
         Dictionary<int, TR1PackedAnimation> animations = definition.Animations;
         bool firstAnimationConfigured = false;
@@ -139,7 +139,7 @@ public class AnimationTransportHandler
         AnimationUtilities.ImportAnimationFrames(level, definition);
     }
 
-    public void Import(TR2Level level, TR2ModelDefinition definition)
+    public static void Import(TR2Level level, TR2ModelDefinition definition)
     {
         Dictionary<int, TR2PackedAnimation> animations = definition.Animations;
         bool firstAnimationConfigured = false;
@@ -194,7 +194,7 @@ public class AnimationTransportHandler
         AnimationUtilities.ImportAnimationFrames(level, definition);
     }
 
-    public void Import(TR3Level level, TR3ModelDefinition definition)
+    public static void Import(TR3Level level, TR3ModelDefinition definition)
     {
         Dictionary<int, TR3PackedAnimation> animations = definition.Animations;
         bool firstAnimationConfigured = false;

--- a/TRModelTransporter/Handlers/Animations/AnimationUtilities.cs
+++ b/TRModelTransporter/Handlers/Animations/AnimationUtilities.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using TRLevelControl.Model;
+﻿using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;
 using TRModelTransporter.Model.Animations;
 using TRModelTransporter.Model.Definitions;

--- a/TRModelTransporter/Handlers/Animations/AnimationUtilities.cs
+++ b/TRModelTransporter/Handlers/Animations/AnimationUtilities.cs
@@ -5,562 +5,561 @@ using TRLevelControl.Model.Enums;
 using TRModelTransporter.Model.Animations;
 using TRModelTransporter.Model.Definitions;
 
-namespace TRModelTransporter.Handlers
+namespace TRModelTransporter.Handlers;
+
+public static class AnimationUtilities
 {
-    public static class AnimationUtilities
+    public static int GetModelAnimationCount(TR1Level level, TRModel model)
     {
-        public static int GetModelAnimationCount(TR1Level level, TRModel model)
-        {
-            return GetModelAnimationCount(level.Models, model, level.NumAnimations);
-        }
+        return GetModelAnimationCount(level.Models, model, level.NumAnimations);
+    }
 
-        public static int GetModelAnimationCount(TR2Level level, TRModel model)
-        {
-            return GetModelAnimationCount(level.Models, model, level.NumAnimations);
-        }
+    public static int GetModelAnimationCount(TR2Level level, TRModel model)
+    {
+        return GetModelAnimationCount(level.Models, model, level.NumAnimations);
+    }
 
-        public static int GetModelAnimationCount(TR3Level level, TRModel model)
-        {
-            return GetModelAnimationCount(level.Models, model, level.NumAnimations);
-        }
+    public static int GetModelAnimationCount(TR3Level level, TRModel model)
+    {
+        return GetModelAnimationCount(level.Models, model, level.NumAnimations);
+    }
 
-        public static int GetModelAnimationCount(TRModel[] models, TRModel model, uint totalAnimations)
+    public static int GetModelAnimationCount(TRModel[] models, TRModel model, uint totalAnimations)
+    {
+        TRModel nextModel = model;
+        int modelIndex = models.ToList().IndexOf(model) + 1;
+        while (modelIndex < models.Length)
         {
-            TRModel nextModel = model;
-            int modelIndex = models.ToList().IndexOf(model) + 1;
-            while (modelIndex < models.Length)
+            nextModel = models[modelIndex++];
+            if (nextModel.Animation != ushort.MaxValue)
             {
-                nextModel = models[modelIndex++];
-                if (nextModel.Animation != ushort.MaxValue)
+                break;
+            }
+        }
+
+        ushort nextStartAnimation = nextModel.Animation;
+        if (model == nextModel || nextStartAnimation == ushort.MaxValue)
+        {
+            nextStartAnimation = (ushort)totalAnimations;
+        }
+
+        return model.Animation == ushort.MaxValue ? 0 : nextStartAnimation - model.Animation;
+    }
+
+    public static void PackStateChanges(TR1Level level, TRAnimation animation, TR1PackedAnimation packedAnimation)
+    {
+        for (int stateChangeIndex = 0; stateChangeIndex < animation.NumStateChanges; stateChangeIndex++)
+        {
+            TRStateChange stateChange = level.StateChanges[animation.StateChangeOffset + stateChangeIndex];
+            packedAnimation.StateChanges.Add(stateChange);
+
+            int dispatchOffset = stateChange.AnimDispatch;
+            for (int i = 0; i < stateChange.NumAnimDispatches; i++, dispatchOffset++)
+            {
+                if (!packedAnimation.AnimationDispatches.ContainsKey(dispatchOffset))
                 {
+                    TRAnimDispatch dispatch = level.AnimDispatches[dispatchOffset];
+                    packedAnimation.AnimationDispatches[dispatchOffset] = dispatch;
+                }
+            }
+        }
+    }
+
+    public static void PackStateChanges(TR2Level level, TRAnimation animation, TR2PackedAnimation packedAnimation)
+    {
+        for (int stateChangeIndex = 0; stateChangeIndex < animation.NumStateChanges; stateChangeIndex++)
+        {
+            TRStateChange stateChange = level.StateChanges[animation.StateChangeOffset + stateChangeIndex];
+            packedAnimation.StateChanges.Add(stateChange);
+
+            int dispatchOffset = stateChange.AnimDispatch;
+            for (int i = 0; i < stateChange.NumAnimDispatches; i++, dispatchOffset++)
+            {
+                if (!packedAnimation.AnimationDispatches.ContainsKey(dispatchOffset))
+                {
+                    TRAnimDispatch dispatch = level.AnimDispatches[dispatchOffset];
+                    packedAnimation.AnimationDispatches[dispatchOffset] = dispatch;
+                }
+            }
+        }
+    }
+
+    public static void PackStateChanges(TR3Level level, TRAnimation animation, TR3PackedAnimation packedAnimation)
+    {
+        for (int stateChangeIndex = 0; stateChangeIndex < animation.NumStateChanges; stateChangeIndex++)
+        {
+            TRStateChange stateChange = level.StateChanges[animation.StateChangeOffset + stateChangeIndex];
+            packedAnimation.StateChanges.Add(stateChange);
+
+            int dispatchOffset = stateChange.AnimDispatch;
+            for (int i = 0; i < stateChange.NumAnimDispatches; i++, dispatchOffset++)
+            {
+                if (!packedAnimation.AnimationDispatches.ContainsKey(dispatchOffset))
+                {
+                    TRAnimDispatch dispatch = level.AnimDispatches[dispatchOffset];
+                    packedAnimation.AnimationDispatches[dispatchOffset] = dispatch;
+                }
+            }
+        }
+    }
+
+    public static void PackAnimCommands(TR1Level level, TRAnimation animation, TR1PackedAnimation packedAnimation)
+    {
+        packedAnimation.Commands = PackAnimCommands(level.AnimCommands, animation);
+    }
+
+    public static void PackAnimCommands(TR2Level level, TRAnimation animation, TR2PackedAnimation packedAnimation)
+    {
+        packedAnimation.Commands = PackAnimCommands(level.AnimCommands, animation);
+    }
+
+    public static void PackAnimCommands(TR3Level level, TRAnimation animation, TR3PackedAnimation packedAnimation)
+    {
+        packedAnimation.Commands = PackAnimCommands(level.AnimCommands, animation);
+    }
+
+    private static Dictionary<int, TR1PackedAnimationCommand> PackAnimCommands(TRAnimCommand[] animCommands, TRAnimation animation)
+    {
+        Dictionary<int, TR1PackedAnimationCommand> cmds = new Dictionary<int, TR1PackedAnimationCommand>();
+
+        int cmdOffset = animation.AnimCommand;
+        for (int i = 0; i < animation.NumAnimCommands; i++)
+        {
+            int cmdIndex = cmdOffset++;
+            TRAnimCommand cmd = animCommands[cmdIndex];
+
+            int paramCount;
+            switch ((TRAnimCommandTypes)cmd.Value)
+            {
+                case TRAnimCommandTypes.SetPosition:
+                    paramCount = 3;
                     break;
-                }
+                case TRAnimCommandTypes.JumpDistance:
+                case TRAnimCommandTypes.PlaySound:
+                case TRAnimCommandTypes.FlipEffect:
+                    paramCount = 2;
+                    break;
+                default:
+                    paramCount = 0;
+                    break;
             }
 
-            ushort nextStartAnimation = nextModel.Animation;
-            if (model == nextModel || nextStartAnimation == ushort.MaxValue)
+            short[] paramArr = new short[paramCount];
+            for (int j = 0; j < paramCount; j++)
             {
-                nextStartAnimation = (ushort)totalAnimations;
+                paramArr[j] = animCommands[cmdOffset++].Value;
             }
 
-            return model.Animation == ushort.MaxValue ? 0 : nextStartAnimation - model.Animation;
+            cmds[cmdIndex] = new TR1PackedAnimationCommand
+            {
+                Command = (TRAnimCommandTypes)cmd.Value,
+                Params = paramArr
+            };
         }
 
-        public static void PackStateChanges(TR1Level level, TRAnimation animation, TR1PackedAnimation packedAnimation)
-        {
-            for (int stateChangeIndex = 0; stateChangeIndex < animation.NumStateChanges; stateChangeIndex++)
-            {
-                TRStateChange stateChange = level.StateChanges[animation.StateChangeOffset + stateChangeIndex];
-                packedAnimation.StateChanges.Add(stateChange);
+        return cmds;
+    }
 
-                int dispatchOffset = stateChange.AnimDispatch;
-                for (int i = 0; i < stateChange.NumAnimDispatches; i++, dispatchOffset++)
+    public static void PackAnimSounds(TR1Level level, TR1PackedAnimation packedAnimation)
+    {
+        PackAnimSounds(level.SoundMap, level.SoundDetails, level.SampleIndices, level.Samples, packedAnimation);
+    }
+
+    public static void PackAnimSounds(TR2Level level, TR2PackedAnimation packedAnimation)
+    {
+        PackAnimSounds(level.SoundMap, level.SoundDetails, level.SampleIndices, packedAnimation);
+    }
+
+    public static void PackAnimSounds(TR3Level level, TR3PackedAnimation packedAnimation)
+    {
+        PackAnimSounds(level.SoundMap, level.SoundDetails, level.SampleIndices, packedAnimation);
+    }
+
+    // Covers TR1
+    private static void PackAnimSounds(short[] soundMap, TRSoundDetails[] soundDetails, uint[] sampleIndices, byte[] wavSamples, TR1PackedAnimation packedAnimation)
+    {
+        foreach (TR1PackedAnimationCommand cmd in packedAnimation.Commands.Values)
+        {
+            if (cmd.Command == TRAnimCommandTypes.PlaySound)
+            {
+                int soundMapIndex = cmd.Params[1] & 0x3fff;
+                short soundDetailsIndex = soundMap[soundMapIndex];
+                packedAnimation.Sound.SoundMapIndices[soundMapIndex] = soundDetailsIndex;
+                if (soundDetailsIndex != -1)
                 {
-                    if (!packedAnimation.AnimationDispatches.ContainsKey(dispatchOffset))
+                    TRSoundDetails details = soundDetails[soundDetailsIndex];
+                    packedAnimation.Sound.SoundDetails[soundDetailsIndex] = details;
+
+                    uint[] samples = new uint[details.NumSounds];
+                    for (int i = 0; i < details.NumSounds; i++)
                     {
-                        TRAnimDispatch dispatch = level.AnimDispatches[dispatchOffset];
-                        packedAnimation.AnimationDispatches[dispatchOffset] = dispatch;
+                        ushort sampleIndex = (ushort)(details.Sample + i);
+                        samples[i] = sampleIndices[sampleIndex];
+
+                        uint nextIndex = sampleIndex == sampleIndices.Length - 1 ? (uint)sampleIndices.Length : sampleIndices[sampleIndex + 1];
+                        packedAnimation.Sound.Samples[samples[i]] = GetSample(samples[i], nextIndex, wavSamples);
                     }
+
+                    packedAnimation.Sound.SampleIndices[details.Sample] = samples;
                 }
             }
         }
+    }
 
-        public static void PackStateChanges(TR2Level level, TRAnimation animation, TR2PackedAnimation packedAnimation)
+    public static byte[] GetSample(uint offset, uint endOffset, byte[] wavSamples)
+    {
+        List<byte> data = new List<byte>();
+        for (uint i = offset; i < endOffset; i++)
         {
-            for (int stateChangeIndex = 0; stateChangeIndex < animation.NumStateChanges; stateChangeIndex++)
-            {
-                TRStateChange stateChange = level.StateChanges[animation.StateChangeOffset + stateChangeIndex];
-                packedAnimation.StateChanges.Add(stateChange);
+            data.Add(wavSamples[i]);
+        }
+        return data.ToArray();
+    }
 
-                int dispatchOffset = stateChange.AnimDispatch;
-                for (int i = 0; i < stateChange.NumAnimDispatches; i++, dispatchOffset++)
+    // Covers TR2
+    private static void PackAnimSounds(short[] soundMap, TRSoundDetails[] soundDetails, uint[] sampleIndices, TR2PackedAnimation packedAnimation)
+    {
+        foreach (TR1PackedAnimationCommand cmd in packedAnimation.Commands.Values)
+        {
+            if (cmd.Command == TRAnimCommandTypes.PlaySound)
+            {
+                int soundMapIndex = cmd.Params[1] & 0x3fff;
+                short soundDetailsIndex = soundMap[soundMapIndex];
+                packedAnimation.Sound.SoundMapIndices[soundMapIndex] = soundDetailsIndex;
+                if (soundDetailsIndex != -1)
                 {
-                    if (!packedAnimation.AnimationDispatches.ContainsKey(dispatchOffset))
+                    TRSoundDetails details = soundDetails[soundDetailsIndex];
+                    packedAnimation.Sound.SoundDetails[soundDetailsIndex] = details;
+
+                    uint[] samples = new uint[details.NumSounds];
+                    for (int i = 0; i < details.NumSounds; i++)
                     {
-                        TRAnimDispatch dispatch = level.AnimDispatches[dispatchOffset];
-                        packedAnimation.AnimationDispatches[dispatchOffset] = dispatch;
+                        samples[i] = sampleIndices[(ushort)(details.Sample + i)];
                     }
+
+                    packedAnimation.Sound.SampleIndices[details.Sample] = samples;
                 }
             }
         }
+    }
 
-        public static void PackStateChanges(TR3Level level, TRAnimation animation, TR3PackedAnimation packedAnimation)
+    // Covers TR3-5
+    private static void PackAnimSounds(short[] soundMap, TR3SoundDetails[] soundDetails, uint[] sampleIndices, TR3PackedAnimation packedAnimation)
+    {
+        foreach (TR1PackedAnimationCommand cmd in packedAnimation.Commands.Values)
         {
-            for (int stateChangeIndex = 0; stateChangeIndex < animation.NumStateChanges; stateChangeIndex++)
+            if (cmd.Command == TRAnimCommandTypes.PlaySound)
             {
-                TRStateChange stateChange = level.StateChanges[animation.StateChangeOffset + stateChangeIndex];
-                packedAnimation.StateChanges.Add(stateChange);
-
-                int dispatchOffset = stateChange.AnimDispatch;
-                for (int i = 0; i < stateChange.NumAnimDispatches; i++, dispatchOffset++)
+                int soundMapIndex = cmd.Params[1] & 0x3fff;
+                short soundDetailsIndex = soundMap[soundMapIndex];
+                packedAnimation.Sound.SoundMapIndices[soundMapIndex] = soundDetailsIndex;
+                if (soundDetailsIndex != -1)
                 {
-                    if (!packedAnimation.AnimationDispatches.ContainsKey(dispatchOffset))
+                    TR3SoundDetails details = soundDetails[soundDetailsIndex];
+                    packedAnimation.Sound.SoundDetails[soundDetailsIndex] = details;
+
+                    uint[] samples = new uint[details.NumSounds];
+                    for (int i = 0; i < details.NumSounds; i++)
                     {
-                        TRAnimDispatch dispatch = level.AnimDispatches[dispatchOffset];
-                        packedAnimation.AnimationDispatches[dispatchOffset] = dispatch;
+                        samples[i] = sampleIndices[(ushort)(details.Sample + i)];
                     }
+
+                    packedAnimation.Sound.SampleIndices[details.Sample] = samples;
                 }
             }
         }
+    }
 
-        public static void PackAnimCommands(TR1Level level, TRAnimation animation, TR1PackedAnimation packedAnimation)
+    public static ushort[] GetAnimationFrames(TR1Level level, TRModel model)
+    {
+        return GetAnimationFrames(model, level.Models, level.Frames);
+    }
+
+    public static ushort[] GetAnimationFrames(TR2Level level, TRModel model)
+    {
+        return GetAnimationFrames(model, level.Models, level.Frames);
+    }
+
+    public static ushort[] GetAnimationFrames(TR3Level level, TRModel model)
+    {
+        return GetAnimationFrames(model, level.Models, level.Frames);
+    }
+
+    public static ushort[] GetAnimationFrames(TRModel model, TRModel[] allModels, ushort[] allFrames)
+    {
+        int modelIndex = allModels.ToList().IndexOf(model);
+        uint endFrame = 0;
+        if (modelIndex == allModels.Length - 1)
         {
-            packedAnimation.Commands = PackAnimCommands(level.AnimCommands, animation);
+            endFrame = (uint)allFrames.Length;
         }
-
-        public static void PackAnimCommands(TR2Level level, TRAnimation animation, TR2PackedAnimation packedAnimation)
+        else
         {
-            packedAnimation.Commands = PackAnimCommands(level.AnimCommands, animation);
-        }
-
-        public static void PackAnimCommands(TR3Level level, TRAnimation animation, TR3PackedAnimation packedAnimation)
-        {
-            packedAnimation.Commands = PackAnimCommands(level.AnimCommands, animation);
-        }
-
-        private static Dictionary<int, TR1PackedAnimationCommand> PackAnimCommands(TRAnimCommand[] animCommands, TRAnimation animation)
-        {
-            Dictionary<int, TR1PackedAnimationCommand> cmds = new Dictionary<int, TR1PackedAnimationCommand>();
-
-            int cmdOffset = animation.AnimCommand;
-            for (int i = 0; i < animation.NumAnimCommands; i++)
+            while (endFrame == 0 && modelIndex < allModels.Length)
             {
-                int cmdIndex = cmdOffset++;
-                TRAnimCommand cmd = animCommands[cmdIndex];
-
-                int paramCount;
-                switch ((TRAnimCommandTypes)cmd.Value)
-                {
-                    case TRAnimCommandTypes.SetPosition:
-                        paramCount = 3;
-                        break;
-                    case TRAnimCommandTypes.JumpDistance:
-                    case TRAnimCommandTypes.PlaySound:
-                    case TRAnimCommandTypes.FlipEffect:
-                        paramCount = 2;
-                        break;
-                    default:
-                        paramCount = 0;
-                        break;
-                }
-
-                short[] paramArr = new short[paramCount];
-                for (int j = 0; j < paramCount; j++)
-                {
-                    paramArr[j] = animCommands[cmdOffset++].Value;
-                }
-
-                cmds[cmdIndex] = new TR1PackedAnimationCommand
-                {
-                    Command = (TRAnimCommandTypes)cmd.Value,
-                    Params = paramArr
-                };
-            }
-
-            return cmds;
-        }
-
-        public static void PackAnimSounds(TR1Level level, TR1PackedAnimation packedAnimation)
-        {
-            PackAnimSounds(level.SoundMap, level.SoundDetails, level.SampleIndices, level.Samples, packedAnimation);
-        }
-
-        public static void PackAnimSounds(TR2Level level, TR2PackedAnimation packedAnimation)
-        {
-            PackAnimSounds(level.SoundMap, level.SoundDetails, level.SampleIndices, packedAnimation);
-        }
-
-        public static void PackAnimSounds(TR3Level level, TR3PackedAnimation packedAnimation)
-        {
-            PackAnimSounds(level.SoundMap, level.SoundDetails, level.SampleIndices, packedAnimation);
-        }
-
-        // Covers TR1
-        private static void PackAnimSounds(short[] soundMap, TRSoundDetails[] soundDetails, uint[] sampleIndices, byte[] wavSamples, TR1PackedAnimation packedAnimation)
-        {
-            foreach (TR1PackedAnimationCommand cmd in packedAnimation.Commands.Values)
-            {
-                if (cmd.Command == TRAnimCommandTypes.PlaySound)
-                {
-                    int soundMapIndex = cmd.Params[1] & 0x3fff;
-                    short soundDetailsIndex = soundMap[soundMapIndex];
-                    packedAnimation.Sound.SoundMapIndices[soundMapIndex] = soundDetailsIndex;
-                    if (soundDetailsIndex != -1)
-                    {
-                        TRSoundDetails details = soundDetails[soundDetailsIndex];
-                        packedAnimation.Sound.SoundDetails[soundDetailsIndex] = details;
-
-                        uint[] samples = new uint[details.NumSounds];
-                        for (int i = 0; i < details.NumSounds; i++)
-                        {
-                            ushort sampleIndex = (ushort)(details.Sample + i);
-                            samples[i] = sampleIndices[sampleIndex];
-
-                            uint nextIndex = sampleIndex == sampleIndices.Length - 1 ? (uint)sampleIndices.Length : sampleIndices[sampleIndex + 1];
-                            packedAnimation.Sound.Samples[samples[i]] = GetSample(samples[i], nextIndex, wavSamples);
-                        }
-
-                        packedAnimation.Sound.SampleIndices[details.Sample] = samples;
-                    }
-                }
+                endFrame = allModels[++modelIndex].FrameOffset / 2;
             }
         }
 
-        public static byte[] GetSample(uint offset, uint endOffset, byte[] wavSamples)
+        List<ushort> frames = new List<ushort>();
+        for (uint i = model.FrameOffset / 2; i < endFrame; i++)
         {
-            List<byte> data = new List<byte>();
-            for (uint i = offset; i < endOffset; i++)
-            {
-                data.Add(wavSamples[i]);
-            }
-            return data.ToArray();
+            frames.Add(allFrames[i]);
         }
 
-        // Covers TR2
-        private static void PackAnimSounds(short[] soundMap, TRSoundDetails[] soundDetails, uint[] sampleIndices, TR2PackedAnimation packedAnimation)
+        return frames.ToArray();
+    }
+
+    public static void UnpackStateChanges(List<TRAnimDispatch> animDispatches, List<TRStateChange> stateChanges, TR1PackedAnimation packedAnimation)
+    {
+        if (packedAnimation.Animation.NumStateChanges == 0)
         {
-            foreach (TR1PackedAnimationCommand cmd in packedAnimation.Commands.Values)
-            {
-                if (cmd.Command == TRAnimCommandTypes.PlaySound)
-                {
-                    int soundMapIndex = cmd.Params[1] & 0x3fff;
-                    short soundDetailsIndex = soundMap[soundMapIndex];
-                    packedAnimation.Sound.SoundMapIndices[soundMapIndex] = soundDetailsIndex;
-                    if (soundDetailsIndex != -1)
-                    {
-                        TRSoundDetails details = soundDetails[soundDetailsIndex];
-                        packedAnimation.Sound.SoundDetails[soundDetailsIndex] = details;
-
-                        uint[] samples = new uint[details.NumSounds];
-                        for (int i = 0; i < details.NumSounds; i++)
-                        {
-                            samples[i] = sampleIndices[(ushort)(details.Sample + i)];
-                        }
-
-                        packedAnimation.Sound.SampleIndices[details.Sample] = samples;
-                    }
-                }
-            }
+            return;
         }
 
-        // Covers TR3-5
-        private static void PackAnimSounds(short[] soundMap, TR3SoundDetails[] soundDetails, uint[] sampleIndices, TR3PackedAnimation packedAnimation)
+        // Import the AnimDispatches first, noting their new indices            
+        Dictionary<int, int> indexMap = new Dictionary<int, int>();
+        foreach (int oldDispatchIndex in packedAnimation.AnimationDispatches.Keys)
         {
-            foreach (TR1PackedAnimationCommand cmd in packedAnimation.Commands.Values)
-            {
-                if (cmd.Command == TRAnimCommandTypes.PlaySound)
-                {
-                    int soundMapIndex = cmd.Params[1] & 0x3fff;
-                    short soundDetailsIndex = soundMap[soundMapIndex];
-                    packedAnimation.Sound.SoundMapIndices[soundMapIndex] = soundDetailsIndex;
-                    if (soundDetailsIndex != -1)
-                    {
-                        TR3SoundDetails details = soundDetails[soundDetailsIndex];
-                        packedAnimation.Sound.SoundDetails[soundDetailsIndex] = details;
-
-                        uint[] samples = new uint[details.NumSounds];
-                        for (int i = 0; i < details.NumSounds; i++)
-                        {
-                            samples[i] = sampleIndices[(ushort)(details.Sample + i)];
-                        }
-
-                        packedAnimation.Sound.SampleIndices[details.Sample] = samples;
-                    }
-                }
-            }
+            TRAnimDispatch dispatch = packedAnimation.AnimationDispatches[oldDispatchIndex];
+            indexMap[oldDispatchIndex] = animDispatches.Count;
+            animDispatches.Add(dispatch);
         }
 
-        public static ushort[] GetAnimationFrames(TR1Level level, TRModel model)
+        // The animation's StateChangeOffset will be the current length of level StateChanges
+        packedAnimation.Animation.StateChangeOffset = (ushort)stateChanges.Count;
+
+        // Import Each state change, re-mapping AnimDispatch to new index
+        foreach (TRStateChange stateChange in packedAnimation.StateChanges)
         {
-            return GetAnimationFrames(model, level.Models, level.Frames);
+            stateChange.AnimDispatch = (ushort)indexMap[stateChange.AnimDispatch];
+            stateChanges.Add(stateChange);
+        }
+    }
+
+    public static void UnpackStateChanges(List<TRAnimDispatch> animDispatches, List<TRStateChange> stateChanges, TR2PackedAnimation packedAnimation)
+    {
+        if (packedAnimation.Animation.NumStateChanges == 0)
+        {
+            return;
         }
 
-        public static ushort[] GetAnimationFrames(TR2Level level, TRModel model)
+        // Import the AnimDispatches first, noting their new indices            
+        Dictionary<int, int> indexMap = new Dictionary<int, int>();
+        foreach (int oldDispatchIndex in packedAnimation.AnimationDispatches.Keys)
         {
-            return GetAnimationFrames(model, level.Models, level.Frames);
+            TRAnimDispatch dispatch = packedAnimation.AnimationDispatches[oldDispatchIndex];
+            indexMap[oldDispatchIndex] = animDispatches.Count;
+            animDispatches.Add(dispatch);
         }
 
-        public static ushort[] GetAnimationFrames(TR3Level level, TRModel model)
+        // The animation's StateChangeOffset will be the current length of level StateChanges
+        packedAnimation.Animation.StateChangeOffset = (ushort)stateChanges.Count;
+
+        // Import Each state change, re-mapping AnimDispatch to new index
+        foreach (TRStateChange stateChange in packedAnimation.StateChanges)
         {
-            return GetAnimationFrames(model, level.Models, level.Frames);
+            stateChange.AnimDispatch = (ushort)indexMap[stateChange.AnimDispatch];
+            stateChanges.Add(stateChange);
+        }
+    }
+
+    public static void UnpackStateChanges(List<TRAnimDispatch> animDispatches, List<TRStateChange> stateChanges, TR3PackedAnimation packedAnimation)
+    {
+        if (packedAnimation.Animation.NumStateChanges == 0)
+        {
+            return;
         }
 
-        public static ushort[] GetAnimationFrames(TRModel model, TRModel[] allModels, ushort[] allFrames)
+        // Import the AnimDispatches first, noting their new indices            
+        Dictionary<int, int> indexMap = new Dictionary<int, int>();
+        foreach (int oldDispatchIndex in packedAnimation.AnimationDispatches.Keys)
         {
-            int modelIndex = allModels.ToList().IndexOf(model);
-            uint endFrame = 0;
-            if (modelIndex == allModels.Length - 1)
-            {
-                endFrame = (uint)allFrames.Length;
-            }
-            else
-            {
-                while (endFrame == 0 && modelIndex < allModels.Length)
-                {
-                    endFrame = allModels[++modelIndex].FrameOffset / 2;
-                }
-            }
-
-            List<ushort> frames = new List<ushort>();
-            for (uint i = model.FrameOffset / 2; i < endFrame; i++)
-            {
-                frames.Add(allFrames[i]);
-            }
-
-            return frames.ToArray();
+            TRAnimDispatch dispatch = packedAnimation.AnimationDispatches[oldDispatchIndex];
+            indexMap[oldDispatchIndex] = animDispatches.Count;
+            animDispatches.Add(dispatch);
         }
 
-        public static void UnpackStateChanges(List<TRAnimDispatch> animDispatches, List<TRStateChange> stateChanges, TR1PackedAnimation packedAnimation)
+        // The animation's StateChangeOffset will be the current length of level StateChanges
+        packedAnimation.Animation.StateChangeOffset = (ushort)stateChanges.Count;
+
+        // Import Each state change, re-mapping AnimDispatch to new index
+        foreach (TRStateChange stateChange in packedAnimation.StateChanges)
         {
-            if (packedAnimation.Animation.NumStateChanges == 0)
-            {
-                return;
-            }
+            stateChange.AnimDispatch = (ushort)indexMap[stateChange.AnimDispatch];
+            stateChanges.Add(stateChange);
+        }
+    }
 
-            // Import the AnimDispatches first, noting their new indices            
-            Dictionary<int, int> indexMap = new Dictionary<int, int>();
-            foreach (int oldDispatchIndex in packedAnimation.AnimationDispatches.Keys)
-            {
-                TRAnimDispatch dispatch = packedAnimation.AnimationDispatches[oldDispatchIndex];
-                indexMap[oldDispatchIndex] = animDispatches.Count;
-                animDispatches.Add(dispatch);
-            }
-
-            // The animation's StateChangeOffset will be the current length of level StateChanges
-            packedAnimation.Animation.StateChangeOffset = (ushort)stateChanges.Count;
-
-            // Import Each state change, re-mapping AnimDispatch to new index
-            foreach (TRStateChange stateChange in packedAnimation.StateChanges)
-            {
-                stateChange.AnimDispatch = (ushort)indexMap[stateChange.AnimDispatch];
-                stateChanges.Add(stateChange);
-            }
+    /**
+     * Commands are packed into CmdType + Params, but these are just 
+     * translated straight back into normal TRAnimCommands.
+     */
+    public static void UnpackAnimCommands(List<TRAnimCommand> levelAnimCommands, TR1PackedAnimation packedAnimation)
+    {
+        if (packedAnimation.Commands.Count == 0)
+        {
+            return;
         }
 
-        public static void UnpackStateChanges(List<TRAnimDispatch> animDispatches, List<TRStateChange> stateChanges, TR2PackedAnimation packedAnimation)
+        packedAnimation.Animation.AnimCommand = (ushort)levelAnimCommands.Count;
+        foreach (TR1PackedAnimationCommand cmd in packedAnimation.Commands.Values)
         {
-            if (packedAnimation.Animation.NumStateChanges == 0)
+            levelAnimCommands.Add(new TRAnimCommand { Value = (short)cmd.Command });
+            foreach (short param in cmd.Params)
             {
-                return;
-            }
-
-            // Import the AnimDispatches first, noting their new indices            
-            Dictionary<int, int> indexMap = new Dictionary<int, int>();
-            foreach (int oldDispatchIndex in packedAnimation.AnimationDispatches.Keys)
-            {
-                TRAnimDispatch dispatch = packedAnimation.AnimationDispatches[oldDispatchIndex];
-                indexMap[oldDispatchIndex] = animDispatches.Count;
-                animDispatches.Add(dispatch);
-            }
-
-            // The animation's StateChangeOffset will be the current length of level StateChanges
-            packedAnimation.Animation.StateChangeOffset = (ushort)stateChanges.Count;
-
-            // Import Each state change, re-mapping AnimDispatch to new index
-            foreach (TRStateChange stateChange in packedAnimation.StateChanges)
-            {
-                stateChange.AnimDispatch = (ushort)indexMap[stateChange.AnimDispatch];
-                stateChanges.Add(stateChange);
+                levelAnimCommands.Add(new TRAnimCommand { Value = param });
             }
         }
+    }
 
-        public static void UnpackStateChanges(List<TRAnimDispatch> animDispatches, List<TRStateChange> stateChanges, TR3PackedAnimation packedAnimation)
+    public static void UnpackAnimCommands(List<TRAnimCommand> levelAnimCommands, TR2PackedAnimation packedAnimation)
+    {
+        if (packedAnimation.Commands.Count == 0)
         {
-            if (packedAnimation.Animation.NumStateChanges == 0)
-            {
-                return;
-            }
-
-            // Import the AnimDispatches first, noting their new indices            
-            Dictionary<int, int> indexMap = new Dictionary<int, int>();
-            foreach (int oldDispatchIndex in packedAnimation.AnimationDispatches.Keys)
-            {
-                TRAnimDispatch dispatch = packedAnimation.AnimationDispatches[oldDispatchIndex];
-                indexMap[oldDispatchIndex] = animDispatches.Count;
-                animDispatches.Add(dispatch);
-            }
-
-            // The animation's StateChangeOffset will be the current length of level StateChanges
-            packedAnimation.Animation.StateChangeOffset = (ushort)stateChanges.Count;
-
-            // Import Each state change, re-mapping AnimDispatch to new index
-            foreach (TRStateChange stateChange in packedAnimation.StateChanges)
-            {
-                stateChange.AnimDispatch = (ushort)indexMap[stateChange.AnimDispatch];
-                stateChanges.Add(stateChange);
-            }
+            return;
         }
 
-        /**
-         * Commands are packed into CmdType + Params, but these are just 
-         * translated straight back into normal TRAnimCommands.
-         */
-        public static void UnpackAnimCommands(List<TRAnimCommand> levelAnimCommands, TR1PackedAnimation packedAnimation)
+        packedAnimation.Animation.AnimCommand = (ushort)levelAnimCommands.Count;
+        foreach (TR1PackedAnimationCommand cmd in packedAnimation.Commands.Values)
         {
-            if (packedAnimation.Commands.Count == 0)
+            levelAnimCommands.Add(new TRAnimCommand { Value = (short)cmd.Command });
+            foreach (short param in cmd.Params)
             {
-                return;
-            }
-
-            packedAnimation.Animation.AnimCommand = (ushort)levelAnimCommands.Count;
-            foreach (TR1PackedAnimationCommand cmd in packedAnimation.Commands.Values)
-            {
-                levelAnimCommands.Add(new TRAnimCommand { Value = (short)cmd.Command });
-                foreach (short param in cmd.Params)
-                {
-                    levelAnimCommands.Add(new TRAnimCommand { Value = param });
-                }
+                levelAnimCommands.Add(new TRAnimCommand { Value = param });
             }
         }
+    }
 
-        public static void UnpackAnimCommands(List<TRAnimCommand> levelAnimCommands, TR2PackedAnimation packedAnimation)
+    public static void UnpackAnimCommands(List<TRAnimCommand> levelAnimCommands, TR3PackedAnimation packedAnimation)
+    {
+        if (packedAnimation.Commands.Count == 0)
         {
-            if (packedAnimation.Commands.Count == 0)
-            {
-                return;
-            }
-
-            packedAnimation.Animation.AnimCommand = (ushort)levelAnimCommands.Count;
-            foreach (TR1PackedAnimationCommand cmd in packedAnimation.Commands.Values)
-            {
-                levelAnimCommands.Add(new TRAnimCommand { Value = (short)cmd.Command });
-                foreach (short param in cmd.Params)
-                {
-                    levelAnimCommands.Add(new TRAnimCommand { Value = param });
-                }
-            }
+            return;
         }
 
-        public static void UnpackAnimCommands(List<TRAnimCommand> levelAnimCommands, TR3PackedAnimation packedAnimation)
+        packedAnimation.Animation.AnimCommand = (ushort)levelAnimCommands.Count;
+        foreach (TR1PackedAnimationCommand cmd in packedAnimation.Commands.Values)
         {
-            if (packedAnimation.Commands.Count == 0)
+            levelAnimCommands.Add(new TRAnimCommand { Value = (short)cmd.Command });
+            foreach (short param in cmd.Params)
             {
-                return;
-            }
-
-            packedAnimation.Animation.AnimCommand = (ushort)levelAnimCommands.Count;
-            foreach (TR1PackedAnimationCommand cmd in packedAnimation.Commands.Values)
-            {
-                levelAnimCommands.Add(new TRAnimCommand { Value = (short)cmd.Command });
-                foreach (short param in cmd.Params)
-                {
-                    levelAnimCommands.Add(new TRAnimCommand { Value = param });
-                }
+                levelAnimCommands.Add(new TRAnimCommand { Value = param });
             }
         }
+    }
 
-        public static void UnpackAnimSounds(TR1Level level, TR1PackedAnimation packedAnimation)
-        {
-            SoundUnpacker soundUnpacker = new SoundUnpacker();
-            soundUnpacker.Unpack(packedAnimation.Sound, level, false);
-            RemapSoundIndices(packedAnimation.Commands.Values, soundUnpacker.SoundIndexMap);
-        }
+    public static void UnpackAnimSounds(TR1Level level, TR1PackedAnimation packedAnimation)
+    {
+        SoundUnpacker soundUnpacker = new SoundUnpacker();
+        soundUnpacker.Unpack(packedAnimation.Sound, level, false);
+        RemapSoundIndices(packedAnimation.Commands.Values, soundUnpacker.SoundIndexMap);
+    }
 
-        public static void UnpackAnimSounds(TR2Level level, TR2PackedAnimation packedAnimation)
-        {
-            SoundUnpacker soundUnpacker = new SoundUnpacker();
-            soundUnpacker.Unpack(packedAnimation.Sound, level, false);
-            RemapSoundIndices(packedAnimation.Commands.Values, soundUnpacker.SoundIndexMap);
-        }
+    public static void UnpackAnimSounds(TR2Level level, TR2PackedAnimation packedAnimation)
+    {
+        SoundUnpacker soundUnpacker = new SoundUnpacker();
+        soundUnpacker.Unpack(packedAnimation.Sound, level, false);
+        RemapSoundIndices(packedAnimation.Commands.Values, soundUnpacker.SoundIndexMap);
+    }
 
-        public static void UnpackAnimSounds(TR3Level level, TR3PackedAnimation packedAnimation)
-        {
-            SoundUnpacker soundUnpacker = new SoundUnpacker();
-            soundUnpacker.Unpack(packedAnimation.Sound, level, false);
-            RemapSoundIndices(packedAnimation.Commands.Values, soundUnpacker.SoundIndexMap);
-        }
+    public static void UnpackAnimSounds(TR3Level level, TR3PackedAnimation packedAnimation)
+    {
+        SoundUnpacker soundUnpacker = new SoundUnpacker();
+        soundUnpacker.Unpack(packedAnimation.Sound, level, false);
+        RemapSoundIndices(packedAnimation.Commands.Values, soundUnpacker.SoundIndexMap);
+    }
 
-        private static void RemapSoundIndices(IEnumerable<TR1PackedAnimationCommand> commands, IReadOnlyDictionary<int, int> soundIndexMap)
+    private static void RemapSoundIndices(IEnumerable<TR1PackedAnimationCommand> commands, IReadOnlyDictionary<int, int> soundIndexMap)
+    {
+        // Change the Params[1] value of each PlaySound AnimCommand to point to the
+        // new index in SoundMap.
+        foreach (TR1PackedAnimationCommand cmd in commands)
         {
-            // Change the Params[1] value of each PlaySound AnimCommand to point to the
-            // new index in SoundMap.
-            foreach (TR1PackedAnimationCommand cmd in commands)
+            if (cmd.Command == TRAnimCommandTypes.PlaySound)
             {
-                if (cmd.Command == TRAnimCommandTypes.PlaySound)
-                {
-                    int oldSoundMapIndex = cmd.Params[1] & 0x3fff;
-                    int newSoundMapIndex = soundIndexMap[oldSoundMapIndex];
+                int oldSoundMapIndex = cmd.Params[1] & 0x3fff;
+                int newSoundMapIndex = soundIndexMap[oldSoundMapIndex];
 
-                    int param = cmd.Params[1] & ~oldSoundMapIndex;
-                    param |= newSoundMapIndex;
-                    cmd.Params[1] = (short)param;
-                }
+                int param = cmd.Params[1] & ~oldSoundMapIndex;
+                param |= newSoundMapIndex;
+                cmd.Params[1] = (short)param;
             }
         }
+    }
 
-        public static int UnpackAnimation(TR1Level level, TR1PackedAnimation animation)
+    public static int UnpackAnimation(TR1Level level, TR1PackedAnimation animation)
+    {
+        List<TRAnimation> levelAnimations = level.Animations.ToList();
+        levelAnimations.Add(animation.Animation);
+        level.Animations = levelAnimations.ToArray();
+        level.NumAnimations++;
+
+        return levelAnimations.Count - 1;
+    }
+
+    public static int UnpackAnimation(TR2Level level, TR2PackedAnimation animation)
+    {
+        List<TRAnimation> levelAnimations = level.Animations.ToList();
+        levelAnimations.Add(animation.Animation);
+        level.Animations = levelAnimations.ToArray();
+        level.NumAnimations++;
+
+        return levelAnimations.Count - 1;
+    }
+
+    public static int UnpackAnimation(TR3Level level, TR3PackedAnimation animation)
+    {
+        List<TRAnimation> levelAnimations = level.Animations.ToList();
+        levelAnimations.Add(animation.Animation);
+        level.Animations = levelAnimations.ToArray();
+        level.NumAnimations++;
+
+        return levelAnimations.Count - 1;
+    }
+
+    public static void ImportAnimationFrames(TR1Level level, TR1ModelDefinition definition)
+    {
+        List<ushort> levelFrames = level.Frames.ToList();
+        definition.Model.FrameOffset = (uint)levelFrames.Count * 2;
+
+        levelFrames.AddRange(definition.AnimationFrames);
+        level.Frames = levelFrames.ToArray();
+        level.NumFrames = (uint)levelFrames.Count;
+
+        foreach (TR1PackedAnimation packedAnimation in definition.Animations.Values)
         {
-            List<TRAnimation> levelAnimations = level.Animations.ToList();
-            levelAnimations.Add(animation.Animation);
-            level.Animations = levelAnimations.ToArray();
-            level.NumAnimations++;
-
-            return levelAnimations.Count - 1;
+            packedAnimation.Animation.FrameOffset += definition.Model.FrameOffset;
         }
+    }
 
-        public static int UnpackAnimation(TR2Level level, TR2PackedAnimation animation)
+    public static void ImportAnimationFrames(TR2Level level, TR2ModelDefinition definition)
+    {
+        List<ushort> levelFrames = level.Frames.ToList();
+        definition.Model.FrameOffset = (uint)levelFrames.Count * 2;
+
+        levelFrames.AddRange(definition.AnimationFrames);
+        level.Frames = levelFrames.ToArray();
+        level.NumFrames = (uint)levelFrames.Count;
+
+        foreach (TR2PackedAnimation packedAnimation in definition.Animations.Values)
         {
-            List<TRAnimation> levelAnimations = level.Animations.ToList();
-            levelAnimations.Add(animation.Animation);
-            level.Animations = levelAnimations.ToArray();
-            level.NumAnimations++;
-
-            return levelAnimations.Count - 1;
+            packedAnimation.Animation.FrameOffset += definition.Model.FrameOffset;
         }
+    }
 
-        public static int UnpackAnimation(TR3Level level, TR3PackedAnimation animation)
+    public static void ImportAnimationFrames(TR3Level level, TR3ModelDefinition definition)
+    {
+        List<ushort> levelFrames = level.Frames.ToList();
+        definition.Model.FrameOffset = (uint)levelFrames.Count * 2;
+
+        levelFrames.AddRange(definition.AnimationFrames);
+        level.Frames = levelFrames.ToArray();
+        level.NumFrames = (uint)levelFrames.Count;
+
+        foreach (TR3PackedAnimation packedAnimation in definition.Animations.Values)
         {
-            List<TRAnimation> levelAnimations = level.Animations.ToList();
-            levelAnimations.Add(animation.Animation);
-            level.Animations = levelAnimations.ToArray();
-            level.NumAnimations++;
-
-            return levelAnimations.Count - 1;
-        }
-
-        public static void ImportAnimationFrames(TR1Level level, TR1ModelDefinition definition)
-        {
-            List<ushort> levelFrames = level.Frames.ToList();
-            definition.Model.FrameOffset = (uint)levelFrames.Count * 2;
-
-            levelFrames.AddRange(definition.AnimationFrames);
-            level.Frames = levelFrames.ToArray();
-            level.NumFrames = (uint)levelFrames.Count;
-
-            foreach (TR1PackedAnimation packedAnimation in definition.Animations.Values)
-            {
-                packedAnimation.Animation.FrameOffset += definition.Model.FrameOffset;
-            }
-        }
-
-        public static void ImportAnimationFrames(TR2Level level, TR2ModelDefinition definition)
-        {
-            List<ushort> levelFrames = level.Frames.ToList();
-            definition.Model.FrameOffset = (uint)levelFrames.Count * 2;
-
-            levelFrames.AddRange(definition.AnimationFrames);
-            level.Frames = levelFrames.ToArray();
-            level.NumFrames = (uint)levelFrames.Count;
-
-            foreach (TR2PackedAnimation packedAnimation in definition.Animations.Values)
-            {
-                packedAnimation.Animation.FrameOffset += definition.Model.FrameOffset;
-            }
-        }
-
-        public static void ImportAnimationFrames(TR3Level level, TR3ModelDefinition definition)
-        {
-            List<ushort> levelFrames = level.Frames.ToList();
-            definition.Model.FrameOffset = (uint)levelFrames.Count * 2;
-
-            levelFrames.AddRange(definition.AnimationFrames);
-            level.Frames = levelFrames.ToArray();
-            level.NumFrames = (uint)levelFrames.Count;
-
-            foreach (TR3PackedAnimation packedAnimation in definition.Animations.Values)
-            {
-                packedAnimation.Animation.FrameOffset += definition.Model.FrameOffset;
-            }
+            packedAnimation.Animation.FrameOffset += definition.Model.FrameOffset;
         }
     }
 }

--- a/TRModelTransporter/Handlers/Animations/AnimationUtilities.cs
+++ b/TRModelTransporter/Handlers/Animations/AnimationUtilities.cs
@@ -118,7 +118,7 @@ public static class AnimationUtilities
 
     private static Dictionary<int, TR1PackedAnimationCommand> PackAnimCommands(TRAnimCommand[] animCommands, TRAnimation animation)
     {
-        Dictionary<int, TR1PackedAnimationCommand> cmds = new Dictionary<int, TR1PackedAnimationCommand>();
+        Dictionary<int, TR1PackedAnimationCommand> cmds = new();
 
         int cmdOffset = animation.AnimCommand;
         for (int i = 0; i < animation.NumAnimCommands; i++)
@@ -206,7 +206,7 @@ public static class AnimationUtilities
 
     public static byte[] GetSample(uint offset, uint endOffset, byte[] wavSamples)
     {
-        List<byte> data = new List<byte>();
+        List<byte> data = new();
         for (uint i = offset; i < endOffset; i++)
         {
             data.Add(wavSamples[i]);
@@ -299,7 +299,7 @@ public static class AnimationUtilities
             }
         }
 
-        List<ushort> frames = new List<ushort>();
+        List<ushort> frames = new();
         for (uint i = model.FrameOffset / 2; i < endFrame; i++)
         {
             frames.Add(allFrames[i]);
@@ -316,7 +316,7 @@ public static class AnimationUtilities
         }
 
         // Import the AnimDispatches first, noting their new indices            
-        Dictionary<int, int> indexMap = new Dictionary<int, int>();
+        Dictionary<int, int> indexMap = new();
         foreach (int oldDispatchIndex in packedAnimation.AnimationDispatches.Keys)
         {
             TRAnimDispatch dispatch = packedAnimation.AnimationDispatches[oldDispatchIndex];
@@ -343,7 +343,7 @@ public static class AnimationUtilities
         }
 
         // Import the AnimDispatches first, noting their new indices            
-        Dictionary<int, int> indexMap = new Dictionary<int, int>();
+        Dictionary<int, int> indexMap = new();
         foreach (int oldDispatchIndex in packedAnimation.AnimationDispatches.Keys)
         {
             TRAnimDispatch dispatch = packedAnimation.AnimationDispatches[oldDispatchIndex];
@@ -370,7 +370,7 @@ public static class AnimationUtilities
         }
 
         // Import the AnimDispatches first, noting their new indices            
-        Dictionary<int, int> indexMap = new Dictionary<int, int>();
+        Dictionary<int, int> indexMap = new();
         foreach (int oldDispatchIndex in packedAnimation.AnimationDispatches.Keys)
         {
             TRAnimDispatch dispatch = packedAnimation.AnimationDispatches[oldDispatchIndex];
@@ -449,21 +449,21 @@ public static class AnimationUtilities
 
     public static void UnpackAnimSounds(TR1Level level, TR1PackedAnimation packedAnimation)
     {
-        SoundUnpacker soundUnpacker = new SoundUnpacker();
+        SoundUnpacker soundUnpacker = new();
         soundUnpacker.Unpack(packedAnimation.Sound, level, false);
         RemapSoundIndices(packedAnimation.Commands.Values, soundUnpacker.SoundIndexMap);
     }
 
     public static void UnpackAnimSounds(TR2Level level, TR2PackedAnimation packedAnimation)
     {
-        SoundUnpacker soundUnpacker = new SoundUnpacker();
+        SoundUnpacker soundUnpacker = new();
         soundUnpacker.Unpack(packedAnimation.Sound, level, false);
         RemapSoundIndices(packedAnimation.Commands.Values, soundUnpacker.SoundIndexMap);
     }
 
     public static void UnpackAnimSounds(TR3Level level, TR3PackedAnimation packedAnimation)
     {
-        SoundUnpacker soundUnpacker = new SoundUnpacker();
+        SoundUnpacker soundUnpacker = new();
         soundUnpacker.Unpack(packedAnimation.Sound, level, false);
         RemapSoundIndices(packedAnimation.Commands.Values, soundUnpacker.SoundIndexMap);
     }

--- a/TRModelTransporter/Handlers/Animations/AnimationUtilities.cs
+++ b/TRModelTransporter/Handlers/Animations/AnimationUtilities.cs
@@ -125,23 +125,12 @@ public static class AnimationUtilities
         {
             int cmdIndex = cmdOffset++;
             TRAnimCommand cmd = animCommands[cmdIndex];
-
-            int paramCount;
-            switch ((TRAnimCommandTypes)cmd.Value)
+            int paramCount = (TRAnimCommandTypes)cmd.Value switch
             {
-                case TRAnimCommandTypes.SetPosition:
-                    paramCount = 3;
-                    break;
-                case TRAnimCommandTypes.JumpDistance:
-                case TRAnimCommandTypes.PlaySound:
-                case TRAnimCommandTypes.FlipEffect:
-                    paramCount = 2;
-                    break;
-                default:
-                    paramCount = 0;
-                    break;
-            }
-
+                TRAnimCommandTypes.SetPosition => 3,
+                TRAnimCommandTypes.JumpDistance or TRAnimCommandTypes.PlaySound or TRAnimCommandTypes.FlipEffect => 2,
+                _ => 0,
+            };
             short[] paramArr = new short[paramCount];
             for (int j = 0; j < paramCount; j++)
             {

--- a/TRModelTransporter/Handlers/CinematicTransportHandler.cs
+++ b/TRModelTransporter/Handlers/CinematicTransportHandler.cs
@@ -8,7 +8,7 @@ public class CinematicTransportHandler
 {
     public void Export(TR1Level level, TR1ModelDefinition definition, IEnumerable<TREntities> entityTypes)
     {
-        List<TRCinematicFrame> frames = new List<TRCinematicFrame>();
+        List<TRCinematicFrame> frames = new();
         if (entityTypes != null && entityTypes.Contains(definition.Entity))
         {
             frames.AddRange(level.CinematicFrames);
@@ -19,7 +19,7 @@ public class CinematicTransportHandler
 
     public void Export(TR2Level level, TR2ModelDefinition definition, IEnumerable<TR2Entities> entityTypes)
     {
-        List<TRCinematicFrame> frames = new List<TRCinematicFrame>();
+        List<TRCinematicFrame> frames = new();
         if (entityTypes != null && entityTypes.Contains(definition.Entity))
         {
             frames.AddRange(level.CinematicFrames);
@@ -30,7 +30,7 @@ public class CinematicTransportHandler
 
     public void Export(TR3Level level, TR3ModelDefinition definition, IEnumerable<TR3Entities> entityTypes)
     {
-        List<TRCinematicFrame> frames = new List<TRCinematicFrame>();
+        List<TRCinematicFrame> frames = new();
         if (entityTypes != null && entityTypes.Contains(definition.Entity))
         {
             frames.AddRange(level.CinematicFrames);

--- a/TRModelTransporter/Handlers/CinematicTransportHandler.cs
+++ b/TRModelTransporter/Handlers/CinematicTransportHandler.cs
@@ -4,69 +4,68 @@ using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;
 using TRModelTransporter.Model.Definitions;
 
-namespace TRModelTransporter.Handlers
+namespace TRModelTransporter.Handlers;
+
+public class CinematicTransportHandler
 {
-    public class CinematicTransportHandler
+    public void Export(TR1Level level, TR1ModelDefinition definition, IEnumerable<TREntities> entityTypes)
     {
-        public void Export(TR1Level level, TR1ModelDefinition definition, IEnumerable<TREntities> entityTypes)
+        List<TRCinematicFrame> frames = new List<TRCinematicFrame>();
+        if (entityTypes != null && entityTypes.Contains(definition.Entity))
         {
-            List<TRCinematicFrame> frames = new List<TRCinematicFrame>();
-            if (entityTypes != null && entityTypes.Contains(definition.Entity))
-            {
-                frames.AddRange(level.CinematicFrames);
-            }
-
-            definition.CinematicFrames = frames.ToArray();
+            frames.AddRange(level.CinematicFrames);
         }
 
-        public void Export(TR2Level level, TR2ModelDefinition definition, IEnumerable<TR2Entities> entityTypes)
-        {
-            List<TRCinematicFrame> frames = new List<TRCinematicFrame>();
-            if (entityTypes != null && entityTypes.Contains(definition.Entity))
-            {
-                frames.AddRange(level.CinematicFrames);
-            }
+        definition.CinematicFrames = frames.ToArray();
+    }
 
-            definition.CinematicFrames = frames.ToArray();
+    public void Export(TR2Level level, TR2ModelDefinition definition, IEnumerable<TR2Entities> entityTypes)
+    {
+        List<TRCinematicFrame> frames = new List<TRCinematicFrame>();
+        if (entityTypes != null && entityTypes.Contains(definition.Entity))
+        {
+            frames.AddRange(level.CinematicFrames);
         }
 
-        public void Export(TR3Level level, TR3ModelDefinition definition, IEnumerable<TR3Entities> entityTypes)
-        {
-            List<TRCinematicFrame> frames = new List<TRCinematicFrame>();
-            if (entityTypes != null && entityTypes.Contains(definition.Entity))
-            {
-                frames.AddRange(level.CinematicFrames);
-            }
+        definition.CinematicFrames = frames.ToArray();
+    }
 
-            definition.CinematicFrames = frames.ToArray();
+    public void Export(TR3Level level, TR3ModelDefinition definition, IEnumerable<TR3Entities> entityTypes)
+    {
+        List<TRCinematicFrame> frames = new List<TRCinematicFrame>();
+        if (entityTypes != null && entityTypes.Contains(definition.Entity))
+        {
+            frames.AddRange(level.CinematicFrames);
         }
 
-        public void Import(TR1Level level, TR1ModelDefinition definition)
-        {
-            // We only import frames if the level doesn't have any already.
-            if (level.NumCinematicFrames == 0)
-            {
-                level.CinematicFrames = definition.CinematicFrames;
-                level.NumCinematicFrames = (ushort)definition.CinematicFrames.Length;
-            }
-        }
+        definition.CinematicFrames = frames.ToArray();
+    }
 
-        public void Import(TR2Level level, TR2ModelDefinition definition)
+    public void Import(TR1Level level, TR1ModelDefinition definition)
+    {
+        // We only import frames if the level doesn't have any already.
+        if (level.NumCinematicFrames == 0)
         {
-            if (level.NumCinematicFrames == 0)
-            {
-                level.CinematicFrames = definition.CinematicFrames;
-                level.NumCinematicFrames = (ushort)definition.CinematicFrames.Length;
-            }
+            level.CinematicFrames = definition.CinematicFrames;
+            level.NumCinematicFrames = (ushort)definition.CinematicFrames.Length;
         }
+    }
 
-        public void Import(TR3Level level, TR3ModelDefinition definition)
+    public void Import(TR2Level level, TR2ModelDefinition definition)
+    {
+        if (level.NumCinematicFrames == 0)
         {
-            if (level.NumCinematicFrames == 0)
-            {
-                level.CinematicFrames = definition.CinematicFrames;
-                level.NumCinematicFrames = (ushort)definition.CinematicFrames.Length;
-            }
+            level.CinematicFrames = definition.CinematicFrames;
+            level.NumCinematicFrames = (ushort)definition.CinematicFrames.Length;
+        }
+    }
+
+    public void Import(TR3Level level, TR3ModelDefinition definition)
+    {
+        if (level.NumCinematicFrames == 0)
+        {
+            level.CinematicFrames = definition.CinematicFrames;
+            level.NumCinematicFrames = (ushort)definition.CinematicFrames.Length;
         }
     }
 }

--- a/TRModelTransporter/Handlers/CinematicTransportHandler.cs
+++ b/TRModelTransporter/Handlers/CinematicTransportHandler.cs
@@ -6,7 +6,7 @@ namespace TRModelTransporter.Handlers;
 
 public class CinematicTransportHandler
 {
-    public void Export(TR1Level level, TR1ModelDefinition definition, IEnumerable<TREntities> entityTypes)
+    public static void Export(TR1Level level, TR1ModelDefinition definition, IEnumerable<TREntities> entityTypes)
     {
         List<TRCinematicFrame> frames = new();
         if (entityTypes != null && entityTypes.Contains(definition.Entity))
@@ -17,7 +17,7 @@ public class CinematicTransportHandler
         definition.CinematicFrames = frames.ToArray();
     }
 
-    public void Export(TR2Level level, TR2ModelDefinition definition, IEnumerable<TR2Entities> entityTypes)
+    public static void Export(TR2Level level, TR2ModelDefinition definition, IEnumerable<TR2Entities> entityTypes)
     {
         List<TRCinematicFrame> frames = new();
         if (entityTypes != null && entityTypes.Contains(definition.Entity))
@@ -28,7 +28,7 @@ public class CinematicTransportHandler
         definition.CinematicFrames = frames.ToArray();
     }
 
-    public void Export(TR3Level level, TR3ModelDefinition definition, IEnumerable<TR3Entities> entityTypes)
+    public static void Export(TR3Level level, TR3ModelDefinition definition, IEnumerable<TR3Entities> entityTypes)
     {
         List<TRCinematicFrame> frames = new();
         if (entityTypes != null && entityTypes.Contains(definition.Entity))
@@ -39,7 +39,7 @@ public class CinematicTransportHandler
         definition.CinematicFrames = frames.ToArray();
     }
 
-    public void Import(TR1Level level, TR1ModelDefinition definition)
+    public static void Import(TR1Level level, TR1ModelDefinition definition)
     {
         // We only import frames if the level doesn't have any already.
         if (level.NumCinematicFrames == 0)
@@ -49,7 +49,7 @@ public class CinematicTransportHandler
         }
     }
 
-    public void Import(TR2Level level, TR2ModelDefinition definition)
+    public static void Import(TR2Level level, TR2ModelDefinition definition)
     {
         if (level.NumCinematicFrames == 0)
         {
@@ -58,7 +58,7 @@ public class CinematicTransportHandler
         }
     }
 
-    public void Import(TR3Level level, TR3ModelDefinition definition)
+    public static void Import(TR3Level level, TR3ModelDefinition definition)
     {
         if (level.NumCinematicFrames == 0)
         {

--- a/TRModelTransporter/Handlers/CinematicTransportHandler.cs
+++ b/TRModelTransporter/Handlers/CinematicTransportHandler.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using TRLevelControl.Model;
+﻿using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;
 using TRModelTransporter.Model.Definitions;
 

--- a/TRModelTransporter/Handlers/ColourTransportHandler.cs
+++ b/TRModelTransporter/Handlers/ColourTransportHandler.cs
@@ -5,152 +5,151 @@ using TRModelTransporter.Model.Definitions;
 using TRTexture16Importer;
 using TRTexture16Importer.Helpers;
 
-namespace TRModelTransporter.Handlers
+namespace TRModelTransporter.Handlers;
+
+public class ColourTransportHandler
 {
-    public class ColourTransportHandler
+    public void Export(TR1Level level, TR1ModelDefinition definition)
     {
-        public void Export(TR1Level level, TR1ModelDefinition definition)
+        definition.Colours = GetUsedMeshColours(definition.Meshes, level.Palette);
+    }
+
+    public void Export(TR2Level level, TR2ModelDefinition definition)
+    {
+        definition.Colours = GetUsedMeshColours(definition.Meshes, level.Palette16);
+    }
+
+    public void Export(TR3Level level, TR3ModelDefinition definition)
+    {
+        definition.Colours = GetUsedMeshColours(definition.Meshes, level.Palette16);
+    }
+
+    private Dictionary<int, TRColour> GetUsedMeshColours(TRMesh[] meshes, TRColour[] colours)
+    {
+        ISet<int> colourIndices = GetAllColourIndices(meshes, false);
+
+        Dictionary<int, TRColour> usedColours = new Dictionary<int, TRColour>();
+        foreach (int i in colourIndices)
         {
-            definition.Colours = GetUsedMeshColours(definition.Meshes, level.Palette);
+            usedColours[i] = colours[i];
         }
 
-        public void Export(TR2Level level, TR2ModelDefinition definition)
+        return usedColours;
+    }
+
+    private Dictionary<int, TRColour4> GetUsedMeshColours(TRMesh[] meshes, TRColour4[] colours)
+    {
+        ISet<int> colourIndices = GetAllColourIndices(meshes, true);
+
+        Dictionary<int, TRColour4> usedColours = new Dictionary<int, TRColour4>();
+        foreach (int i in colourIndices)
         {
-            definition.Colours = GetUsedMeshColours(definition.Meshes, level.Palette16);
+            usedColours[i] = colours[i];
         }
 
-        public void Export(TR3Level level, TR3ModelDefinition definition)
-        {
-            definition.Colours = GetUsedMeshColours(definition.Meshes, level.Palette16);
-        }
+        return usedColours;
+    }
 
-        private Dictionary<int, TRColour> GetUsedMeshColours(TRMesh[] meshes, TRColour[] colours)
+    private ISet<int> GetAllColourIndices(TRMesh[] meshes, bool has16Bit)
+    {
+        ISet<int> colourIndices = new SortedSet<int>();
+        foreach (TRMesh mesh in meshes)
         {
-            ISet<int> colourIndices = GetAllColourIndices(meshes, false);
-
-            Dictionary<int, TRColour> usedColours = new Dictionary<int, TRColour>();
-            foreach (int i in colourIndices)
+            foreach (TRFace4 rect in mesh.ColouredRectangles)
             {
-                usedColours[i] = colours[i];
+                colourIndices.Add(has16Bit ? rect.Texture >> 8 : rect.Texture);
             }
-
-            return usedColours;
-        }
-
-        private Dictionary<int, TRColour4> GetUsedMeshColours(TRMesh[] meshes, TRColour4[] colours)
-        {
-            ISet<int> colourIndices = GetAllColourIndices(meshes, true);
-
-            Dictionary<int, TRColour4> usedColours = new Dictionary<int, TRColour4>();
-            foreach (int i in colourIndices)
+            foreach (TRFace3 tri in mesh.ColouredTriangles)
             {
-                usedColours[i] = colours[i];
-            }
-
-            return usedColours;
-        }
-
-        private ISet<int> GetAllColourIndices(TRMesh[] meshes, bool has16Bit)
-        {
-            ISet<int> colourIndices = new SortedSet<int>();
-            foreach (TRMesh mesh in meshes)
-            {
-                foreach (TRFace4 rect in mesh.ColouredRectangles)
-                {
-                    colourIndices.Add(has16Bit ? rect.Texture >> 8 : rect.Texture);
-                }
-                foreach (TRFace3 tri in mesh.ColouredTriangles)
-                {
-                    colourIndices.Add(has16Bit ? tri.Texture >> 8 : tri.Texture);
-                }
-            }
-
-            return colourIndices;
-        }
-
-        public void Import(TR1Level level, TR1ModelDefinition definition, TR1PaletteManager paletteManager)
-        {
-            Dictionary<int, int> indexMap = new Dictionary<int, int>();
-
-            foreach (int paletteIndex in definition.Colours.Keys)
-            {
-                TRColour newColour = definition.Colours[paletteIndex];
-                indexMap[paletteIndex] = paletteManager.GetOrAddPaletteIndex(newColour);
-            }
-
-            paletteManager.WritePalletteToLevel();
-            ReindexMeshTextures(definition.Meshes, indexMap, false);
-        }
-
-        public void Import(TR2Level level, TR2ModelDefinition definition)
-        {
-            List<TRColour4> palette16 = level.Palette16.ToList();
-            Dictionary<int, int> indexMap = new Dictionary<int, int>();
-            
-            foreach (int paletteIndex in definition.Colours.Keys)
-            {
-                TRColour4 newColour = definition.Colours[paletteIndex];
-                int existingIndex = FindPaletteIndex(palette16, newColour);
-                indexMap[paletteIndex] = existingIndex == -1 ? PaletteUtilities.Import(level, newColour) : existingIndex;
-            }
-
-            ReindexMeshTextures(definition.Meshes, indexMap, true);
-
-            PaletteUtilities.ResetPaletteTracking(level.Palette16);
-        }
-
-        public void Import(TR3Level level, TR3ModelDefinition definition)
-        {
-            List<TRColour4> palette16 = level.Palette16.ToList();
-            Dictionary<int, int> indexMap = new Dictionary<int, int>();
-
-            foreach (int paletteIndex in definition.Colours.Keys)
-            {
-                TRColour4 newColour = definition.Colours[paletteIndex];
-                int existingIndex = FindPaletteIndex(palette16, newColour);
-                indexMap[paletteIndex] = existingIndex == -1 ? PaletteUtilities.Import(level, newColour) : existingIndex;
-            }
-
-            ReindexMeshTextures(definition.Meshes, indexMap, true);
-
-            PaletteUtilities.ResetPaletteTracking(level.Palette16);
-        }
-
-        private int FindPaletteIndex(List<TRColour4> colours, TRColour4 colour)
-        {
-            return colours.FindIndex
-            (
-                e => e.Red == colour.Red && e.Green == colour.Green && e.Blue == colour.Blue
-            );
-        }
-
-        private void ReindexMeshTextures(TRMesh[] meshes, Dictionary<int, int> indexMap, bool has16Bit)
-        {
-            foreach (TRMesh mesh in meshes)
-            {
-                foreach (TRFace4 rect in mesh.ColouredRectangles)
-                {
-                    rect.Texture = ReindexTexture(rect.Texture, indexMap, has16Bit);
-                }
-                foreach (TRFace3 tri in mesh.ColouredTriangles)
-                {
-                    tri.Texture = ReindexTexture(tri.Texture, indexMap, has16Bit);
-                }
+                colourIndices.Add(has16Bit ? tri.Texture >> 8 : tri.Texture);
             }
         }
 
-        private ushort ReindexTexture(ushort value, Dictionary<int, int> indexMap, bool has16Bit)
+        return colourIndices;
+    }
+
+    public void Import(TR1Level level, TR1ModelDefinition definition, TR1PaletteManager paletteManager)
+    {
+        Dictionary<int, int> indexMap = new Dictionary<int, int>();
+
+        foreach (int paletteIndex in definition.Colours.Keys)
         {
-            int p16 = value;;
-            if (has16Bit)
-            {
-                p16 >>= 8;
-            }
-            if (indexMap.ContainsKey(p16))
-            {
-                return (ushort)(has16Bit ? (indexMap[p16] << 8 | (value & 0xFF)) : indexMap[p16]);
-            }
-            return value;
+            TRColour newColour = definition.Colours[paletteIndex];
+            indexMap[paletteIndex] = paletteManager.GetOrAddPaletteIndex(newColour);
         }
+
+        paletteManager.WritePalletteToLevel();
+        ReindexMeshTextures(definition.Meshes, indexMap, false);
+    }
+
+    public void Import(TR2Level level, TR2ModelDefinition definition)
+    {
+        List<TRColour4> palette16 = level.Palette16.ToList();
+        Dictionary<int, int> indexMap = new Dictionary<int, int>();
+        
+        foreach (int paletteIndex in definition.Colours.Keys)
+        {
+            TRColour4 newColour = definition.Colours[paletteIndex];
+            int existingIndex = FindPaletteIndex(palette16, newColour);
+            indexMap[paletteIndex] = existingIndex == -1 ? PaletteUtilities.Import(level, newColour) : existingIndex;
+        }
+
+        ReindexMeshTextures(definition.Meshes, indexMap, true);
+
+        PaletteUtilities.ResetPaletteTracking(level.Palette16);
+    }
+
+    public void Import(TR3Level level, TR3ModelDefinition definition)
+    {
+        List<TRColour4> palette16 = level.Palette16.ToList();
+        Dictionary<int, int> indexMap = new Dictionary<int, int>();
+
+        foreach (int paletteIndex in definition.Colours.Keys)
+        {
+            TRColour4 newColour = definition.Colours[paletteIndex];
+            int existingIndex = FindPaletteIndex(palette16, newColour);
+            indexMap[paletteIndex] = existingIndex == -1 ? PaletteUtilities.Import(level, newColour) : existingIndex;
+        }
+
+        ReindexMeshTextures(definition.Meshes, indexMap, true);
+
+        PaletteUtilities.ResetPaletteTracking(level.Palette16);
+    }
+
+    private int FindPaletteIndex(List<TRColour4> colours, TRColour4 colour)
+    {
+        return colours.FindIndex
+        (
+            e => e.Red == colour.Red && e.Green == colour.Green && e.Blue == colour.Blue
+        );
+    }
+
+    private void ReindexMeshTextures(TRMesh[] meshes, Dictionary<int, int> indexMap, bool has16Bit)
+    {
+        foreach (TRMesh mesh in meshes)
+        {
+            foreach (TRFace4 rect in mesh.ColouredRectangles)
+            {
+                rect.Texture = ReindexTexture(rect.Texture, indexMap, has16Bit);
+            }
+            foreach (TRFace3 tri in mesh.ColouredTriangles)
+            {
+                tri.Texture = ReindexTexture(tri.Texture, indexMap, has16Bit);
+            }
+        }
+    }
+
+    private ushort ReindexTexture(ushort value, Dictionary<int, int> indexMap, bool has16Bit)
+    {
+        int p16 = value;;
+        if (has16Bit)
+        {
+            p16 >>= 8;
+        }
+        if (indexMap.ContainsKey(p16))
+        {
+            return (ushort)(has16Bit ? (indexMap[p16] << 8 | (value & 0xFF)) : indexMap[p16]);
+        }
+        return value;
     }
 }

--- a/TRModelTransporter/Handlers/ColourTransportHandler.cs
+++ b/TRModelTransporter/Handlers/ColourTransportHandler.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using TRLevelControl.Model;
+﻿using TRLevelControl.Model;
 using TRModelTransporter.Model.Definitions;
 using TRTexture16Importer;
 using TRTexture16Importer.Helpers;

--- a/TRModelTransporter/Handlers/ColourTransportHandler.cs
+++ b/TRModelTransporter/Handlers/ColourTransportHandler.cs
@@ -26,7 +26,7 @@ public class ColourTransportHandler
     {
         ISet<int> colourIndices = GetAllColourIndices(meshes, false);
 
-        Dictionary<int, TRColour> usedColours = new Dictionary<int, TRColour>();
+        Dictionary<int, TRColour> usedColours = new();
         foreach (int i in colourIndices)
         {
             usedColours[i] = colours[i];
@@ -39,7 +39,7 @@ public class ColourTransportHandler
     {
         ISet<int> colourIndices = GetAllColourIndices(meshes, true);
 
-        Dictionary<int, TRColour4> usedColours = new Dictionary<int, TRColour4>();
+        Dictionary<int, TRColour4> usedColours = new();
         foreach (int i in colourIndices)
         {
             usedColours[i] = colours[i];
@@ -68,7 +68,7 @@ public class ColourTransportHandler
 
     public void Import(TR1Level level, TR1ModelDefinition definition, TR1PaletteManager paletteManager)
     {
-        Dictionary<int, int> indexMap = new Dictionary<int, int>();
+        Dictionary<int, int> indexMap = new();
 
         foreach (int paletteIndex in definition.Colours.Keys)
         {
@@ -83,7 +83,7 @@ public class ColourTransportHandler
     public void Import(TR2Level level, TR2ModelDefinition definition)
     {
         List<TRColour4> palette16 = level.Palette16.ToList();
-        Dictionary<int, int> indexMap = new Dictionary<int, int>();
+        Dictionary<int, int> indexMap = new();
         
         foreach (int paletteIndex in definition.Colours.Keys)
         {
@@ -100,7 +100,7 @@ public class ColourTransportHandler
     public void Import(TR3Level level, TR3ModelDefinition definition)
     {
         List<TRColour4> palette16 = level.Palette16.ToList();
-        Dictionary<int, int> indexMap = new Dictionary<int, int>();
+        Dictionary<int, int> indexMap = new();
 
         foreach (int paletteIndex in definition.Colours.Keys)
         {

--- a/TRModelTransporter/Handlers/ColourTransportHandler.cs
+++ b/TRModelTransporter/Handlers/ColourTransportHandler.cs
@@ -66,7 +66,7 @@ public class ColourTransportHandler
         return colourIndices;
     }
 
-    public static void Import(TR1Level level, TR1ModelDefinition definition, TR1PaletteManager paletteManager)
+    public static void Import(TR1ModelDefinition definition, TR1PaletteManager paletteManager)
     {
         Dictionary<int, int> indexMap = new();
 

--- a/TRModelTransporter/Handlers/ColourTransportHandler.cs
+++ b/TRModelTransporter/Handlers/ColourTransportHandler.cs
@@ -7,22 +7,22 @@ namespace TRModelTransporter.Handlers;
 
 public class ColourTransportHandler
 {
-    public void Export(TR1Level level, TR1ModelDefinition definition)
+    public static void Export(TR1Level level, TR1ModelDefinition definition)
     {
         definition.Colours = GetUsedMeshColours(definition.Meshes, level.Palette);
     }
 
-    public void Export(TR2Level level, TR2ModelDefinition definition)
+    public static void Export(TR2Level level, TR2ModelDefinition definition)
     {
         definition.Colours = GetUsedMeshColours(definition.Meshes, level.Palette16);
     }
 
-    public void Export(TR3Level level, TR3ModelDefinition definition)
+    public static void Export(TR3Level level, TR3ModelDefinition definition)
     {
         definition.Colours = GetUsedMeshColours(definition.Meshes, level.Palette16);
     }
 
-    private Dictionary<int, TRColour> GetUsedMeshColours(TRMesh[] meshes, TRColour[] colours)
+    private static Dictionary<int, TRColour> GetUsedMeshColours(TRMesh[] meshes, TRColour[] colours)
     {
         ISet<int> colourIndices = GetAllColourIndices(meshes, false);
 
@@ -35,7 +35,7 @@ public class ColourTransportHandler
         return usedColours;
     }
 
-    private Dictionary<int, TRColour4> GetUsedMeshColours(TRMesh[] meshes, TRColour4[] colours)
+    private static Dictionary<int, TRColour4> GetUsedMeshColours(TRMesh[] meshes, TRColour4[] colours)
     {
         ISet<int> colourIndices = GetAllColourIndices(meshes, true);
 
@@ -48,7 +48,7 @@ public class ColourTransportHandler
         return usedColours;
     }
 
-    private ISet<int> GetAllColourIndices(TRMesh[] meshes, bool has16Bit)
+    private static ISet<int> GetAllColourIndices(TRMesh[] meshes, bool has16Bit)
     {
         ISet<int> colourIndices = new SortedSet<int>();
         foreach (TRMesh mesh in meshes)
@@ -66,7 +66,7 @@ public class ColourTransportHandler
         return colourIndices;
     }
 
-    public void Import(TR1Level level, TR1ModelDefinition definition, TR1PaletteManager paletteManager)
+    public static void Import(TR1Level level, TR1ModelDefinition definition, TR1PaletteManager paletteManager)
     {
         Dictionary<int, int> indexMap = new();
 
@@ -80,7 +80,7 @@ public class ColourTransportHandler
         ReindexMeshTextures(definition.Meshes, indexMap, false);
     }
 
-    public void Import(TR2Level level, TR2ModelDefinition definition)
+    public static void Import(TR2Level level, TR2ModelDefinition definition)
     {
         List<TRColour4> palette16 = level.Palette16.ToList();
         Dictionary<int, int> indexMap = new();
@@ -97,7 +97,7 @@ public class ColourTransportHandler
         PaletteUtilities.ResetPaletteTracking(level.Palette16);
     }
 
-    public void Import(TR3Level level, TR3ModelDefinition definition)
+    public static void Import(TR3Level level, TR3ModelDefinition definition)
     {
         List<TRColour4> palette16 = level.Palette16.ToList();
         Dictionary<int, int> indexMap = new();
@@ -114,7 +114,7 @@ public class ColourTransportHandler
         PaletteUtilities.ResetPaletteTracking(level.Palette16);
     }
 
-    private int FindPaletteIndex(List<TRColour4> colours, TRColour4 colour)
+    private static int FindPaletteIndex(List<TRColour4> colours, TRColour4 colour)
     {
         return colours.FindIndex
         (
@@ -122,7 +122,7 @@ public class ColourTransportHandler
         );
     }
 
-    private void ReindexMeshTextures(TRMesh[] meshes, Dictionary<int, int> indexMap, bool has16Bit)
+    private static void ReindexMeshTextures(TRMesh[] meshes, Dictionary<int, int> indexMap, bool has16Bit)
     {
         foreach (TRMesh mesh in meshes)
         {
@@ -137,7 +137,7 @@ public class ColourTransportHandler
         }
     }
 
-    private ushort ReindexTexture(ushort value, Dictionary<int, int> indexMap, bool has16Bit)
+    private static ushort ReindexTexture(ushort value, Dictionary<int, int> indexMap, bool has16Bit)
     {
         int p16 = value;;
         if (has16Bit)

--- a/TRModelTransporter/Handlers/MeshTransportHandler.cs
+++ b/TRModelTransporter/Handlers/MeshTransportHandler.cs
@@ -2,91 +2,90 @@
 using TRLevelControl.Model;
 using TRModelTransporter.Model.Definitions;
 
-namespace TRModelTransporter.Handlers
+namespace TRModelTransporter.Handlers;
+
+public class MeshTransportHandler
 {
-    public class MeshTransportHandler
+    public void Export(TR1Level level, TR1ModelDefinition definition)
     {
-        public void Export(TR1Level level, TR1ModelDefinition definition)
-        {
-            definition.MeshTrees = TRMeshUtilities.GetModelMeshTrees(level, definition.Model);
-            definition.Meshes = TRMeshUtilities.GetModelMeshes(level, definition.Model);
-        }
+        definition.MeshTrees = TRMeshUtilities.GetModelMeshTrees(level, definition.Model);
+        definition.Meshes = TRMeshUtilities.GetModelMeshes(level, definition.Model);
+    }
 
-        public void Export(TR2Level level, TR2ModelDefinition definition)
-        {
-            definition.MeshTrees = TRMeshUtilities.GetModelMeshTrees(level, definition.Model);
-            definition.Meshes = TRMeshUtilities.GetModelMeshes(level, definition.Model);
-        }
+    public void Export(TR2Level level, TR2ModelDefinition definition)
+    {
+        definition.MeshTrees = TRMeshUtilities.GetModelMeshTrees(level, definition.Model);
+        definition.Meshes = TRMeshUtilities.GetModelMeshes(level, definition.Model);
+    }
 
-        public void Export(TR3Level level, TR3ModelDefinition definition)
-        {
-            definition.MeshTrees = TRMeshUtilities.GetModelMeshTrees(level, definition.Model);
-            definition.Meshes = TRMeshUtilities.GetModelMeshes(level, definition.Model);
-        }
+    public void Export(TR3Level level, TR3ModelDefinition definition)
+    {
+        definition.MeshTrees = TRMeshUtilities.GetModelMeshTrees(level, definition.Model);
+        definition.Meshes = TRMeshUtilities.GetModelMeshes(level, definition.Model);
+    }
 
-        public void Import(TR1Level level, TR1ModelDefinition definition)
+    public void Import(TR1Level level, TR1ModelDefinition definition)
+    {
+        // Copy the MeshTreeNodes and Meshes into the level, making a note of the first
+        // inserted index for each - this is used to update the Model to point to the
+        // correct starting positions.
+        for (int i = 0; i < definition.MeshTrees.Length; i++)
         {
-            // Copy the MeshTreeNodes and Meshes into the level, making a note of the first
-            // inserted index for each - this is used to update the Model to point to the
-            // correct starting positions.
-            for (int i = 0; i < definition.MeshTrees.Length; i++)
+            int insertedIndex = TRMeshUtilities.InsertMeshTreeNode(level, definition.MeshTrees[i]);
+            if (i == 0)
             {
-                int insertedIndex = TRMeshUtilities.InsertMeshTreeNode(level, definition.MeshTrees[i]);
-                if (i == 0)
-                {
-                    definition.Model.MeshTree = 4 * (uint)insertedIndex;
-                }
-            }
-
-            for (int i = 0; i < definition.Meshes.Length; i++)
-            {
-                int insertedIndex = TRMeshUtilities.InsertMesh(level, definition.Meshes[i]);
-                if (i == 0)
-                {
-                    definition.Model.StartingMesh = (ushort)insertedIndex;
-                }
+                definition.Model.MeshTree = 4 * (uint)insertedIndex;
             }
         }
 
-        public void Import(TR2Level level, TR2ModelDefinition definition)
+        for (int i = 0; i < definition.Meshes.Length; i++)
         {
-            for (int i = 0; i < definition.MeshTrees.Length; i++)
+            int insertedIndex = TRMeshUtilities.InsertMesh(level, definition.Meshes[i]);
+            if (i == 0)
             {
-                int insertedIndex = TRMeshUtilities.InsertMeshTreeNode(level, definition.MeshTrees[i]);
-                if (i == 0)
-                {
-                    definition.Model.MeshTree = 4 * (uint)insertedIndex;
-                }
+                definition.Model.StartingMesh = (ushort)insertedIndex;
             }
+        }
+    }
 
-            for (int i = 0; i < definition.Meshes.Length; i++)
+    public void Import(TR2Level level, TR2ModelDefinition definition)
+    {
+        for (int i = 0; i < definition.MeshTrees.Length; i++)
+        {
+            int insertedIndex = TRMeshUtilities.InsertMeshTreeNode(level, definition.MeshTrees[i]);
+            if (i == 0)
             {
-                int insertedIndex = TRMeshUtilities.InsertMesh(level, definition.Meshes[i]);
-                if (i == 0)
-                {
-                    definition.Model.StartingMesh = (ushort)insertedIndex;
-                }
+                definition.Model.MeshTree = 4 * (uint)insertedIndex;
             }
         }
 
-        public void Import(TR3Level level, TR3ModelDefinition definition)
+        for (int i = 0; i < definition.Meshes.Length; i++)
         {
-            for (int i = 0; i < definition.MeshTrees.Length; i++)
+            int insertedIndex = TRMeshUtilities.InsertMesh(level, definition.Meshes[i]);
+            if (i == 0)
             {
-                int insertedIndex = TRMeshUtilities.InsertMeshTreeNode(level, definition.MeshTrees[i]);
-                if (i == 0)
-                {
-                    definition.Model.MeshTree = 4 * (uint)insertedIndex;
-                }
+                definition.Model.StartingMesh = (ushort)insertedIndex;
             }
+        }
+    }
 
-            for (int i = 0; i < definition.Meshes.Length; i++)
+    public void Import(TR3Level level, TR3ModelDefinition definition)
+    {
+        for (int i = 0; i < definition.MeshTrees.Length; i++)
+        {
+            int insertedIndex = TRMeshUtilities.InsertMeshTreeNode(level, definition.MeshTrees[i]);
+            if (i == 0)
             {
-                int insertedIndex = TRMeshUtilities.InsertMesh(level, definition.Meshes[i]);
-                if (i == 0)
-                {
-                    definition.Model.StartingMesh = (ushort)insertedIndex;
-                }
+                definition.Model.MeshTree = 4 * (uint)insertedIndex;
+            }
+        }
+
+        for (int i = 0; i < definition.Meshes.Length; i++)
+        {
+            int insertedIndex = TRMeshUtilities.InsertMesh(level, definition.Meshes[i]);
+            if (i == 0)
+            {
+                definition.Model.StartingMesh = (ushort)insertedIndex;
             }
         }
     }

--- a/TRModelTransporter/Handlers/MeshTransportHandler.cs
+++ b/TRModelTransporter/Handlers/MeshTransportHandler.cs
@@ -6,25 +6,25 @@ namespace TRModelTransporter.Handlers;
 
 public class MeshTransportHandler
 {
-    public void Export(TR1Level level, TR1ModelDefinition definition)
+    public static void Export(TR1Level level, TR1ModelDefinition definition)
     {
         definition.MeshTrees = TRMeshUtilities.GetModelMeshTrees(level, definition.Model);
         definition.Meshes = TRMeshUtilities.GetModelMeshes(level, definition.Model);
     }
 
-    public void Export(TR2Level level, TR2ModelDefinition definition)
+    public static void Export(TR2Level level, TR2ModelDefinition definition)
     {
         definition.MeshTrees = TRMeshUtilities.GetModelMeshTrees(level, definition.Model);
         definition.Meshes = TRMeshUtilities.GetModelMeshes(level, definition.Model);
     }
 
-    public void Export(TR3Level level, TR3ModelDefinition definition)
+    public static void Export(TR3Level level, TR3ModelDefinition definition)
     {
         definition.MeshTrees = TRMeshUtilities.GetModelMeshTrees(level, definition.Model);
         definition.Meshes = TRMeshUtilities.GetModelMeshes(level, definition.Model);
     }
 
-    public void Import(TR1Level level, TR1ModelDefinition definition)
+    public static void Import(TR1Level level, TR1ModelDefinition definition)
     {
         // Copy the MeshTreeNodes and Meshes into the level, making a note of the first
         // inserted index for each - this is used to update the Model to point to the
@@ -48,7 +48,7 @@ public class MeshTransportHandler
         }
     }
 
-    public void Import(TR2Level level, TR2ModelDefinition definition)
+    public static void Import(TR2Level level, TR2ModelDefinition definition)
     {
         for (int i = 0; i < definition.MeshTrees.Length; i++)
         {
@@ -69,7 +69,7 @@ public class MeshTransportHandler
         }
     }
 
-    public void Import(TR3Level level, TR3ModelDefinition definition)
+    public static void Import(TR3Level level, TR3ModelDefinition definition)
     {
         for (int i = 0; i < definition.MeshTrees.Length; i++)
         {

--- a/TRModelTransporter/Handlers/ModelTransportHandler.cs
+++ b/TRModelTransporter/Handlers/ModelTransportHandler.cs
@@ -5,142 +5,141 @@ using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;
 using TRModelTransporter.Model.Definitions;
 
-namespace TRModelTransporter.Handlers
+namespace TRModelTransporter.Handlers;
+
+public class ModelTransportHandler
 {
-    public class ModelTransportHandler
+    public void Export(TR1Level level, TR1ModelDefinition definition, TREntities entity)
     {
-        public void Export(TR1Level level, TR1ModelDefinition definition, TREntities entity)
+        definition.Model = GetTRModel(level.Models, (short)entity);
+    }
+
+    public void Export(TR2Level level, TR2ModelDefinition definition, TR2Entities entity)
+    {
+        definition.Model = GetTRModel(level.Models, (short)entity);
+    }
+
+    public void Export(TR3Level level, TR3ModelDefinition definition, TR3Entities entity)
+    {
+        definition.Model = GetTRModel(level.Models, (short)entity);
+    }
+
+    private TRModel GetTRModel(IEnumerable<TRModel> models, short entityID)
+    {
+        TRModel model = models.ToList().Find(m => m.ID == entityID);
+        if (model == null)
         {
-            definition.Model = GetTRModel(level.Models, (short)entity);
+            throw new ArgumentException(string.Format("The model for {0} could not be found.", entityID));
+        }
+        return model;
+    }
+
+    public void Import(TR1Level level, TR1ModelDefinition definition, Dictionary<TREntities, TREntities> aliasPriority, IEnumerable<TREntities> laraDependants)
+    {
+        List<TRModel> levelModels = level.Models.ToList();
+        int i = levelModels.FindIndex(m => m.ID == (short)definition.Entity);
+        if (i == -1)
+        {
+            levelModels.Add(definition.Model);
+            level.Models = levelModels.ToArray();
+            level.NumModels++;
+        }
+        else if (!aliasPriority.ContainsKey(definition.Entity) || aliasPriority[definition.Entity] == definition.Alias)
+        {
+            if (!definition.HasGraphics)
+            {
+                // The original mesh data may still be needed so don't overwrite
+                definition.Model.MeshTree = level.Models[i].MeshTree;
+                definition.Model.NumMeshes = level.Models[i].NumMeshes;
+                definition.Model.StartingMesh = level.Models[i].StartingMesh;
+            }
+            level.Models[i] = definition.Model;
         }
 
-        public void Export(TR2Level level, TR2ModelDefinition definition, TR2Entities entity)
+        if (laraDependants != null)
         {
-            definition.Model = GetTRModel(level.Models, (short)entity);
-        }
-
-        public void Export(TR3Level level, TR3ModelDefinition definition, TR3Entities entity)
-        {
-            definition.Model = GetTRModel(level.Models, (short)entity);
-        }
-
-        private TRModel GetTRModel(IEnumerable<TRModel> models, short entityID)
-        {
-            TRModel model = models.ToList().Find(m => m.ID == entityID);
-            if (model == null)
-            {
-                throw new ArgumentException(string.Format("The model for {0} could not be found.", entityID));
-            }
-            return model;
-        }
-
-        public void Import(TR1Level level, TR1ModelDefinition definition, Dictionary<TREntities, TREntities> aliasPriority, IEnumerable<TREntities> laraDependants)
-        {
-            List<TRModel> levelModels = level.Models.ToList();
-            int i = levelModels.FindIndex(m => m.ID == (short)definition.Entity);
-            if (i == -1)
-            {
-                levelModels.Add(definition.Model);
-                level.Models = levelModels.ToArray();
-                level.NumModels++;
-            }
-            else if (!aliasPriority.ContainsKey(definition.Entity) || aliasPriority[definition.Entity] == definition.Alias)
-            {
-                if (!definition.HasGraphics)
-                {
-                    // The original mesh data may still be needed so don't overwrite
-                    definition.Model.MeshTree = level.Models[i].MeshTree;
-                    definition.Model.NumMeshes = level.Models[i].NumMeshes;
-                    definition.Model.StartingMesh = level.Models[i].StartingMesh;
-                }
-                level.Models[i] = definition.Model;
-            }
-
-            if (laraDependants != null)
-            {
-                if (definition.Entity == TREntities.Lara)
-                {
-                    ReplaceLaraDependants(levelModels, definition.Model, laraDependants.Select(e => (short)e));
-                }
-                else if (laraDependants.Contains((TREntities)definition.Model.ID))
-                {
-                    ReplaceLaraDependants(levelModels, levelModels.Find(m => m.ID == (uint)TREntities.Lara), new short[] { (short)definition.Model.ID });
-                }
-            }
-        }
-
-        public void Import(TR2Level level, TR2ModelDefinition definition, Dictionary<TR2Entities, TR2Entities> aliasPriority, IEnumerable<TR2Entities> laraDependants)
-        {
-            List<TRModel> levelModels = level.Models.ToList();
-            int i = levelModels.FindIndex(m => m.ID == (short)definition.Entity);
-            if (i == -1)
-            {
-                levelModels.Add(definition.Model);
-                level.Models = levelModels.ToArray();
-                level.NumModels++;
-            }
-            else if (!aliasPriority.ContainsKey(definition.Entity) || aliasPriority[definition.Entity] == definition.Alias)
-            {
-                // Replacement occurs for the likes of aliases taking the place of another
-                // e.g. WhiteTiger replacing BengalTiger in GW, or if we have a specific
-                // alias that should always have a higher priority than its peers.
-                level.Models[i] = definition.Model;
-            }
-
-            // If we have replaced Lara, we need to update models such as CameraTarget, FlameEmitter etc
-            // as these use Lara's hips as placeholders. This means we can avoid texture corruption in
-            // TRView but it's also needed for the shower cutscene in HSH. If these entities are found,
-            // their starting mesh and mesh tree indices are just remapped to Lara's.
-            if (definition.Entity == TR2Entities.Lara && laraDependants != null)
+            if (definition.Entity == TREntities.Lara)
             {
                 ReplaceLaraDependants(levelModels, definition.Model, laraDependants.Select(e => (short)e));
             }
-        }
-
-        public void Import(TR3Level level, TR3ModelDefinition definition, Dictionary<TR3Entities, TR3Entities> aliasPriority, IEnumerable<TR3Entities> laraDependants, IEnumerable<TR3Entities> unsafeReplacements)
-        {
-            List<TRModel> levelModels = level.Models.ToList();
-            int i = levelModels.FindIndex(m => m.ID == (short)definition.Entity);
-            if (i == -1)
+            else if (laraDependants.Contains((TREntities)definition.Model.ID))
             {
-                levelModels.Add(definition.Model);
-                level.Models = levelModels.ToArray();
-                level.NumModels++;
-            }
-            else if (!aliasPriority.ContainsKey(definition.Entity) || aliasPriority[definition.Entity] == definition.Alias)
-            {
-                if (!unsafeReplacements.Contains(definition.Entity))
-                {
-                    level.Models[i] = definition.Model;
-                }
-                else
-                {
-                    // #234 Replacing Lara entirely can cause locking issues after pressing buttons or crouching
-                    // where she refuses to come out of her stance. TR3 seems bound to having Lara's animations start
-                    // at 0, so because these don't change per skin, we just replace the meshes and frames here.
-                    level.Models[i].NumMeshes = definition.Model.NumMeshes;
-                    level.Models[i].StartingMesh = definition.Model.StartingMesh;
-                    level.Models[i].MeshTree = definition.Model.MeshTree;
-                    level.Models[i].FrameOffset = definition.Model.FrameOffset;
-                }
-            }
-
-            if (definition.Entity == TR3Entities.Lara && laraDependants != null)
-            {
-                ReplaceLaraDependants(levelModels, definition.Model, laraDependants.Select(e => (short)e));
+                ReplaceLaraDependants(levelModels, levelModels.Find(m => m.ID == (uint)TREntities.Lara), new short[] { (short)definition.Model.ID });
             }
         }
+    }
 
-        private void ReplaceLaraDependants(List<TRModel> models, TRModel lara, IEnumerable<short> entityIDs)
+    public void Import(TR2Level level, TR2ModelDefinition definition, Dictionary<TR2Entities, TR2Entities> aliasPriority, IEnumerable<TR2Entities> laraDependants)
+    {
+        List<TRModel> levelModels = level.Models.ToList();
+        int i = levelModels.FindIndex(m => m.ID == (short)definition.Entity);
+        if (i == -1)
         {
-            foreach (short dependant in entityIDs)
+            levelModels.Add(definition.Model);
+            level.Models = levelModels.ToArray();
+            level.NumModels++;
+        }
+        else if (!aliasPriority.ContainsKey(definition.Entity) || aliasPriority[definition.Entity] == definition.Alias)
+        {
+            // Replacement occurs for the likes of aliases taking the place of another
+            // e.g. WhiteTiger replacing BengalTiger in GW, or if we have a specific
+            // alias that should always have a higher priority than its peers.
+            level.Models[i] = definition.Model;
+        }
+
+        // If we have replaced Lara, we need to update models such as CameraTarget, FlameEmitter etc
+        // as these use Lara's hips as placeholders. This means we can avoid texture corruption in
+        // TRView but it's also needed for the shower cutscene in HSH. If these entities are found,
+        // their starting mesh and mesh tree indices are just remapped to Lara's.
+        if (definition.Entity == TR2Entities.Lara && laraDependants != null)
+        {
+            ReplaceLaraDependants(levelModels, definition.Model, laraDependants.Select(e => (short)e));
+        }
+    }
+
+    public void Import(TR3Level level, TR3ModelDefinition definition, Dictionary<TR3Entities, TR3Entities> aliasPriority, IEnumerable<TR3Entities> laraDependants, IEnumerable<TR3Entities> unsafeReplacements)
+    {
+        List<TRModel> levelModels = level.Models.ToList();
+        int i = levelModels.FindIndex(m => m.ID == (short)definition.Entity);
+        if (i == -1)
+        {
+            levelModels.Add(definition.Model);
+            level.Models = levelModels.ToArray();
+            level.NumModels++;
+        }
+        else if (!aliasPriority.ContainsKey(definition.Entity) || aliasPriority[definition.Entity] == definition.Alias)
+        {
+            if (!unsafeReplacements.Contains(definition.Entity))
             {
-                TRModel dependentModel = models.Find(m => m.ID == dependant);
-                if (dependentModel != null)
-                {
-                    dependentModel.MeshTree = lara.MeshTree;
-                    dependentModel.StartingMesh = lara.StartingMesh;
-                }
+                level.Models[i] = definition.Model;
+            }
+            else
+            {
+                // #234 Replacing Lara entirely can cause locking issues after pressing buttons or crouching
+                // where she refuses to come out of her stance. TR3 seems bound to having Lara's animations start
+                // at 0, so because these don't change per skin, we just replace the meshes and frames here.
+                level.Models[i].NumMeshes = definition.Model.NumMeshes;
+                level.Models[i].StartingMesh = definition.Model.StartingMesh;
+                level.Models[i].MeshTree = definition.Model.MeshTree;
+                level.Models[i].FrameOffset = definition.Model.FrameOffset;
+            }
+        }
+
+        if (definition.Entity == TR3Entities.Lara && laraDependants != null)
+        {
+            ReplaceLaraDependants(levelModels, definition.Model, laraDependants.Select(e => (short)e));
+        }
+    }
+
+    private void ReplaceLaraDependants(List<TRModel> models, TRModel lara, IEnumerable<short> entityIDs)
+    {
+        foreach (short dependant in entityIDs)
+        {
+            TRModel dependentModel = models.Find(m => m.ID == dependant);
+            if (dependentModel != null)
+            {
+                dependentModel.MeshTree = lara.MeshTree;
+                dependentModel.StartingMesh = lara.StartingMesh;
             }
         }
     }

--- a/TRModelTransporter/Handlers/ModelTransportHandler.cs
+++ b/TRModelTransporter/Handlers/ModelTransportHandler.cs
@@ -6,28 +6,28 @@ namespace TRModelTransporter.Handlers;
 
 public class ModelTransportHandler
 {
-    public void Export(TR1Level level, TR1ModelDefinition definition, TREntities entity)
+    public static void Export(TR1Level level, TR1ModelDefinition definition, TREntities entity)
     {
         definition.Model = GetTRModel(level.Models, (short)entity);
     }
 
-    public void Export(TR2Level level, TR2ModelDefinition definition, TR2Entities entity)
+    public static void Export(TR2Level level, TR2ModelDefinition definition, TR2Entities entity)
     {
         definition.Model = GetTRModel(level.Models, (short)entity);
     }
 
-    public void Export(TR3Level level, TR3ModelDefinition definition, TR3Entities entity)
+    public static void Export(TR3Level level, TR3ModelDefinition definition, TR3Entities entity)
     {
         definition.Model = GetTRModel(level.Models, (short)entity);
     }
 
-    private TRModel GetTRModel(IEnumerable<TRModel> models, short entityID)
+    private static TRModel GetTRModel(IEnumerable<TRModel> models, short entityID)
     {
         TRModel model = models.ToList().Find(m => m.ID == entityID);
         return model ?? throw new ArgumentException($"The model for {entityID} could not be found.");
     }
 
-    public void Import(TR1Level level, TR1ModelDefinition definition, Dictionary<TREntities, TREntities> aliasPriority, IEnumerable<TREntities> laraDependants)
+    public static void Import(TR1Level level, TR1ModelDefinition definition, Dictionary<TREntities, TREntities> aliasPriority, IEnumerable<TREntities> laraDependants)
     {
         List<TRModel> levelModels = level.Models.ToList();
         int i = levelModels.FindIndex(m => m.ID == (short)definition.Entity);
@@ -62,7 +62,7 @@ public class ModelTransportHandler
         }
     }
 
-    public void Import(TR2Level level, TR2ModelDefinition definition, Dictionary<TR2Entities, TR2Entities> aliasPriority, IEnumerable<TR2Entities> laraDependants)
+    public static void Import(TR2Level level, TR2ModelDefinition definition, Dictionary<TR2Entities, TR2Entities> aliasPriority, IEnumerable<TR2Entities> laraDependants)
     {
         List<TRModel> levelModels = level.Models.ToList();
         int i = levelModels.FindIndex(m => m.ID == (short)definition.Entity);
@@ -90,7 +90,7 @@ public class ModelTransportHandler
         }
     }
 
-    public void Import(TR3Level level, TR3ModelDefinition definition, Dictionary<TR3Entities, TR3Entities> aliasPriority, IEnumerable<TR3Entities> laraDependants, IEnumerable<TR3Entities> unsafeReplacements)
+    public static void Import(TR3Level level, TR3ModelDefinition definition, Dictionary<TR3Entities, TR3Entities> aliasPriority, IEnumerable<TR3Entities> laraDependants, IEnumerable<TR3Entities> unsafeReplacements)
     {
         List<TRModel> levelModels = level.Models.ToList();
         int i = levelModels.FindIndex(m => m.ID == (short)definition.Entity);
@@ -124,7 +124,7 @@ public class ModelTransportHandler
         }
     }
 
-    private void ReplaceLaraDependants(List<TRModel> models, TRModel lara, IEnumerable<short> entityIDs)
+    private static void ReplaceLaraDependants(List<TRModel> models, TRModel lara, IEnumerable<short> entityIDs)
     {
         foreach (short dependant in entityIDs)
         {

--- a/TRModelTransporter/Handlers/ModelTransportHandler.cs
+++ b/TRModelTransporter/Handlers/ModelTransportHandler.cs
@@ -24,11 +24,7 @@ public class ModelTransportHandler
     private TRModel GetTRModel(IEnumerable<TRModel> models, short entityID)
     {
         TRModel model = models.ToList().Find(m => m.ID == entityID);
-        if (model == null)
-        {
-            throw new ArgumentException(string.Format("The model for {0} could not be found.", entityID));
-        }
-        return model;
+        return model ?? throw new ArgumentException($"The model for {entityID} could not be found.");
     }
 
     public void Import(TR1Level level, TR1ModelDefinition definition, Dictionary<TREntities, TREntities> aliasPriority, IEnumerable<TREntities> laraDependants)

--- a/TRModelTransporter/Handlers/ModelTransportHandler.cs
+++ b/TRModelTransporter/Handlers/ModelTransportHandler.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using TRLevelControl.Model;
+﻿using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;
 using TRModelTransporter.Model.Definitions;
 

--- a/TRModelTransporter/Handlers/Sound/SoundTransportHandler.cs
+++ b/TRModelTransporter/Handlers/Sound/SoundTransportHandler.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using TRLevelControl.Model;
+﻿using TRLevelControl.Model;
 using TRModelTransporter.Model.Definitions;
 
 namespace TRModelTransporter.Handlers;

--- a/TRModelTransporter/Handlers/Sound/SoundTransportHandler.cs
+++ b/TRModelTransporter/Handlers/Sound/SoundTransportHandler.cs
@@ -22,7 +22,7 @@ public class SoundTransportHandler
 
     public void Import(TR1Level level, IEnumerable<TR1ModelDefinition> definitions)
     {
-        SoundUnpacker unpacker = new SoundUnpacker();
+        SoundUnpacker unpacker = new();
         foreach (TR1ModelDefinition definition in definitions)
         {
             if (definition.HardcodedSound != null)
@@ -34,7 +34,7 @@ public class SoundTransportHandler
 
     public void Import(TR2Level level, IEnumerable<TR2ModelDefinition> definitions)
     {
-        SoundUnpacker unpacker = new SoundUnpacker();
+        SoundUnpacker unpacker = new();
         foreach (TR2ModelDefinition definition in definitions)
         {
             if (definition.HardcodedSound != null)
@@ -46,7 +46,7 @@ public class SoundTransportHandler
 
     public void Import(TR3Level level, IEnumerable<TR3ModelDefinition> definitions)
     {
-        SoundUnpacker unpacker = new SoundUnpacker();
+        SoundUnpacker unpacker = new();
         foreach (TR3ModelDefinition definition in definitions)
         {
             if (definition.HardcodedSound != null)

--- a/TRModelTransporter/Handlers/Sound/SoundTransportHandler.cs
+++ b/TRModelTransporter/Handlers/Sound/SoundTransportHandler.cs
@@ -5,22 +5,22 @@ namespace TRModelTransporter.Handlers;
 
 public class SoundTransportHandler
 {
-    public void Export(TR1Level level, TR1ModelDefinition definition, short[] hardcodedSounds)
+    public static void Export(TR1Level level, TR1ModelDefinition definition, short[] hardcodedSounds)
     {
         definition.HardcodedSound = SoundUtilities.BuildPackedSound(level.SoundMap, level.SoundDetails, level.SampleIndices, level.Samples, hardcodedSounds);
     }
 
-    public void Export(TR2Level level, TR2ModelDefinition definition, short[] hardcodedSounds)
+    public static void Export(TR2Level level, TR2ModelDefinition definition, short[] hardcodedSounds)
     {
         definition.HardcodedSound = SoundUtilities.BuildPackedSound(level.SoundMap, level.SoundDetails, level.SampleIndices, hardcodedSounds);
     }
 
-    public void Export(TR3Level level, TR3ModelDefinition definition, short[] hardcodedSounds)
+    public static void Export(TR3Level level, TR3ModelDefinition definition, short[] hardcodedSounds)
     {
         definition.HardcodedSound = SoundUtilities.BuildPackedSound(level.SoundMap, level.SoundDetails, level.SampleIndices, hardcodedSounds);
     }
 
-    public void Import(TR1Level level, IEnumerable<TR1ModelDefinition> definitions)
+    public static void Import(TR1Level level, IEnumerable<TR1ModelDefinition> definitions)
     {
         SoundUnpacker unpacker = new();
         foreach (TR1ModelDefinition definition in definitions)
@@ -32,7 +32,7 @@ public class SoundTransportHandler
         }
     }
 
-    public void Import(TR2Level level, IEnumerable<TR2ModelDefinition> definitions)
+    public static void Import(TR2Level level, IEnumerable<TR2ModelDefinition> definitions)
     {
         SoundUnpacker unpacker = new();
         foreach (TR2ModelDefinition definition in definitions)
@@ -44,7 +44,7 @@ public class SoundTransportHandler
         }
     }
 
-    public void Import(TR3Level level, IEnumerable<TR3ModelDefinition> definitions)
+    public static void Import(TR3Level level, IEnumerable<TR3ModelDefinition> definitions)
     {
         SoundUnpacker unpacker = new();
         foreach (TR3ModelDefinition definition in definitions)

--- a/TRModelTransporter/Handlers/Sound/SoundTransportHandler.cs
+++ b/TRModelTransporter/Handlers/Sound/SoundTransportHandler.cs
@@ -2,58 +2,57 @@
 using TRLevelControl.Model;
 using TRModelTransporter.Model.Definitions;
 
-namespace TRModelTransporter.Handlers
+namespace TRModelTransporter.Handlers;
+
+public class SoundTransportHandler
 {
-    public class SoundTransportHandler
+    public void Export(TR1Level level, TR1ModelDefinition definition, short[] hardcodedSounds)
     {
-        public void Export(TR1Level level, TR1ModelDefinition definition, short[] hardcodedSounds)
-        {
-            definition.HardcodedSound = SoundUtilities.BuildPackedSound(level.SoundMap, level.SoundDetails, level.SampleIndices, level.Samples, hardcodedSounds);
-        }
+        definition.HardcodedSound = SoundUtilities.BuildPackedSound(level.SoundMap, level.SoundDetails, level.SampleIndices, level.Samples, hardcodedSounds);
+    }
 
-        public void Export(TR2Level level, TR2ModelDefinition definition, short[] hardcodedSounds)
-        {
-            definition.HardcodedSound = SoundUtilities.BuildPackedSound(level.SoundMap, level.SoundDetails, level.SampleIndices, hardcodedSounds);
-        }
+    public void Export(TR2Level level, TR2ModelDefinition definition, short[] hardcodedSounds)
+    {
+        definition.HardcodedSound = SoundUtilities.BuildPackedSound(level.SoundMap, level.SoundDetails, level.SampleIndices, hardcodedSounds);
+    }
 
-        public void Export(TR3Level level, TR3ModelDefinition definition, short[] hardcodedSounds)
-        {
-            definition.HardcodedSound = SoundUtilities.BuildPackedSound(level.SoundMap, level.SoundDetails, level.SampleIndices, hardcodedSounds);
-        }
+    public void Export(TR3Level level, TR3ModelDefinition definition, short[] hardcodedSounds)
+    {
+        definition.HardcodedSound = SoundUtilities.BuildPackedSound(level.SoundMap, level.SoundDetails, level.SampleIndices, hardcodedSounds);
+    }
 
-        public void Import(TR1Level level, IEnumerable<TR1ModelDefinition> definitions)
+    public void Import(TR1Level level, IEnumerable<TR1ModelDefinition> definitions)
+    {
+        SoundUnpacker unpacker = new SoundUnpacker();
+        foreach (TR1ModelDefinition definition in definitions)
         {
-            SoundUnpacker unpacker = new SoundUnpacker();
-            foreach (TR1ModelDefinition definition in definitions)
+            if (definition.HardcodedSound != null)
             {
-                if (definition.HardcodedSound != null)
-                {
-                    unpacker.Unpack(definition.HardcodedSound, level, true);
-                }
+                unpacker.Unpack(definition.HardcodedSound, level, true);
             }
         }
+    }
 
-        public void Import(TR2Level level, IEnumerable<TR2ModelDefinition> definitions)
+    public void Import(TR2Level level, IEnumerable<TR2ModelDefinition> definitions)
+    {
+        SoundUnpacker unpacker = new SoundUnpacker();
+        foreach (TR2ModelDefinition definition in definitions)
         {
-            SoundUnpacker unpacker = new SoundUnpacker();
-            foreach (TR2ModelDefinition definition in definitions)
+            if (definition.HardcodedSound != null)
             {
-                if (definition.HardcodedSound != null)
-                {
-                    unpacker.Unpack(definition.HardcodedSound, level, true);
-                }
+                unpacker.Unpack(definition.HardcodedSound, level, true);
             }
         }
+    }
 
-        public void Import(TR3Level level, IEnumerable<TR3ModelDefinition> definitions)
+    public void Import(TR3Level level, IEnumerable<TR3ModelDefinition> definitions)
+    {
+        SoundUnpacker unpacker = new SoundUnpacker();
+        foreach (TR3ModelDefinition definition in definitions)
         {
-            SoundUnpacker unpacker = new SoundUnpacker();
-            foreach (TR3ModelDefinition definition in definitions)
+            if (definition.HardcodedSound != null)
             {
-                if (definition.HardcodedSound != null)
-                {
-                    unpacker.Unpack(definition.HardcodedSound, level, true);
-                }
+                unpacker.Unpack(definition.HardcodedSound, level, true);
             }
         }
     }

--- a/TRModelTransporter/Handlers/Sound/SoundUnpacker.cs
+++ b/TRModelTransporter/Handlers/Sound/SoundUnpacker.cs
@@ -66,7 +66,7 @@ public class SoundUnpacker
     {
         // For TR1, sample WAVs are stored in the level files so we need to import each one provided
         // they don't already exist. Remap the sound keys to the new offset into Samples[].
-        Dictionary<uint, uint> sampleMap = new Dictionary<uint, uint>();
+        Dictionary<uint, uint> sampleMap = new();
         _samples = level.Samples.ToList();
 
         foreach (uint sampleIndex in sampleData.Keys)

--- a/TRModelTransporter/Handlers/Sound/SoundUnpacker.cs
+++ b/TRModelTransporter/Handlers/Sound/SoundUnpacker.cs
@@ -3,332 +3,331 @@ using System.Linq;
 using TRLevelControl.Model;
 using TRModelTransporter.Model.Sound;
 
-namespace TRModelTransporter.Handlers
+namespace TRModelTransporter.Handlers;
+
+public class SoundUnpacker
 {
-    public class SoundUnpacker
+    private static readonly int _maxTR1Sounds = 256;
+    private static readonly int _maxTR2Sounds = 370;
+    private static readonly int _maxTR3Sounds = 450; // TR3+
+
+    private List<uint> _sampleIndices;
+    private List<short> _soundMap;
+    private List<byte> _samples;
+
+    private Dictionary<uint, ushort> _sampleMap;
+    private Dictionary<int, int> _soundDetailsMap;
+    private Dictionary<int, int> _soundIndexMap;
+
+    public IReadOnlyDictionary<int, int> SoundIndexMap => _soundIndexMap;
+
+    public void Unpack(TR1PackedSound sound, TR1Level level, bool retainInternalIndices = false)
     {
-        private static readonly int _maxTR1Sounds = 256;
-        private static readonly int _maxTR2Sounds = 370;
-        private static readonly int _maxTR3Sounds = 450; // TR3+
+        Dictionary<uint, uint> sampleDataMap = ImportSamples(level, sound.Samples);
+        GenerateSampleMap(level.SampleIndices, sound.SampleIndices, sampleDataMap);
+        List<TRSoundDetails> soundDetails = GenerateSoundDetailsMap(level.SoundDetails, sound.SoundDetails);
+        GenerateSoundIndexMap(level, retainInternalIndices, sound.SoundMapIndices);
 
-        private List<uint> _sampleIndices;
-        private List<short> _soundMap;
-        private List<byte> _samples;
+        level.Samples = _samples.ToArray();
+        level.NumSamples = (uint)_samples.Count;
 
-        private Dictionary<uint, ushort> _sampleMap;
-        private Dictionary<int, int> _soundDetailsMap;
-        private Dictionary<int, int> _soundIndexMap;
+        level.SampleIndices = _sampleIndices.ToArray();
+        level.NumSampleIndices = (uint)_sampleIndices.Count;
 
-        public IReadOnlyDictionary<int, int> SoundIndexMap => _soundIndexMap;
+        level.SoundDetails = soundDetails.ToArray();
+        level.NumSoundDetails = (uint)soundDetails.Count;
+    }
 
-        public void Unpack(TR1PackedSound sound, TR1Level level, bool retainInternalIndices = false)
+    public void Unpack(TR2PackedSound sound, TR2Level level, bool retainInternalIndices = false)
+    {
+        GenerateSampleMap(level.SampleIndices, sound.SampleIndices);
+        List<TRSoundDetails> soundDetails = GenerateSoundDetailsMap(level.SoundDetails, sound.SoundDetails);
+        GenerateSoundIndexMap(level, retainInternalIndices, sound.SoundMapIndices);
+
+        level.SampleIndices = _sampleIndices.ToArray();
+        level.NumSampleIndices = (uint)_sampleIndices.Count;
+
+        level.SoundDetails = soundDetails.ToArray();
+        level.NumSoundDetails = (uint)soundDetails.Count;
+    }
+
+    public void Unpack(TR3PackedSound sound, TR3Level level, bool retainInternalIndices = false)
+    {
+        GenerateSampleMap(level.SampleIndices, sound.SampleIndices);
+        List<TR3SoundDetails> soundDetails = GenerateSoundDetailsMap(level.SoundDetails, sound.SoundDetails);
+        GenerateSoundIndexMap(level, retainInternalIndices, sound.SoundMapIndices);
+
+        level.SampleIndices = _sampleIndices.ToArray();
+        level.NumSampleIndices = (uint)_sampleIndices.Count;
+
+        level.SoundDetails = soundDetails.ToArray();
+        level.NumSoundDetails = (uint)soundDetails.Count;
+    }
+
+    private Dictionary<uint, uint> ImportSamples(TR1Level level, Dictionary<uint, byte[]> sampleData)
+    {
+        // For TR1, sample WAVs are stored in the level files so we need to import each one provided
+        // they don't already exist. Remap the sound keys to the new offset into Samples[].
+        Dictionary<uint, uint> sampleMap = new Dictionary<uint, uint>();
+        _samples = level.Samples.ToList();
+
+        foreach (uint sampleIndex in sampleData.Keys)
         {
-            Dictionary<uint, uint> sampleDataMap = ImportSamples(level, sound.Samples);
-            GenerateSampleMap(level.SampleIndices, sound.SampleIndices, sampleDataMap);
-            List<TRSoundDetails> soundDetails = GenerateSoundDetailsMap(level.SoundDetails, sound.SoundDetails);
-            GenerateSoundIndexMap(level, retainInternalIndices, sound.SoundMapIndices);
-
-            level.Samples = _samples.ToArray();
-            level.NumSamples = (uint)_samples.Count;
-
-            level.SampleIndices = _sampleIndices.ToArray();
-            level.NumSampleIndices = (uint)_sampleIndices.Count;
-
-            level.SoundDetails = soundDetails.ToArray();
-            level.NumSoundDetails = (uint)soundDetails.Count;
+            sampleMap[sampleIndex] = (uint)_samples.Count;
+            _samples.AddRange(sampleData[sampleIndex]);
         }
 
-        public void Unpack(TR2PackedSound sound, TR2Level level, bool retainInternalIndices = false)
+        return sampleMap;
+    }
+
+    private void GenerateSampleMap(uint[] sampleIndices, Dictionary<ushort, uint[]> packedIndices, Dictionary<uint, uint> sampleKeyMap = null)
+    {
+        // Insert each required SampleIndex value, which are the values that point into
+        // MAIN.SFX (or Samples[] in TR1). Note the first inserted index for updating
+        // the relevant SoundDetails.Sample.
+        _sampleIndices = sampleIndices.ToList();
+        _sampleMap = new Dictionary<uint, ushort>();
+
+        foreach (ushort sampleIndex in packedIndices.Keys)
         {
-            GenerateSampleMap(level.SampleIndices, sound.SampleIndices);
-            List<TRSoundDetails> soundDetails = GenerateSoundDetailsMap(level.SoundDetails, sound.SoundDetails);
-            GenerateSoundIndexMap(level, retainInternalIndices, sound.SoundMapIndices);
-
-            level.SampleIndices = _sampleIndices.ToArray();
-            level.NumSampleIndices = (uint)_sampleIndices.Count;
-
-            level.SoundDetails = soundDetails.ToArray();
-            level.NumSoundDetails = (uint)soundDetails.Count;
-        }
-
-        public void Unpack(TR3PackedSound sound, TR3Level level, bool retainInternalIndices = false)
-        {
-            GenerateSampleMap(level.SampleIndices, sound.SampleIndices);
-            List<TR3SoundDetails> soundDetails = GenerateSoundDetailsMap(level.SoundDetails, sound.SoundDetails);
-            GenerateSoundIndexMap(level, retainInternalIndices, sound.SoundMapIndices);
-
-            level.SampleIndices = _sampleIndices.ToArray();
-            level.NumSampleIndices = (uint)_sampleIndices.Count;
-
-            level.SoundDetails = soundDetails.ToArray();
-            level.NumSoundDetails = (uint)soundDetails.Count;
-        }
-
-        private Dictionary<uint, uint> ImportSamples(TR1Level level, Dictionary<uint, byte[]> sampleData)
-        {
-            // For TR1, sample WAVs are stored in the level files so we need to import each one provided
-            // they don't already exist. Remap the sound keys to the new offset into Samples[].
-            Dictionary<uint, uint> sampleMap = new Dictionary<uint, uint>();
-            _samples = level.Samples.ToList();
-
-            foreach (uint sampleIndex in sampleData.Keys)
+            uint[] sampleValues = packedIndices[sampleIndex];
+            if (sampleValues.Length > 0)
             {
-                sampleMap[sampleIndex] = (uint)_samples.Count;
-                _samples.AddRange(sampleData[sampleIndex]);
-            }
-
-            return sampleMap;
-        }
-
-        private void GenerateSampleMap(uint[] sampleIndices, Dictionary<ushort, uint[]> packedIndices, Dictionary<uint, uint> sampleKeyMap = null)
-        {
-            // Insert each required SampleIndex value, which are the values that point into
-            // MAIN.SFX (or Samples[] in TR1). Note the first inserted index for updating
-            // the relevant SoundDetails.Sample.
-            _sampleIndices = sampleIndices.ToList();
-            _sampleMap = new Dictionary<uint, ushort>();
-
-            foreach (ushort sampleIndex in packedIndices.Keys)
-            {
-                uint[] sampleValues = packedIndices[sampleIndex];
-                if (sampleValues.Length > 0)
+                // Store each value as long as it does not already exist. Keep a reference to
+                // the first index so we can update the SoundDetails pointer.
+                uint firstSample = 0;
+                for (int i = 0; i < sampleValues.Length; i++)
                 {
-                    // Store each value as long as it does not already exist. Keep a reference to
-                    // the first index so we can update the SoundDetails pointer.
-                    uint firstSample = 0;
-                    for (int i = 0; i < sampleValues.Length; i++)
+                    uint sampleKey = sampleValues[i];
+                    // We may have remapped the sample key (for TR1) so get the new sample pointer
+                    if (sampleKeyMap != null && sampleKeyMap.ContainsKey(sampleValues[i]))
                     {
-                        uint sampleKey = sampleValues[i];
-                        // We may have remapped the sample key (for TR1) so get the new sample pointer
-                        if (sampleKeyMap != null && sampleKeyMap.ContainsKey(sampleValues[i]))
-                        {
-                            sampleKey = sampleKeyMap[sampleValues[i]];
-                        }
-
-                        if (!_sampleIndices.Contains(sampleKey))
-                        {
-                            _sampleIndices.Add(sampleKey);
-                        }
-
-                        if (i == 0)
-                        {
-                            firstSample = sampleKey;
-                        }
+                        sampleKey = sampleKeyMap[sampleValues[i]];
                     }
 
-                    // Store the new index of the first sample
-                    _sampleMap[sampleIndex] = (ushort)_sampleIndices.IndexOf(firstSample);
+                    if (!_sampleIndices.Contains(sampleKey))
+                    {
+                        _sampleIndices.Add(sampleKey);
+                    }
+
+                    if (i == 0)
+                    {
+                        firstSample = sampleKey;
+                    }
                 }
+
+                // Store the new index of the first sample
+                _sampleMap[sampleIndex] = (ushort)_sampleIndices.IndexOf(firstSample);
+            }
+        }
+    }
+
+    // TR1-2
+    private List<TRSoundDetails> GenerateSoundDetailsMap(TRSoundDetails[] currentSoundDetails, Dictionary<int, TRSoundDetails> packedSoundDetails)
+    {
+        // Update each SoundDetails.Sample with the new SampleIndex values. Store
+        // a map of old SoundsDetails indices to new.
+        List<TRSoundDetails> soundDetails = currentSoundDetails.ToList();
+        _soundDetailsMap = new Dictionary<int, int>();
+
+        foreach (int soundDetailsIndex in packedSoundDetails.Keys)
+        {
+            TRSoundDetails details = packedSoundDetails[soundDetailsIndex];
+            details.Sample = _sampleMap[details.Sample];
+            // Avoid duplication of sounds details for tidiness
+            int currentIndex = FindSoundDetailsIndex(details, soundDetails);
+            if (currentIndex == -1)
+            {
+                _soundDetailsMap[soundDetailsIndex] = soundDetails.Count;
+                soundDetails.Add(details);
+            }
+            else
+            {
+                _soundDetailsMap[soundDetailsIndex] = currentIndex;
             }
         }
 
-        // TR1-2
-        private List<TRSoundDetails> GenerateSoundDetailsMap(TRSoundDetails[] currentSoundDetails, Dictionary<int, TRSoundDetails> packedSoundDetails)
-        {
-            // Update each SoundDetails.Sample with the new SampleIndex values. Store
-            // a map of old SoundsDetails indices to new.
-            List<TRSoundDetails> soundDetails = currentSoundDetails.ToList();
-            _soundDetailsMap = new Dictionary<int, int>();
+        return soundDetails;
+    }
 
-            foreach (int soundDetailsIndex in packedSoundDetails.Keys)
+    // TR3+
+    private List<TR3SoundDetails> GenerateSoundDetailsMap(TR3SoundDetails[] currentSoundDetails, Dictionary<int, TR3SoundDetails> packedSoundDetails)
+    {
+        List<TR3SoundDetails> soundDetails = currentSoundDetails.ToList();
+        _soundDetailsMap = new Dictionary<int, int>();
+
+        foreach (int soundDetailsIndex in packedSoundDetails.Keys)
+        {
+            TR3SoundDetails details = packedSoundDetails[soundDetailsIndex];
+            details.Sample = _sampleMap[details.Sample];
+
+            int currentIndex = FindSoundDetailsIndex(details, soundDetails);
+            if (currentIndex == -1)
             {
-                TRSoundDetails details = packedSoundDetails[soundDetailsIndex];
-                details.Sample = _sampleMap[details.Sample];
-                // Avoid duplication of sounds details for tidiness
-                int currentIndex = FindSoundDetailsIndex(details, soundDetails);
-                if (currentIndex == -1)
+                _soundDetailsMap[soundDetailsIndex] = soundDetails.Count;
+                soundDetails.Add(details);
+            }
+            else
+            {
+                _soundDetailsMap[soundDetailsIndex] = currentIndex;
+            }
+        }
+
+        return soundDetails;
+    }
+
+    private int FindSoundDetailsIndex(TRSoundDetails details, List<TRSoundDetails> allDetails)
+    {
+        return allDetails.FindIndex
+        (
+            d => 
+                d.Chance == details.Chance && 
+                d.Characteristics == details.Characteristics && 
+                d.Sample == details.Sample && 
+                d.Volume == details.Volume
+        );
+    }
+
+    private int FindSoundDetailsIndex(TR3SoundDetails details, List<TR3SoundDetails> allDetails)
+    {
+        return allDetails.FindIndex
+        (
+            d =>
+                d.Chance == details.Chance &&
+                d.Characteristics == details.Characteristics &&
+                d.Range == details.Range &&
+                d.Sample == details.Sample &&
+                d.Volume == details.Volume
+        );
+    }
+
+    private void GenerateSoundIndexMap(TR1Level level, bool retainInternalIndices, Dictionary<int, short> packedSoundMapIndices)
+    {
+        _soundIndexMap = new Dictionary<int, int>();
+        if (retainInternalIndices)
+        {
+            // This covers instances where internal sound indices are hard-coded in the game so
+            // we have to retain those indices, but simply point them to the new SoundDetails
+            foreach (int soundMapIndex in packedSoundMapIndices.Keys)
+            {
+                level.SoundMap[soundMapIndex] = (short)_soundDetailsMap[packedSoundMapIndices[soundMapIndex]];
+                _soundIndexMap[soundMapIndex] = level.SoundMap[soundMapIndex];
+            }
+        }
+        else
+        {
+            _soundMap = level.SoundMap.ToList();
+            foreach (int soundMapIndex in packedSoundMapIndices.Keys)
+            {
+                // Sanity check
+                if (soundMapIndex < 0 || soundMapIndex > _maxTR1Sounds - 1)
                 {
-                    _soundDetailsMap[soundDetailsIndex] = soundDetails.Count;
-                    soundDetails.Add(details);
+                    continue;
+                }
+
+                short currentSoundDetailsIndex = packedSoundMapIndices[soundMapIndex];
+                // For null indices, just point to the first existing null in the level
+                if (currentSoundDetailsIndex == -1)
+                {
+                    _soundIndexMap[soundMapIndex] = _soundMap.FindIndex(i => i == -1);
                 }
                 else
                 {
-                    _soundDetailsMap[soundDetailsIndex] = currentIndex;
+                    // Only insert the new SoundDetails index provided there isn't something there already
+                    if (_soundMap[soundMapIndex] == -1)
+                    {
+                        short newSoundDetailsIndex = (short)_soundDetailsMap[currentSoundDetailsIndex];
+                        level.SoundMap[soundMapIndex] = _soundMap[soundMapIndex] = newSoundDetailsIndex;
+                    }
+                    _soundIndexMap[soundMapIndex] = soundMapIndex;
                 }
             }
-
-            return soundDetails;
         }
+    }
 
-        // TR3+
-        private List<TR3SoundDetails> GenerateSoundDetailsMap(TR3SoundDetails[] currentSoundDetails, Dictionary<int, TR3SoundDetails> packedSoundDetails)
+    private void GenerateSoundIndexMap(TR2Level level, bool retainInternalIndices, Dictionary<int, short> packedSoundMapIndices)
+    {
+        _soundIndexMap = new Dictionary<int, int>();
+        if (retainInternalIndices)
         {
-            List<TR3SoundDetails> soundDetails = currentSoundDetails.ToList();
-            _soundDetailsMap = new Dictionary<int, int>();
-
-            foreach (int soundDetailsIndex in packedSoundDetails.Keys)
+            // This covers instances where internal sound indices are hard-coded in the game so
+            // we have to retain those indices, but simply point them to the new SoundDetails
+            foreach (int soundMapIndex in packedSoundMapIndices.Keys)
             {
-                TR3SoundDetails details = packedSoundDetails[soundDetailsIndex];
-                details.Sample = _sampleMap[details.Sample];
-
-                int currentIndex = FindSoundDetailsIndex(details, soundDetails);
-                if (currentIndex == -1)
+                level.SoundMap[soundMapIndex] = (short)_soundDetailsMap[packedSoundMapIndices[soundMapIndex]];
+                _soundIndexMap[soundMapIndex] = level.SoundMap[soundMapIndex];
+            }
+        }
+        else
+        {
+            _soundMap = level.SoundMap.ToList();
+            foreach (int soundMapIndex in packedSoundMapIndices.Keys)
+            {
+                // Sanity check
+                if (soundMapIndex < 0 || soundMapIndex > _maxTR2Sounds - 1)
                 {
-                    _soundDetailsMap[soundDetailsIndex] = soundDetails.Count;
-                    soundDetails.Add(details);
+                    continue;
+                }
+
+                short currentSoundDetailsIndex = packedSoundMapIndices[soundMapIndex];
+                // For null indices, just point to the first existing null in the level
+                if (currentSoundDetailsIndex == -1)
+                {
+                    _soundIndexMap[soundMapIndex] = _soundMap.FindIndex(i => i == -1);
                 }
                 else
                 {
-                    _soundDetailsMap[soundDetailsIndex] = currentIndex;
-                }
-            }
-
-            return soundDetails;
-        }
-
-        private int FindSoundDetailsIndex(TRSoundDetails details, List<TRSoundDetails> allDetails)
-        {
-            return allDetails.FindIndex
-            (
-                d => 
-                    d.Chance == details.Chance && 
-                    d.Characteristics == details.Characteristics && 
-                    d.Sample == details.Sample && 
-                    d.Volume == details.Volume
-            );
-        }
-
-        private int FindSoundDetailsIndex(TR3SoundDetails details, List<TR3SoundDetails> allDetails)
-        {
-            return allDetails.FindIndex
-            (
-                d =>
-                    d.Chance == details.Chance &&
-                    d.Characteristics == details.Characteristics &&
-                    d.Range == details.Range &&
-                    d.Sample == details.Sample &&
-                    d.Volume == details.Volume
-            );
-        }
-
-        private void GenerateSoundIndexMap(TR1Level level, bool retainInternalIndices, Dictionary<int, short> packedSoundMapIndices)
-        {
-            _soundIndexMap = new Dictionary<int, int>();
-            if (retainInternalIndices)
-            {
-                // This covers instances where internal sound indices are hard-coded in the game so
-                // we have to retain those indices, but simply point them to the new SoundDetails
-                foreach (int soundMapIndex in packedSoundMapIndices.Keys)
-                {
-                    level.SoundMap[soundMapIndex] = (short)_soundDetailsMap[packedSoundMapIndices[soundMapIndex]];
-                    _soundIndexMap[soundMapIndex] = level.SoundMap[soundMapIndex];
-                }
-            }
-            else
-            {
-                _soundMap = level.SoundMap.ToList();
-                foreach (int soundMapIndex in packedSoundMapIndices.Keys)
-                {
-                    // Sanity check
-                    if (soundMapIndex < 0 || soundMapIndex > _maxTR1Sounds - 1)
+                    // Only insert the new SoundDetails index provided there isn't something there already
+                    if (_soundMap[soundMapIndex] == -1)
                     {
-                        continue;
+                        short newSoundDetailsIndex = (short)_soundDetailsMap[currentSoundDetailsIndex];
+                        level.SoundMap[soundMapIndex] = _soundMap[soundMapIndex] = newSoundDetailsIndex;
                     }
-
-                    short currentSoundDetailsIndex = packedSoundMapIndices[soundMapIndex];
-                    // For null indices, just point to the first existing null in the level
-                    if (currentSoundDetailsIndex == -1)
-                    {
-                        _soundIndexMap[soundMapIndex] = _soundMap.FindIndex(i => i == -1);
-                    }
-                    else
-                    {
-                        // Only insert the new SoundDetails index provided there isn't something there already
-                        if (_soundMap[soundMapIndex] == -1)
-                        {
-                            short newSoundDetailsIndex = (short)_soundDetailsMap[currentSoundDetailsIndex];
-                            level.SoundMap[soundMapIndex] = _soundMap[soundMapIndex] = newSoundDetailsIndex;
-                        }
-                        _soundIndexMap[soundMapIndex] = soundMapIndex;
-                    }
+                    _soundIndexMap[soundMapIndex] = soundMapIndex;
                 }
             }
         }
+    }
 
-        private void GenerateSoundIndexMap(TR2Level level, bool retainInternalIndices, Dictionary<int, short> packedSoundMapIndices)
+    private void GenerateSoundIndexMap(TR3Level level, bool retainInternalIndices, Dictionary<int, short> packedSoundMapIndices)
+    {
+        _soundIndexMap = new Dictionary<int, int>();
+        if (retainInternalIndices)
         {
-            _soundIndexMap = new Dictionary<int, int>();
-            if (retainInternalIndices)
+            // This covers instances where internal sound indices are hard-coded in the game so
+            // we have to retain those indices, but simply point them to the new SoundDetails
+            foreach (int soundMapIndex in packedSoundMapIndices.Keys)
             {
-                // This covers instances where internal sound indices are hard-coded in the game so
-                // we have to retain those indices, but simply point them to the new SoundDetails
-                foreach (int soundMapIndex in packedSoundMapIndices.Keys)
-                {
-                    level.SoundMap[soundMapIndex] = (short)_soundDetailsMap[packedSoundMapIndices[soundMapIndex]];
-                    _soundIndexMap[soundMapIndex] = level.SoundMap[soundMapIndex];
-                }
-            }
-            else
-            {
-                _soundMap = level.SoundMap.ToList();
-                foreach (int soundMapIndex in packedSoundMapIndices.Keys)
-                {
-                    // Sanity check
-                    if (soundMapIndex < 0 || soundMapIndex > _maxTR2Sounds - 1)
-                    {
-                        continue;
-                    }
-
-                    short currentSoundDetailsIndex = packedSoundMapIndices[soundMapIndex];
-                    // For null indices, just point to the first existing null in the level
-                    if (currentSoundDetailsIndex == -1)
-                    {
-                        _soundIndexMap[soundMapIndex] = _soundMap.FindIndex(i => i == -1);
-                    }
-                    else
-                    {
-                        // Only insert the new SoundDetails index provided there isn't something there already
-                        if (_soundMap[soundMapIndex] == -1)
-                        {
-                            short newSoundDetailsIndex = (short)_soundDetailsMap[currentSoundDetailsIndex];
-                            level.SoundMap[soundMapIndex] = _soundMap[soundMapIndex] = newSoundDetailsIndex;
-                        }
-                        _soundIndexMap[soundMapIndex] = soundMapIndex;
-                    }
-                }
+                level.SoundMap[soundMapIndex] = (short)_soundDetailsMap[packedSoundMapIndices[soundMapIndex]];
+                _soundIndexMap[soundMapIndex] = level.SoundMap[soundMapIndex];
             }
         }
-
-        private void GenerateSoundIndexMap(TR3Level level, bool retainInternalIndices, Dictionary<int, short> packedSoundMapIndices)
+        else
         {
-            _soundIndexMap = new Dictionary<int, int>();
-            if (retainInternalIndices)
+            _soundMap = level.SoundMap.ToList();
+            foreach (int soundMapIndex in packedSoundMapIndices.Keys)
             {
-                // This covers instances where internal sound indices are hard-coded in the game so
-                // we have to retain those indices, but simply point them to the new SoundDetails
-                foreach (int soundMapIndex in packedSoundMapIndices.Keys)
+                // Sanity check
+                if (soundMapIndex < 0 || soundMapIndex > _maxTR3Sounds - 1)
                 {
-                    level.SoundMap[soundMapIndex] = (short)_soundDetailsMap[packedSoundMapIndices[soundMapIndex]];
-                    _soundIndexMap[soundMapIndex] = level.SoundMap[soundMapIndex];
+                    continue;
                 }
-            }
-            else
-            {
-                _soundMap = level.SoundMap.ToList();
-                foreach (int soundMapIndex in packedSoundMapIndices.Keys)
-                {
-                    // Sanity check
-                    if (soundMapIndex < 0 || soundMapIndex > _maxTR3Sounds - 1)
-                    {
-                        continue;
-                    }
 
-                    short currentSoundDetailsIndex = packedSoundMapIndices[soundMapIndex];
-                    // For null indices, just point to the first existing null in the level
-                    if (currentSoundDetailsIndex == -1)
+                short currentSoundDetailsIndex = packedSoundMapIndices[soundMapIndex];
+                // For null indices, just point to the first existing null in the level
+                if (currentSoundDetailsIndex == -1)
+                {
+                    _soundIndexMap[soundMapIndex] = _soundMap.FindIndex(i => i == -1);
+                }
+                else
+                {
+                    // Only insert the new SoundDetails index provided there isn't something there already
+                    if (_soundMap[soundMapIndex] == -1)
                     {
-                        _soundIndexMap[soundMapIndex] = _soundMap.FindIndex(i => i == -1);
+                        short newSoundDetailsIndex = (short)_soundDetailsMap[currentSoundDetailsIndex];
+                        level.SoundMap[soundMapIndex] = _soundMap[soundMapIndex] = newSoundDetailsIndex;
                     }
-                    else
-                    {
-                        // Only insert the new SoundDetails index provided there isn't something there already
-                        if (_soundMap[soundMapIndex] == -1)
-                        {
-                            short newSoundDetailsIndex = (short)_soundDetailsMap[currentSoundDetailsIndex];
-                            level.SoundMap[soundMapIndex] = _soundMap[soundMapIndex] = newSoundDetailsIndex;
-                        }
-                        _soundIndexMap[soundMapIndex] = soundMapIndex;
-                    }
+                    _soundIndexMap[soundMapIndex] = soundMapIndex;
                 }
             }
         }

--- a/TRModelTransporter/Handlers/Sound/SoundUnpacker.cs
+++ b/TRModelTransporter/Handlers/Sound/SoundUnpacker.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using TRLevelControl.Model;
+﻿using TRLevelControl.Model;
 using TRModelTransporter.Model.Sound;
 
 namespace TRModelTransporter.Handlers;

--- a/TRModelTransporter/Handlers/Sound/SoundUnpacker.cs
+++ b/TRModelTransporter/Handlers/Sound/SoundUnpacker.cs
@@ -174,7 +174,7 @@ public class SoundUnpacker
         return soundDetails;
     }
 
-    private int FindSoundDetailsIndex(TRSoundDetails details, List<TRSoundDetails> allDetails)
+    private static int FindSoundDetailsIndex(TRSoundDetails details, List<TRSoundDetails> allDetails)
     {
         return allDetails.FindIndex
         (
@@ -186,7 +186,7 @@ public class SoundUnpacker
         );
     }
 
-    private int FindSoundDetailsIndex(TR3SoundDetails details, List<TR3SoundDetails> allDetails)
+    private static int FindSoundDetailsIndex(TR3SoundDetails details, List<TR3SoundDetails> allDetails)
     {
         return allDetails.FindIndex
         (

--- a/TRModelTransporter/Handlers/Sound/SoundUtilities.cs
+++ b/TRModelTransporter/Handlers/Sound/SoundUtilities.cs
@@ -19,7 +19,7 @@ public static class SoundUtilities
             return null;
         }
 
-        TR1PackedSound packedSound = new TR1PackedSound();
+        TR1PackedSound packedSound = new();
 
         short id = -2;
         foreach (int index in hardcodedSounds)
@@ -65,7 +65,7 @@ public static class SoundUtilities
             return null;
         }
 
-        TR2PackedSound packedSound = new TR2PackedSound();
+        TR2PackedSound packedSound = new();
 
         short id = -2;
         foreach (int index in hardcodedSounds)
@@ -107,7 +107,7 @@ public static class SoundUtilities
             return null;
         }
 
-        TR3PackedSound packedSound = new TR3PackedSound();
+        TR3PackedSound packedSound = new();
 
         short id = -2;
         foreach (int index in hardcodedSounds)
@@ -145,10 +145,10 @@ public static class SoundUtilities
 
     public static void ResortSoundIndices(TR1Level level)
     {
-        List<short> newSoundMap = new List<short>();
-        List<TRSoundDetails> newSoundDetails = new List<TRSoundDetails>();
-        List<uint> newSampleIndices = new List<uint>();
-        List<byte> newSamples = new List<byte>();
+        List<short> newSoundMap = new();
+        List<TRSoundDetails> newSoundDetails = new();
+        List<uint> newSampleIndices = new();
+        List<byte> newSamples = new();
 
         for (int soundID = 0; soundID < level.SoundMap.Length; soundID++)
         {
@@ -217,7 +217,7 @@ public static class SoundUtilities
     {
         // Store the values from SampleIndices against their current positions
         // in the list.             
-        Dictionary<int, uint> indexMap = new Dictionary<int, uint>();
+        Dictionary<int, uint> indexMap = new();
         for (int i = 0; i < sampleIndices.Count; i++)
         {
             indexMap[i] = sampleIndices[i];
@@ -233,7 +233,7 @@ public static class SoundUtilities
         }
 
         // Repeat for SoundMap -> SoundDetails
-        Dictionary<int, TRSoundDetails> soundMapIndices = new Dictionary<int, TRSoundDetails>();
+        Dictionary<int, TRSoundDetails> soundMapIndices = new();
         for (int i = 0; i < soundMap.Count; i++)
         {
             if (soundMap[i] != -1)
@@ -258,7 +258,7 @@ public static class SoundUtilities
     {
         // Store the values from SampleIndices against their current positions
         // in the list.             
-        Dictionary<int, uint> indexMap = new Dictionary<int, uint>();
+        Dictionary<int, uint> indexMap = new();
         for (int i = 0; i < sampleIndices.Count; i++)
         {
             indexMap[i] = sampleIndices[i];
@@ -274,7 +274,7 @@ public static class SoundUtilities
         }
 
         // Repeat for SoundMap -> SoundDetails
-        Dictionary<int, TR3SoundDetails> soundMapIndices = new Dictionary<int, TR3SoundDetails>();
+        Dictionary<int, TR3SoundDetails> soundMapIndices = new();
         for (int i = 0; i < soundMap.Count; i++)
         {
             if (soundMap[i] != -1)

--- a/TRModelTransporter/Handlers/Sound/SoundUtilities.cs
+++ b/TRModelTransporter/Handlers/Sound/SoundUtilities.cs
@@ -3,298 +3,297 @@ using System.Linq;
 using TRLevelControl.Model;
 using TRModelTransporter.Model.Sound;
 
-namespace TRModelTransporter.Handlers
+namespace TRModelTransporter.Handlers;
+
+public static class SoundUtilities
 {
-    public static class SoundUtilities
+    public static void ImportLevelSound(TR1Level baseLevel, TR1Level sourceLevel, short[] soundIDs)
     {
-        public static void ImportLevelSound(TR1Level baseLevel, TR1Level sourceLevel, short[] soundIDs)
+        TR1PackedSound sound = BuildPackedSound(sourceLevel.SoundMap, sourceLevel.SoundDetails, sourceLevel.SampleIndices, sourceLevel.Samples, soundIDs);
+        new SoundUnpacker().Unpack(sound, baseLevel);
+        SoundUtilities.ResortSoundIndices(baseLevel);
+    }
+
+    public static TR1PackedSound BuildPackedSound(short[] soundMap, TRSoundDetails[] soundDetails, uint[] sampleIndices, byte[] wavSamples, short[] hardcodedSounds)
+    {
+        if (hardcodedSounds == null || hardcodedSounds.Length == 0)
         {
-            TR1PackedSound sound = BuildPackedSound(sourceLevel.SoundMap, sourceLevel.SoundDetails, sourceLevel.SampleIndices, sourceLevel.Samples, soundIDs);
-            new SoundUnpacker().Unpack(sound, baseLevel);
-            SoundUtilities.ResortSoundIndices(baseLevel);
+            return null;
         }
 
-        public static TR1PackedSound BuildPackedSound(short[] soundMap, TRSoundDetails[] soundDetails, uint[] sampleIndices, byte[] wavSamples, short[] hardcodedSounds)
+        TR1PackedSound packedSound = new TR1PackedSound();
+
+        short id = -2;
+        foreach (int index in hardcodedSounds)
         {
-            if (hardcodedSounds == null || hardcodedSounds.Length == 0)
+            packedSound.SoundMapIndices[index] = id--;
+        }
+
+        int offset = 2;
+        foreach (short index in packedSound.SoundMapIndices.Keys)
+        {
+            short val = packedSound.SoundMapIndices[index];
+            TRSoundDetails details = soundDetails[soundMap[index]];
+
+            uint[] samples = new uint[details.NumSounds];
+            for (int i = 0; i < details.NumSounds; i++)
             {
-                return null;
+                ushort sampleIndex = (ushort)(details.Sample + i);
+                samples[i] = sampleIndices[sampleIndex];
+
+                uint nextIndex = sampleIndex == sampleIndices.Length - 1 ? (uint)wavSamples.Length : sampleIndices[sampleIndex + 1];
+                packedSound.Samples[samples[i]] = AnimationUtilities.GetSample(samples[i], nextIndex, wavSamples);
             }
 
-            TR1PackedSound packedSound = new TR1PackedSound();
+            packedSound.SampleIndices[(ushort)(ushort.MaxValue - offset)] = samples;
 
-            short id = -2;
-            foreach (int index in hardcodedSounds)
+            packedSound.SoundDetails[val] = new TRSoundDetails
             {
-                packedSound.SoundMapIndices[index] = id--;
+                Chance = details.Chance,
+                Characteristics = details.Characteristics,
+                Sample = (ushort)(ushort.MaxValue - offset),
+                Volume = details.Volume
+            };
+            offset++;
+        }
+
+        return packedSound;
+    }
+
+    public static TR2PackedSound BuildPackedSound(short[] soundMap, TRSoundDetails[] soundDetails, uint[] sampleIndices, short[] hardcodedSounds)
+    {
+        if (hardcodedSounds == null || hardcodedSounds.Length == 0)
+        {
+            return null;
+        }
+
+        TR2PackedSound packedSound = new TR2PackedSound();
+
+        short id = -2;
+        foreach (int index in hardcodedSounds)
+        {
+            packedSound.SoundMapIndices[index] = id--;
+        }
+
+        int offset = 2;
+        foreach (short index in packedSound.SoundMapIndices.Keys)
+        {
+            short val = packedSound.SoundMapIndices[index];
+            TRSoundDetails details = soundDetails[soundMap[index]];
+
+            uint[] samples = new uint[details.NumSounds];
+            for (int i = 0; i < details.NumSounds; i++)
+            {
+                samples[i] = sampleIndices[(ushort)(details.Sample + i)];
             }
 
-            int offset = 2;
-            foreach (short index in packedSound.SoundMapIndices.Keys)
-            {
-                short val = packedSound.SoundMapIndices[index];
-                TRSoundDetails details = soundDetails[soundMap[index]];
+            packedSound.SampleIndices[(ushort)(ushort.MaxValue - offset)] = samples;
 
-                uint[] samples = new uint[details.NumSounds];
+            packedSound.SoundDetails[val] = new TRSoundDetails
+            {
+                Chance = details.Chance,
+                Characteristics = details.Characteristics,
+                Sample = (ushort)(ushort.MaxValue - offset),
+                Volume = details.Volume
+            };
+            offset++;
+        }
+
+        return packedSound;
+    }
+
+    public static TR3PackedSound BuildPackedSound(short[] soundMap, TR3SoundDetails[] soundDetails, uint[] sampleIndices, short[] hardcodedSounds)
+    {
+        if (hardcodedSounds == null || hardcodedSounds.Length == 0)
+        {
+            return null;
+        }
+
+        TR3PackedSound packedSound = new TR3PackedSound();
+
+        short id = -2;
+        foreach (int index in hardcodedSounds)
+        {
+            packedSound.SoundMapIndices[index] = id--;
+        }
+
+        int offset = 2;
+        foreach (short index in packedSound.SoundMapIndices.Keys)
+        {
+            short val = packedSound.SoundMapIndices[index];
+            TR3SoundDetails details = soundDetails[soundMap[index]];
+
+            uint[] samples = new uint[details.NumSounds];
+            for (int i = 0; i < details.NumSounds; i++)
+            {
+                samples[i] = sampleIndices[(ushort)(details.Sample + i)];
+            }
+
+            packedSound.SampleIndices[(ushort)(ushort.MaxValue - offset)] = samples;
+
+            packedSound.SoundDetails[val] = new TR3SoundDetails
+            {
+                Chance = details.Chance,
+                Characteristics = details.Characteristics,
+                Sample = (ushort)(ushort.MaxValue - offset),
+                Volume = details.Volume,
+                Range = details.Range
+            };
+            offset++;
+        }
+
+        return packedSound;
+    }
+
+    public static void ResortSoundIndices(TR1Level level)
+    {
+        List<short> newSoundMap = new List<short>();
+        List<TRSoundDetails> newSoundDetails = new List<TRSoundDetails>();
+        List<uint> newSampleIndices = new List<uint>();
+        List<byte> newSamples = new List<byte>();
+
+        for (int soundID = 0; soundID < level.SoundMap.Length; soundID++)
+        {
+            if (level.SoundMap[soundID] == -1)
+            {
+                newSoundMap.Add(-1);
+            }
+            else
+            {
+                TRSoundDetails details = level.SoundDetails[level.SoundMap[soundID]];
+                newSoundMap.Add((short)newSoundDetails.Count);
+                newSoundDetails.Add(details);
+
+                ushort oldSample = details.Sample;
+                details.Sample = (ushort)newSampleIndices.Count;
                 for (int i = 0; i < details.NumSounds; i++)
                 {
-                    ushort sampleIndex = (ushort)(details.Sample + i);
-                    samples[i] = sampleIndices[sampleIndex];
+                    ushort samplePointerIndex = (ushort)(oldSample + i);
 
-                    uint nextIndex = sampleIndex == sampleIndices.Length - 1 ? (uint)wavSamples.Length : sampleIndices[sampleIndex + 1];
-                    packedSound.Samples[samples[i]] = AnimationUtilities.GetSample(samples[i], nextIndex, wavSamples);
+                    uint oldSampleIndex = level.SampleIndices[oldSample + i];
+                    uint nextSampleIndex = samplePointerIndex == level.SampleIndices.Length - 1 ? (uint)level.Samples.Length : level.SampleIndices[samplePointerIndex + 1];
+
+                    newSampleIndices.Add((uint)newSamples.Count);
+                    newSamples.AddRange(AnimationUtilities.GetSample(oldSampleIndex, nextSampleIndex, level.Samples));
                 }
-
-                packedSound.SampleIndices[(ushort)(ushort.MaxValue - offset)] = samples;
-
-                packedSound.SoundDetails[val] = new TRSoundDetails
-                {
-                    Chance = details.Chance,
-                    Characteristics = details.Characteristics,
-                    Sample = (ushort)(ushort.MaxValue - offset),
-                    Volume = details.Volume
-                };
-                offset++;
-            }
-
-            return packedSound;
-        }
-
-        public static TR2PackedSound BuildPackedSound(short[] soundMap, TRSoundDetails[] soundDetails, uint[] sampleIndices, short[] hardcodedSounds)
-        {
-            if (hardcodedSounds == null || hardcodedSounds.Length == 0)
-            {
-                return null;
-            }
-
-            TR2PackedSound packedSound = new TR2PackedSound();
-
-            short id = -2;
-            foreach (int index in hardcodedSounds)
-            {
-                packedSound.SoundMapIndices[index] = id--;
-            }
-
-            int offset = 2;
-            foreach (short index in packedSound.SoundMapIndices.Keys)
-            {
-                short val = packedSound.SoundMapIndices[index];
-                TRSoundDetails details = soundDetails[soundMap[index]];
-
-                uint[] samples = new uint[details.NumSounds];
-                for (int i = 0; i < details.NumSounds; i++)
-                {
-                    samples[i] = sampleIndices[(ushort)(details.Sample + i)];
-                }
-
-                packedSound.SampleIndices[(ushort)(ushort.MaxValue - offset)] = samples;
-
-                packedSound.SoundDetails[val] = new TRSoundDetails
-                {
-                    Chance = details.Chance,
-                    Characteristics = details.Characteristics,
-                    Sample = (ushort)(ushort.MaxValue - offset),
-                    Volume = details.Volume
-                };
-                offset++;
-            }
-
-            return packedSound;
-        }
-
-        public static TR3PackedSound BuildPackedSound(short[] soundMap, TR3SoundDetails[] soundDetails, uint[] sampleIndices, short[] hardcodedSounds)
-        {
-            if (hardcodedSounds == null || hardcodedSounds.Length == 0)
-            {
-                return null;
-            }
-
-            TR3PackedSound packedSound = new TR3PackedSound();
-
-            short id = -2;
-            foreach (int index in hardcodedSounds)
-            {
-                packedSound.SoundMapIndices[index] = id--;
-            }
-
-            int offset = 2;
-            foreach (short index in packedSound.SoundMapIndices.Keys)
-            {
-                short val = packedSound.SoundMapIndices[index];
-                TR3SoundDetails details = soundDetails[soundMap[index]];
-
-                uint[] samples = new uint[details.NumSounds];
-                for (int i = 0; i < details.NumSounds; i++)
-                {
-                    samples[i] = sampleIndices[(ushort)(details.Sample + i)];
-                }
-
-                packedSound.SampleIndices[(ushort)(ushort.MaxValue - offset)] = samples;
-
-                packedSound.SoundDetails[val] = new TR3SoundDetails
-                {
-                    Chance = details.Chance,
-                    Characteristics = details.Characteristics,
-                    Sample = (ushort)(ushort.MaxValue - offset),
-                    Volume = details.Volume,
-                    Range = details.Range
-                };
-                offset++;
-            }
-
-            return packedSound;
-        }
-
-        public static void ResortSoundIndices(TR1Level level)
-        {
-            List<short> newSoundMap = new List<short>();
-            List<TRSoundDetails> newSoundDetails = new List<TRSoundDetails>();
-            List<uint> newSampleIndices = new List<uint>();
-            List<byte> newSamples = new List<byte>();
-
-            for (int soundID = 0; soundID < level.SoundMap.Length; soundID++)
-            {
-                if (level.SoundMap[soundID] == -1)
-                {
-                    newSoundMap.Add(-1);
-                }
-                else
-                {
-                    TRSoundDetails details = level.SoundDetails[level.SoundMap[soundID]];
-                    newSoundMap.Add((short)newSoundDetails.Count);
-                    newSoundDetails.Add(details);
-
-                    ushort oldSample = details.Sample;
-                    details.Sample = (ushort)newSampleIndices.Count;
-                    for (int i = 0; i < details.NumSounds; i++)
-                    {
-                        ushort samplePointerIndex = (ushort)(oldSample + i);
-
-                        uint oldSampleIndex = level.SampleIndices[oldSample + i];
-                        uint nextSampleIndex = samplePointerIndex == level.SampleIndices.Length - 1 ? (uint)level.Samples.Length : level.SampleIndices[samplePointerIndex + 1];
-
-                        newSampleIndices.Add((uint)newSamples.Count);
-                        newSamples.AddRange(AnimationUtilities.GetSample(oldSampleIndex, nextSampleIndex, level.Samples));
-                    }
-                }
-            }
-
-            level.SoundMap = newSoundMap.ToArray();
-            level.SoundDetails = newSoundDetails.ToArray();
-            level.SampleIndices = newSampleIndices.ToArray();
-            level.Samples = newSamples.ToArray();
-
-            level.NumSoundDetails = (uint)newSoundDetails.Count;
-            level.NumSampleIndices = (uint)newSampleIndices.Count;
-            level.NumSamples = (uint)newSamples.Count;
-        }
-
-        public static void ResortSoundIndices(TR2Level level)
-        {
-            List<uint> sampleIndices = level.SampleIndices.ToList();
-            List<TRSoundDetails> soundDetails = level.SoundDetails.ToList();
-            List<short> soundMap = level.SoundMap.ToList();
-
-            ResortSoundIndices(sampleIndices, soundDetails, soundMap);
-
-            level.SampleIndices = sampleIndices.ToArray();
-            level.SoundDetails = soundDetails.ToArray();
-            level.SoundMap = soundMap.ToArray();
-        }
-
-        public static void ResortSoundIndices(TR3Level level)
-        {
-            List<uint> sampleIndices = level.SampleIndices.ToList();
-            List<TR3SoundDetails> soundDetails = level.SoundDetails.ToList();
-            List<short> soundMap = level.SoundMap.ToList();
-
-            ResortSoundIndices(sampleIndices, soundDetails, soundMap);
-
-            level.SampleIndices = sampleIndices.ToArray();
-            level.SoundDetails = soundDetails.ToArray();
-            level.SoundMap = soundMap.ToArray();
-        }
-
-        private static void ResortSoundIndices(List<uint> sampleIndices, List<TRSoundDetails> soundDetails, List<short> soundMap)
-        {
-            // Store the values from SampleIndices against their current positions
-            // in the list.             
-            Dictionary<int, uint> indexMap = new Dictionary<int, uint>();
-            for (int i = 0; i < sampleIndices.Count; i++)
-            {
-                indexMap[i] = sampleIndices[i];
-            }
-
-            // Sort the indices to avoid the game crashing
-            sampleIndices.Sort();
-
-            // Remap each SoundDetail to use the new index of the sample it points to
-            foreach (TRSoundDetails details in soundDetails)
-            {
-                details.Sample = (ushort)sampleIndices.IndexOf(indexMap[details.Sample]);
-            }
-
-            // Repeat for SoundMap -> SoundDetails
-            Dictionary<int, TRSoundDetails> soundMapIndices = new Dictionary<int, TRSoundDetails>();
-            for (int i = 0; i < soundMap.Count; i++)
-            {
-                if (soundMap[i] != -1)
-                {
-                    soundMapIndices[i] = soundDetails[soundMap[i]];
-                }
-            }
-
-            soundDetails.Sort(delegate (TRSoundDetails d1, TRSoundDetails d2)
-            {
-                return d1.Sample.CompareTo(d2.Sample);
-            });
-
-            foreach (int mapIndex in soundMapIndices.Keys)
-            {
-                TRSoundDetails details = soundMapIndices[mapIndex];
-                soundMap[mapIndex] = (short)soundDetails.IndexOf(details);
             }
         }
 
-        private static void ResortSoundIndices(List<uint> sampleIndices, List<TR3SoundDetails> soundDetails, List<short> soundMap)
+        level.SoundMap = newSoundMap.ToArray();
+        level.SoundDetails = newSoundDetails.ToArray();
+        level.SampleIndices = newSampleIndices.ToArray();
+        level.Samples = newSamples.ToArray();
+
+        level.NumSoundDetails = (uint)newSoundDetails.Count;
+        level.NumSampleIndices = (uint)newSampleIndices.Count;
+        level.NumSamples = (uint)newSamples.Count;
+    }
+
+    public static void ResortSoundIndices(TR2Level level)
+    {
+        List<uint> sampleIndices = level.SampleIndices.ToList();
+        List<TRSoundDetails> soundDetails = level.SoundDetails.ToList();
+        List<short> soundMap = level.SoundMap.ToList();
+
+        ResortSoundIndices(sampleIndices, soundDetails, soundMap);
+
+        level.SampleIndices = sampleIndices.ToArray();
+        level.SoundDetails = soundDetails.ToArray();
+        level.SoundMap = soundMap.ToArray();
+    }
+
+    public static void ResortSoundIndices(TR3Level level)
+    {
+        List<uint> sampleIndices = level.SampleIndices.ToList();
+        List<TR3SoundDetails> soundDetails = level.SoundDetails.ToList();
+        List<short> soundMap = level.SoundMap.ToList();
+
+        ResortSoundIndices(sampleIndices, soundDetails, soundMap);
+
+        level.SampleIndices = sampleIndices.ToArray();
+        level.SoundDetails = soundDetails.ToArray();
+        level.SoundMap = soundMap.ToArray();
+    }
+
+    private static void ResortSoundIndices(List<uint> sampleIndices, List<TRSoundDetails> soundDetails, List<short> soundMap)
+    {
+        // Store the values from SampleIndices against their current positions
+        // in the list.             
+        Dictionary<int, uint> indexMap = new Dictionary<int, uint>();
+        for (int i = 0; i < sampleIndices.Count; i++)
         {
-            // Store the values from SampleIndices against their current positions
-            // in the list.             
-            Dictionary<int, uint> indexMap = new Dictionary<int, uint>();
-            for (int i = 0; i < sampleIndices.Count; i++)
+            indexMap[i] = sampleIndices[i];
+        }
+
+        // Sort the indices to avoid the game crashing
+        sampleIndices.Sort();
+
+        // Remap each SoundDetail to use the new index of the sample it points to
+        foreach (TRSoundDetails details in soundDetails)
+        {
+            details.Sample = (ushort)sampleIndices.IndexOf(indexMap[details.Sample]);
+        }
+
+        // Repeat for SoundMap -> SoundDetails
+        Dictionary<int, TRSoundDetails> soundMapIndices = new Dictionary<int, TRSoundDetails>();
+        for (int i = 0; i < soundMap.Count; i++)
+        {
+            if (soundMap[i] != -1)
             {
-                indexMap[i] = sampleIndices[i];
+                soundMapIndices[i] = soundDetails[soundMap[i]];
             }
+        }
 
-            // Sort the indices to avoid the game crashing
-            sampleIndices.Sort();
+        soundDetails.Sort(delegate (TRSoundDetails d1, TRSoundDetails d2)
+        {
+            return d1.Sample.CompareTo(d2.Sample);
+        });
 
-            // Remap each SoundDetail to use the new index of the sample it points to
-            foreach (TR3SoundDetails details in soundDetails)
+        foreach (int mapIndex in soundMapIndices.Keys)
+        {
+            TRSoundDetails details = soundMapIndices[mapIndex];
+            soundMap[mapIndex] = (short)soundDetails.IndexOf(details);
+        }
+    }
+
+    private static void ResortSoundIndices(List<uint> sampleIndices, List<TR3SoundDetails> soundDetails, List<short> soundMap)
+    {
+        // Store the values from SampleIndices against their current positions
+        // in the list.             
+        Dictionary<int, uint> indexMap = new Dictionary<int, uint>();
+        for (int i = 0; i < sampleIndices.Count; i++)
+        {
+            indexMap[i] = sampleIndices[i];
+        }
+
+        // Sort the indices to avoid the game crashing
+        sampleIndices.Sort();
+
+        // Remap each SoundDetail to use the new index of the sample it points to
+        foreach (TR3SoundDetails details in soundDetails)
+        {
+            details.Sample = (ushort)sampleIndices.IndexOf(indexMap[details.Sample]);
+        }
+
+        // Repeat for SoundMap -> SoundDetails
+        Dictionary<int, TR3SoundDetails> soundMapIndices = new Dictionary<int, TR3SoundDetails>();
+        for (int i = 0; i < soundMap.Count; i++)
+        {
+            if (soundMap[i] != -1)
             {
-                details.Sample = (ushort)sampleIndices.IndexOf(indexMap[details.Sample]);
+                soundMapIndices[i] = soundDetails[soundMap[i]];
             }
+        }
 
-            // Repeat for SoundMap -> SoundDetails
-            Dictionary<int, TR3SoundDetails> soundMapIndices = new Dictionary<int, TR3SoundDetails>();
-            for (int i = 0; i < soundMap.Count; i++)
-            {
-                if (soundMap[i] != -1)
-                {
-                    soundMapIndices[i] = soundDetails[soundMap[i]];
-                }
-            }
+        soundDetails.Sort(delegate (TR3SoundDetails d1, TR3SoundDetails d2)
+        {
+            return d1.Sample.CompareTo(d2.Sample);
+        });
 
-            soundDetails.Sort(delegate (TR3SoundDetails d1, TR3SoundDetails d2)
-            {
-                return d1.Sample.CompareTo(d2.Sample);
-            });
-
-            foreach (int mapIndex in soundMapIndices.Keys)
-            {
-                TR3SoundDetails details = soundMapIndices[mapIndex];
-                soundMap[mapIndex] = (short)soundDetails.IndexOf(details);
-            }
+        foreach (int mapIndex in soundMapIndices.Keys)
+        {
+            TR3SoundDetails details = soundMapIndices[mapIndex];
+            soundMap[mapIndex] = (short)soundDetails.IndexOf(details);
         }
     }
 }

--- a/TRModelTransporter/Handlers/Sound/SoundUtilities.cs
+++ b/TRModelTransporter/Handlers/Sound/SoundUtilities.cs
@@ -28,7 +28,7 @@ public static class SoundUtilities
         }
 
         int offset = 2;
-        foreach (short index in packedSound.SoundMapIndices.Keys)
+        foreach (int index in packedSound.SoundMapIndices.Keys)
         {
             short val = packedSound.SoundMapIndices[index];
             TRSoundDetails details = soundDetails[soundMap[index]];
@@ -74,7 +74,7 @@ public static class SoundUtilities
         }
 
         int offset = 2;
-        foreach (short index in packedSound.SoundMapIndices.Keys)
+        foreach (int index in packedSound.SoundMapIndices.Keys)
         {
             short val = packedSound.SoundMapIndices[index];
             TRSoundDetails details = soundDetails[soundMap[index]];
@@ -116,7 +116,7 @@ public static class SoundUtilities
         }
 
         int offset = 2;
-        foreach (short index in packedSound.SoundMapIndices.Keys)
+        foreach (int index in packedSound.SoundMapIndices.Keys)
         {
             short val = packedSound.SoundMapIndices[index];
             TR3SoundDetails details = soundDetails[soundMap[index]];

--- a/TRModelTransporter/Handlers/Sound/SoundUtilities.cs
+++ b/TRModelTransporter/Handlers/Sound/SoundUtilities.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using TRLevelControl.Model;
+﻿using TRLevelControl.Model;
 using TRModelTransporter.Model.Sound;
 
 namespace TRModelTransporter.Handlers;

--- a/TRModelTransporter/Handlers/Textures/AbstractTextureExportHandler.cs
+++ b/TRModelTransporter/Handlers/Textures/AbstractTextureExportHandler.cs
@@ -10,150 +10,149 @@ using TRModelTransporter.Model.Textures;
 using TRModelTransporter.Packing;
 using TRModelTransporter.Utilities;
 
-namespace TRModelTransporter.Handlers
+namespace TRModelTransporter.Handlers;
+
+public abstract class AbstractTextureExportHandler<E, L, D>
+    where E : Enum
+    where L : class
+    where D : AbstractTRModelDefinition<E>
 {
-    public abstract class AbstractTextureExportHandler<E, L, D>
-        where E : Enum
-        where L : class
-        where D : AbstractTRModelDefinition<E>
+    protected const int _exportBitmapWidth = 320;
+    protected const int _exportBitmapHeight = 640;
+
+    protected L _level;
+    protected D _definition;
+    protected ITextureClassifier _classifier;
+    protected IEnumerable<E> _spriteDependencies;
+    protected IEnumerable<int> _ignoreableTextureIndices;
+
+    protected AbstractTexturePacker<E, L> _packer;
+
+    protected List<TexturedTileSegment> _allSegments;
+    public event EventHandler<SegmentEventArgs> SegmentExported;
+    public event EventHandler<TRTextureRemapEventArgs> SegmentRemapped;
+
+    public void Export(L level, D definition, ITextureClassifier classifier, IEnumerable<E> spriteDependencies, IEnumerable<int> ignoreableTextureIndices)
     {
-        protected const int _exportBitmapWidth = 320;
-        protected const int _exportBitmapHeight = 640;
+        _level = level;
+        _definition = definition;
+        _classifier = classifier;
+        _spriteDependencies = spriteDependencies;
+        _ignoreableTextureIndices = ignoreableTextureIndices;
 
-        protected L _level;
-        protected D _definition;
-        protected ITextureClassifier _classifier;
-        protected IEnumerable<E> _spriteDependencies;
-        protected IEnumerable<int> _ignoreableTextureIndices;
+        _allSegments = new List<TexturedTileSegment>();
 
-        protected AbstractTexturePacker<E, L> _packer;
-
-        protected List<TexturedTileSegment> _allSegments;
-        public event EventHandler<SegmentEventArgs> SegmentExported;
-        public event EventHandler<TRTextureRemapEventArgs> SegmentRemapped;
-
-        public void Export(L level, D definition, ITextureClassifier classifier, IEnumerable<E> spriteDependencies, IEnumerable<int> ignoreableTextureIndices)
+        using (_packer = CreatePacker())
         {
-            _level = level;
-            _definition = definition;
-            _classifier = classifier;
-            _spriteDependencies = spriteDependencies;
-            _ignoreableTextureIndices = ignoreableTextureIndices;
+            CollateSegments();
+            ExportSegments();
+        }
+    }
 
-            _allSegments = new List<TexturedTileSegment>();
+    protected abstract AbstractTexturePacker<E, L> CreatePacker();
 
-            using (_packer = CreatePacker())
+    protected abstract TRSpriteSequence GetSprite(E entity);
+
+    protected virtual void CollateSegments()
+    {
+        Dictionary<TexturedTile, List<TexturedTileSegment>> textureSegments = _packer.GetModelSegments(_definition.Entity);
+
+        TRTextureDeduplicator<E> deduplicator = new TRTextureDeduplicator<E>
+        {
+            SegmentMap = textureSegments,
+            UpdateGraphics = false,
+            SegmentRemapped = SegmentRemapped
+        };
+        deduplicator.Deduplicate();
+
+        _definition.ObjectTextures = new Dictionary<int, List<IndexedTRObjectTexture>>();
+        _definition.SpriteSequences = new Dictionary<E, TRSpriteSequence>();
+        _definition.SpriteTextures = new Dictionary<E, Dictionary<int, List<IndexedTRSpriteTexture>>>();
+
+        int bitmapIndex = 0;
+        foreach (List<TexturedTileSegment> segments in textureSegments.Values)
+        {
+            for (int i = 0; i < segments.Count; i++)
             {
-                CollateSegments();
-                ExportSegments();
+                TexturedTileSegment segment = segments[i];
+                if (!deduplicator.ShouldIgnoreSegment(_ignoreableTextureIndices, segment))
+                {
+                    _allSegments.Add(segment);
+                    _definition.ObjectTextures[bitmapIndex++] = new List<IndexedTRObjectTexture>(segment.Textures.Cast<IndexedTRObjectTexture>().ToArray());
+                }
             }
         }
 
-        protected abstract AbstractTexturePacker<E, L> CreatePacker();
-
-        protected abstract TRSpriteSequence GetSprite(E entity);
-
-        protected virtual void CollateSegments()
+        foreach (E spriteEntity in _spriteDependencies)
         {
-            Dictionary<TexturedTile, List<TexturedTileSegment>> textureSegments = _packer.GetModelSegments(_definition.Entity);
-
-            TRTextureDeduplicator<E> deduplicator = new TRTextureDeduplicator<E>
+            TRSpriteSequence sequence = GetSprite(spriteEntity);
+            if (sequence != null)
             {
-                SegmentMap = textureSegments,
-                UpdateGraphics = false,
-                SegmentRemapped = SegmentRemapped
-            };
-            deduplicator.Deduplicate();
+                _definition.SpriteSequences[spriteEntity] = sequence;
+            }
 
-            _definition.ObjectTextures = new Dictionary<int, List<IndexedTRObjectTexture>>();
-            _definition.SpriteSequences = new Dictionary<E, TRSpriteSequence>();
-            _definition.SpriteTextures = new Dictionary<E, Dictionary<int, List<IndexedTRSpriteTexture>>>();
-
-            int bitmapIndex = 0;
-            foreach (List<TexturedTileSegment> segments in textureSegments.Values)
+            Dictionary<TexturedTile, List<TexturedTileSegment>> spriteSegments = _packer.GetSpriteSegments(spriteEntity);
+            _definition.SpriteTextures[spriteEntity] = new Dictionary<int, List<IndexedTRSpriteTexture>>();
+            foreach (List<TexturedTileSegment> segments in spriteSegments.Values)
             {
                 for (int i = 0; i < segments.Count; i++)
                 {
                     TexturedTileSegment segment = segments[i];
-                    if (!deduplicator.ShouldIgnoreSegment(_ignoreableTextureIndices, segment))
-                    {
-                        _allSegments.Add(segment);
-                        _definition.ObjectTextures[bitmapIndex++] = new List<IndexedTRObjectTexture>(segment.Textures.Cast<IndexedTRObjectTexture>().ToArray());
-                    }
-                }
-            }
-
-            foreach (E spriteEntity in _spriteDependencies)
-            {
-                TRSpriteSequence sequence = GetSprite(spriteEntity);
-                if (sequence != null)
-                {
-                    _definition.SpriteSequences[spriteEntity] = sequence;
-                }
-
-                Dictionary<TexturedTile, List<TexturedTileSegment>> spriteSegments = _packer.GetSpriteSegments(spriteEntity);
-                _definition.SpriteTextures[spriteEntity] = new Dictionary<int, List<IndexedTRSpriteTexture>>();
-                foreach (List<TexturedTileSegment> segments in spriteSegments.Values)
-                {
-                    for (int i = 0; i < segments.Count; i++)
-                    {
-                        TexturedTileSegment segment = segments[i];
-                        _allSegments.Add(segment);
-                        _definition.SpriteTextures[spriteEntity][bitmapIndex++] = new List<IndexedTRSpriteTexture>(segment.Textures.Cast<IndexedTRSpriteTexture>().ToArray());
-                    }
+                    _allSegments.Add(segment);
+                    _definition.SpriteTextures[spriteEntity][bitmapIndex++] = new List<IndexedTRSpriteTexture>(segment.Textures.Cast<IndexedTRSpriteTexture>().ToArray());
                 }
             }
         }
+    }
 
-        protected virtual void ExportSegments()
+    protected virtual void ExportSegments()
+    {
+        if (_allSegments.Count == 0)
         {
-            if (_allSegments.Count == 0)
+            return;
+        }
+
+        using (DefaultTexturePacker segmentPacker = new DefaultTexturePacker())
+        {
+            segmentPacker.AddRectangles(_allSegments);
+
+            segmentPacker.Options = new PackingOptions
             {
-                return;
+                FillMode = PackingFillMode.Horizontal,
+                OrderMode = PackingOrderMode.Area,
+                Order = PackingOrder.Descending,
+                GroupMode = PackingGroupMode.Squares
+            };
+            segmentPacker.TileWidth = _exportBitmapWidth;
+            segmentPacker.TileHeight = _exportBitmapHeight;
+            segmentPacker.MaximumTiles = 1;
+
+            segmentPacker.Pack();
+
+            if (segmentPacker.OrphanedRectangles.Count > 0)
+            {
+                throw new PackingException(string.Format("Failed to export textures for {0}.", _definition.Entity));
             }
 
-            using (DefaultTexturePacker segmentPacker = new DefaultTexturePacker())
+            TexturedTile tile = segmentPacker.Tiles[0];
+            List<Rectangle> rects = new List<Rectangle>();
+            foreach (TexturedTileSegment segment in _allSegments)
             {
-                segmentPacker.AddRectangles(_allSegments);
+                rects.Add(segment.MappedBounds);
+            }
 
-                segmentPacker.Options = new PackingOptions
+            _definition.TextureSegments = rects.ToArray();
+
+            Rectangle region = tile.GetOccupiedRegion();
+            _definition.Bitmap = tile.BitmapGraphics.Extract(region);
+
+            foreach (TexturedTileSegment segment in _allSegments)
+            {
+                SegmentExported?.Invoke(this, new SegmentEventArgs
                 {
-                    FillMode = PackingFillMode.Horizontal,
-                    OrderMode = PackingOrderMode.Area,
-                    Order = PackingOrder.Descending,
-                    GroupMode = PackingGroupMode.Squares
-                };
-                segmentPacker.TileWidth = _exportBitmapWidth;
-                segmentPacker.TileHeight = _exportBitmapHeight;
-                segmentPacker.MaximumTiles = 1;
-
-                segmentPacker.Pack();
-
-                if (segmentPacker.OrphanedRectangles.Count > 0)
-                {
-                    throw new PackingException(string.Format("Failed to export textures for {0}.", _definition.Entity));
-                }
-
-                TexturedTile tile = segmentPacker.Tiles[0];
-                List<Rectangle> rects = new List<Rectangle>();
-                foreach (TexturedTileSegment segment in _allSegments)
-                {
-                    rects.Add(segment.MappedBounds);
-                }
-
-                _definition.TextureSegments = rects.ToArray();
-
-                Rectangle region = tile.GetOccupiedRegion();
-                _definition.Bitmap = tile.BitmapGraphics.Extract(region);
-
-                foreach (TexturedTileSegment segment in _allSegments)
-                {
-                    SegmentExported?.Invoke(this, new SegmentEventArgs
-                    {
-                        SegmentIndex = segment.FirstTextureIndex,
-                        Bitmap = segment.Bitmap
-                    });
-                }
+                    SegmentIndex = segment.FirstTextureIndex,
+                    Bitmap = segment.Bitmap
+                });
             }
         }
     }

--- a/TRModelTransporter/Handlers/Textures/AbstractTextureExportHandler.cs
+++ b/TRModelTransporter/Handlers/Textures/AbstractTextureExportHandler.cs
@@ -54,7 +54,7 @@ public abstract class AbstractTextureExportHandler<E, L, D>
     {
         Dictionary<TexturedTile, List<TexturedTileSegment>> textureSegments = _packer.GetModelSegments(_definition.Entity);
 
-        TRTextureDeduplicator<E> deduplicator = new TRTextureDeduplicator<E>
+        TRTextureDeduplicator<E> deduplicator = new()
         {
             SegmentMap = textureSegments,
             UpdateGraphics = false,
@@ -109,7 +109,7 @@ public abstract class AbstractTextureExportHandler<E, L, D>
             return;
         }
 
-        using (DefaultTexturePacker segmentPacker = new DefaultTexturePacker())
+        using (DefaultTexturePacker segmentPacker = new())
         {
             segmentPacker.AddRectangles(_allSegments);
 
@@ -132,7 +132,7 @@ public abstract class AbstractTextureExportHandler<E, L, D>
             }
 
             TexturedTile tile = segmentPacker.Tiles[0];
-            List<Rectangle> rects = new List<Rectangle>();
+            List<Rectangle> rects = new();
             foreach (TexturedTileSegment segment in _allSegments)
             {
                 rects.Add(segment.MappedBounds);

--- a/TRModelTransporter/Handlers/Textures/AbstractTextureExportHandler.cs
+++ b/TRModelTransporter/Handlers/Textures/AbstractTextureExportHandler.cs
@@ -1,8 +1,5 @@
 ﻿using RectanglePacker.Organisation;
-using System;
-using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
 using TRLevelControl.Model;
 using TRModelTransporter.Events;
 using TRModelTransporter.Model;

--- a/TRModelTransporter/Handlers/Textures/AbstractTextureImportHandler.cs
+++ b/TRModelTransporter/Handlers/Textures/AbstractTextureImportHandler.cs
@@ -199,7 +199,7 @@ public abstract class AbstractTextureImportHandler<E, L, D>
             {
                 foreach (AbstractIndexedTRTexture texture in segment.Textures)
                 {
-                    if (!(texture is IndexedTRObjectTexture objTexture)) // Sprites handled later
+                    if (texture is not IndexedTRObjectTexture objTexture) // Sprites handled later
                     {
                         continue;
                     }

--- a/TRModelTransporter/Handlers/Textures/AbstractTextureImportHandler.cs
+++ b/TRModelTransporter/Handlers/Textures/AbstractTextureImportHandler.cs
@@ -10,86 +10,122 @@ using TRModelTransporter.Model.Textures;
 using TRModelTransporter.Packing;
 using TRTexture16Importer.Helpers;
 
-namespace TRModelTransporter.Handlers
+namespace TRModelTransporter.Handlers;
+
+public abstract class AbstractTextureImportHandler<E, L, D>
+    where E : Enum
+    where L : class
+    where D : AbstractTRModelDefinition<E>
 {
-    public abstract class AbstractTextureImportHandler<E, L, D>
-        where E : Enum
-        where L : class
-        where D : AbstractTRModelDefinition<E>
+    public ITransportDataProvider<E> Data { get; set; }
+
+    protected Dictionary<D, List<TexturedTileSegment>> _importSegments;
+
+    protected L _level;
+    protected IEnumerable<D> _definitions;
+    protected IEnumerable<E> _entitiesToRemove;
+    protected AbstractTextureRemapGroup<E, L> _textureRemap;
+    protected bool _clearUnusedSprites;
+    protected ITexturePositionMonitor<E> _positionMonitor;
+
+    public void Import(L level, IEnumerable<D> definitions, IEnumerable<E> entitiesToRemove, AbstractTextureRemapGroup<E, L> textureRemap, bool clearUnusedSprites, ITexturePositionMonitor<E> positionMonitor)
     {
-        public ITransportDataProvider<E> Data { get; set; }
+        _level = level;
+        _definitions = definitions;
+        _entitiesToRemove = entitiesToRemove;
+        _textureRemap = textureRemap;
+        _clearUnusedSprites = clearUnusedSprites;
+        _positionMonitor = positionMonitor;
 
-        protected Dictionary<D, List<TexturedTileSegment>> _importSegments;
+        // Pull together all of the texture segments for each of the definitions
+        CollateSegments();
 
-        protected L _level;
-        protected IEnumerable<D> _definitions;
-        protected IEnumerable<E> _entitiesToRemove;
-        protected AbstractTextureRemapGroup<E, L> _textureRemap;
-        protected bool _clearUnusedSprites;
-        protected ITexturePositionMonitor<E> _positionMonitor;
-
-        public void Import(L level, IEnumerable<D> definitions, IEnumerable<E> entitiesToRemove, AbstractTextureRemapGroup<E, L> textureRemap, bool clearUnusedSprites, ITexturePositionMonitor<E> positionMonitor)
+        // Pack the textures into the level, or bail if it wasn't possible
+        PackingResult<TexturedTile, TexturedTileSegment> packingResult = Pack();
+        if (packingResult.OrphanCount > 0)
         {
-            _level = level;
-            _definitions = definitions;
-            _entitiesToRemove = entitiesToRemove;
-            _textureRemap = textureRemap;
-            _clearUnusedSprites = clearUnusedSprites;
-            _positionMonitor = positionMonitor;
-
-            // Pull together all of the texture segments for each of the definitions
-            CollateSegments();
-
-            // Pack the textures into the level, or bail if it wasn't possible
-            PackingResult<TexturedTile, TexturedTileSegment> packingResult = Pack();
-            if (packingResult.OrphanCount > 0)
+            List<string> entityNames = new List<string>();
+            foreach (D def in _definitions)
             {
-                List<string> entityNames = new List<string>();
-                foreach (D def in _definitions)
-                {
-                    entityNames.Add(def.Entity.ToString());
-                }
-                throw new PackingException(string.Format
-                (
-                    "Failed to pack {0} rectangles for model types [{1}].",
-                    packingResult.OrphanCount,
-                    string.Join(", ", entityNames)
-                ));
+                entityNames.Add(def.Entity.ToString());
             }
-
-            // Update the level with any new ObjectTextures and update meshes accordingly
-            MergeObjectTextures();
-
-            // Update the level with any new SpriteTextures and SpriteSequences
-            MergeSpriteTextures();
-
-            // Inform the texture position monitor of the new location of tracked textures
-            NotifyTextureWatcher();
+            throw new PackingException(string.Format
+            (
+                "Failed to pack {0} rectangles for model types [{1}].",
+                packingResult.OrphanCount,
+                string.Join(", ", entityNames)
+            ));
         }
 
-        protected virtual void CollateSegments()
-        {
-            // Rebuild the segment list. We assume the list of IndexedTRObjectTextures has been
-            // ordered by area descending to preserve the "master" texture for each segment.
-            _importSegments = new Dictionary<D, List<TexturedTileSegment>>();
+        // Update the level with any new ObjectTextures and update meshes accordingly
+        MergeObjectTextures();
 
-            // Track existing sprite sequences to avoid duplication
-            List<TRSpriteSequence> spriteSequences = new List<TRSpriteSequence>(GetExistingSpriteSequences());
-            foreach (D definition in _definitions)
+        // Update the level with any new SpriteTextures and SpriteSequences
+        MergeSpriteTextures();
+
+        // Inform the texture position monitor of the new location of tracked textures
+        NotifyTextureWatcher();
+    }
+
+    protected virtual void CollateSegments()
+    {
+        // Rebuild the segment list. We assume the list of IndexedTRObjectTextures has been
+        // ordered by area descending to preserve the "master" texture for each segment.
+        _importSegments = new Dictionary<D, List<TexturedTileSegment>>();
+
+        // Track existing sprite sequences to avoid duplication
+        List<TRSpriteSequence> spriteSequences = new List<TRSpriteSequence>(GetExistingSpriteSequences());
+        foreach (D definition in _definitions)
+        {
+            if (!definition.HasGraphics || definition.IsDependencyOnly)
             {
-                if (!definition.HasGraphics || definition.IsDependencyOnly)
+                continue;
+            }
+
+            _importSegments[definition] = new List<TexturedTileSegment>();
+            using (BitmapGraphics bg = new BitmapGraphics(definition.Bitmap))
+            {
+                foreach (int segmentIndex in definition.ObjectTextures.Keys)
                 {
-                    continue;
+                    Bitmap segmentClip = bg.Extract(definition.TextureSegments[segmentIndex]);
+                    TexturedTileSegment segment = null;
+                    foreach (IndexedTRObjectTexture texture in definition.ObjectTextures[segmentIndex])
+                    {
+                        if (segment == null)
+                        {
+                            _importSegments[definition].Add(segment = new TexturedTileSegment(texture, segmentClip));
+                        }
+                        else
+                        {
+                            segment.AddTexture(texture);
+                        }
+                    }
                 }
 
-                _importSegments[definition] = new List<TexturedTileSegment>();
-                using (BitmapGraphics bg = new BitmapGraphics(definition.Bitmap))
+                List<E> spriteEntities = new List<E>(definition.SpriteSequences.Keys);
+                foreach (E spriteEntity in spriteEntities)
                 {
-                    foreach (int segmentIndex in definition.ObjectTextures.Keys)
+                    TRSpriteSequence existingSequence = spriteSequences.Find(s => s.SpriteID == Convert.ToInt32(spriteEntity));
+                    if (existingSequence != null)
+                    {
+                        definition.SpriteSequences.Remove(spriteEntity);
+                        continue;
+                    }
+                    else
+                    {
+                        // Add it to the tracking list in case we are importing 2 or more models
+                        // that share a sequence e.g. Dragon/Flamethrower and Flame_S_H
+                        spriteSequences.Add(new TRSpriteSequence { SpriteID = Convert.ToInt32(spriteEntity) });
+                    }
+
+                    // The sequence will be merged later when we know the sprite texture offsets.
+                    // For now, add the segments we need for packing.
+                    Dictionary<int, List<IndexedTRSpriteTexture>> spriteTextures = definition.SpriteTextures[spriteEntity];
+                    foreach (int segmentIndex in spriteTextures.Keys)
                     {
                         Bitmap segmentClip = bg.Extract(definition.TextureSegments[segmentIndex]);
                         TexturedTileSegment segment = null;
-                        foreach (IndexedTRObjectTexture texture in definition.ObjectTextures[segmentIndex])
+                        foreach (IndexedTRSpriteTexture texture in spriteTextures[segmentIndex])
                         {
                             if (segment == null)
                             {
@@ -101,312 +137,275 @@ namespace TRModelTransporter.Handlers
                             }
                         }
                     }
+                }
+            }
+        }
+    }
 
-                    List<E> spriteEntities = new List<E>(definition.SpriteSequences.Keys);
-                    foreach (E spriteEntity in spriteEntities)
+    protected virtual PackingResult<TexturedTile, TexturedTileSegment> Pack()
+    {
+        using (AbstractTexturePacker<E, L> packer = CreatePacker())
+        {
+            packer.MaximumTiles = Data.TextureTileLimit;
+
+            ProcessRemovals(packer);
+
+            List<TexturedTileSegment> allSegments = new List<TexturedTileSegment>();
+            foreach (List<TexturedTileSegment> segmentList in _importSegments.Values)
+            {
+                // We only add unique segments, so if another segment already exists, 
+                // remap the definition's segment to that one. Example of when this is
+                // needed is importing the dragon as DragonBack duplicates a lot of
+                // DragonFront, so this will greatly reduce the import cost.
+                for (int i = 0; i < segmentList.Count; i++)
+                {
+                    TexturedTileSegment segment = segmentList[i];
+                    int j = FindMatchingSegment(allSegments, segment);
+                    if (j == -1)
                     {
-                        TRSpriteSequence existingSequence = spriteSequences.Find(s => s.SpriteID == Convert.ToInt32(spriteEntity));
-                        if (existingSequence != null)
+                        allSegments.Add(segment);
+                    }
+                    else
+                    {
+                        TexturedTileSegment otherSegment = allSegments[j];
+                        segmentList[i] = allSegments[j];
+                        foreach (IndexedTRObjectTexture texture in segment.Textures)
                         {
-                            definition.SpriteSequences.Remove(spriteEntity);
+                            if (!otherSegment.IsObjectTextureFor(texture.Index))
+                            {
+                                otherSegment.AddTexture(texture);
+                            }
+                        }
+                    }
+                }
+            }
+
+            packer.AddRectangles(allSegments);
+
+            return packer.Pack(true);
+        }
+    }
+
+    protected virtual void MergeObjectTextures()
+    {
+        // Add each ObjectTexture to the level and store a map of old index to new index.
+        // Make use of any invalid texture first because we are limited to 2048 entries
+        List<TRObjectTexture> levelObjectTextures = GetExistingObjectTextures().ToList();
+        Queue<int> reusableIndices = new Queue<int>(GetInvalidObjectTextureIndices());
+
+        Dictionary<D, Dictionary<int, int>> indexMap = new Dictionary<D, Dictionary<int, int>>();
+        foreach (D definition in _definitions)
+        {
+            if (!_importSegments.ContainsKey(definition))
+            {
+                continue;
+            }
+
+            indexMap[definition] = new Dictionary<int, int>();
+            foreach (TexturedTileSegment segment in _importSegments[definition])
+            {
+                foreach (AbstractIndexedTRTexture texture in segment.Textures)
+                {
+                    if (!(texture is IndexedTRObjectTexture objTexture)) // Sprites handled later
+                    {
+                        continue;
+                    }
+
+                    int newIndex;
+                    if (reusableIndices.Count > 0)
+                    {
+                        newIndex = reusableIndices.Dequeue();
+                        levelObjectTextures[newIndex] = objTexture.Texture;
+                    }
+                    else if (levelObjectTextures.Count < Data.TextureObjectLimit)
+                    {
+                        levelObjectTextures.Add(objTexture.Texture);
+                        newIndex = levelObjectTextures.Count - 1;
+                    }
+                    else
+                    {
+                        throw new PackingException(string.Format("Limit of {0} textures reached.", Data.TextureObjectLimit));
+                    }
+
+                    indexMap[definition][texture.Index] = newIndex;
+                }
+            }
+        }
+
+        // Save the new textures in the level
+        WriteObjectTextures(levelObjectTextures);
+
+        // Change the definition's meshes so that the textured rectangles and triangles point
+        // to the correct object texture.
+        RemapMeshTextures(indexMap);
+    }
+
+    protected virtual void MergeSpriteTextures()
+    {
+        List<TRSpriteTexture> levelSpriteTextures = GetExistingSpriteTextures().ToList();
+        List<TRSpriteSequence> levelSpriteSequences = GetExistingSpriteSequences().ToList();
+
+        foreach (D definition in _definitions)
+        {
+            if (!_importSegments.ContainsKey(definition) || definition.SpriteSequences.Count == 0)
+            {
+                continue;
+            }
+
+            foreach (E spriteEntity in definition.SpriteSequences.Keys)
+            {
+                TRSpriteSequence sequence = definition.SpriteSequences[spriteEntity];
+                sequence.Offset = -1;
+                levelSpriteSequences.Add(sequence);
+
+                foreach (int bitmapIndex in definition.SpriteTextures[spriteEntity].Keys)
+                {
+                    List<IndexedTRSpriteTexture> textures = definition.SpriteTextures[spriteEntity][bitmapIndex];
+
+                    for (int i = 0; i < textures.Count; i++)
+                    {
+                        if (sequence.Offset == -1)
+                        {
+                            // mark the position of the first sprite only
+                            sequence.Offset = (short)levelSpriteTextures.Count;
+                        }
+                        levelSpriteTextures.Add(textures[i].Texture);
+                    }
+                }
+            }
+        }
+
+        WriteSpriteTextures(levelSpriteTextures);
+        WriteSpriteSequences(levelSpriteSequences);
+    }
+
+    protected abstract IEnumerable<TRSpriteSequence> GetExistingSpriteSequences();
+
+    protected abstract IEnumerable<TRSpriteTexture> GetExistingSpriteTextures();
+
+    protected abstract AbstractTexturePacker<E, L> CreatePacker();
+
+    protected abstract void ProcessRemovals(AbstractTexturePacker<E, L> packer);
+
+    protected abstract IEnumerable<TRObjectTexture> GetExistingObjectTextures();
+
+    protected abstract IEnumerable<int> GetInvalidObjectTextureIndices();
+
+    protected abstract void WriteObjectTextures(IEnumerable<TRObjectTexture> objectTextures);
+
+    protected abstract void WriteSpriteTextures(IEnumerable<TRSpriteTexture> spriteTextures);
+
+    protected abstract void WriteSpriteSequences(IEnumerable<TRSpriteSequence> spriteSequences);
+
+    protected abstract void RemapMeshTextures(Dictionary<D, Dictionary<int, int>> indexMap);
+
+    public abstract void ResetUnusedTextures();
+
+    protected abstract IEnumerable<E> CollateWatchedTextures(IEnumerable<E> watchedEntities, D definition);
+
+    protected virtual void NotifyTextureWatcher()
+    {
+        if (_positionMonitor == null)
+        {
+            return;
+        }
+
+        // Notify if anything has been removed first
+        if (_entitiesToRemove != null)
+        {
+            _positionMonitor.EntityTexturesRemoved(new List<E>(_entitiesToRemove));
+        }
+
+        // If the monitor isn't interested in any new entities, skip the actual processing
+        Dictionary<E, List<int>> watchedTextures = _positionMonitor.GetMonitoredTextureIndices();
+        if (watchedTextures.Count == 0)
+        {
+            return;
+        }
+
+        Dictionary<E, List<PositionedTexture>> textureResults = new Dictionary<E, List<PositionedTexture>>();
+
+        foreach (D definition in _importSegments.Keys)
+        {
+            // Does this definition have any entities we are interested in?
+            List<E> entities = new List<E>();
+            if (watchedTextures.ContainsKey(definition.Alias))
+            {
+                entities.Add(definition.Alias);
+            }
+
+            // Allow subclasses to add to the list if required
+            entities.AddRange(CollateWatchedTextures(watchedTextures.Keys, definition));
+
+            if (entities.Count == 0)
+            {
+                continue;
+            }
+
+            foreach (E entity in entities)
+            {
+                foreach (int watchedIndex in watchedTextures[entity])
+                {
+                    foreach (TexturedTileSegment segment in _importSegments[definition])
+                    {
+                        AbstractIndexedTRTexture texture = segment.GetTexture(watchedIndex);
+                        if (texture == null)
+                        {
                             continue;
                         }
-                        else
-                        {
-                            // Add it to the tracking list in case we are importing 2 or more models
-                            // that share a sequence e.g. Dragon/Flamethrower and Flame_S_H
-                            spriteSequences.Add(new TRSpriteSequence { SpriteID = Convert.ToInt32(spriteEntity) });
-                        }
 
-                        // The sequence will be merged later when we know the sprite texture offsets.
-                        // For now, add the segments we need for packing.
-                        Dictionary<int, List<IndexedTRSpriteTexture>> spriteTextures = definition.SpriteTextures[spriteEntity];
-                        foreach (int segmentIndex in spriteTextures.Keys)
+                        if (!textureResults.ContainsKey(entity))
                         {
-                            Bitmap segmentClip = bg.Extract(definition.TextureSegments[segmentIndex]);
-                            TexturedTileSegment segment = null;
-                            foreach (IndexedTRSpriteTexture texture in spriteTextures[segmentIndex])
-                            {
-                                if (segment == null)
-                                {
-                                    _importSegments[definition].Add(segment = new TexturedTileSegment(texture, segmentClip));
-                                }
-                                else
-                                {
-                                    segment.AddTexture(texture);
-                                }
-                            }
+                            textureResults[entity] = new List<PositionedTexture>();
                         }
+                        textureResults[entity].Add(new PositionedTexture(texture));
+                        break;
                     }
                 }
             }
         }
 
-        protected virtual PackingResult<TexturedTile, TexturedTileSegment> Pack()
+        _positionMonitor.MonitoredTexturesPositioned(textureResults);
+    }
+
+    protected int FindMatchingSegment(List<TexturedTileSegment> segments, TexturedTileSegment segment)
+    {
+        for (int i = 0; i < segments.Count; i++)
         {
-            using (AbstractTexturePacker<E, L> packer = CreatePacker())
+            TexturedTileSegment otherSegment = segments[i];
+            if
+            (
+                otherSegment.FirstTextureIndex == segment.FirstTextureIndex &&
+                otherSegment.FirstClassification == segment.FirstClassification
+            )
             {
-                packer.MaximumTiles = Data.TextureTileLimit;
-
-                ProcessRemovals(packer);
-
-                List<TexturedTileSegment> allSegments = new List<TexturedTileSegment>();
-                foreach (List<TexturedTileSegment> segmentList in _importSegments.Values)
-                {
-                    // We only add unique segments, so if another segment already exists, 
-                    // remap the definition's segment to that one. Example of when this is
-                    // needed is importing the dragon as DragonBack duplicates a lot of
-                    // DragonFront, so this will greatly reduce the import cost.
-                    for (int i = 0; i < segmentList.Count; i++)
-                    {
-                        TexturedTileSegment segment = segmentList[i];
-                        int j = FindMatchingSegment(allSegments, segment);
-                        if (j == -1)
-                        {
-                            allSegments.Add(segment);
-                        }
-                        else
-                        {
-                            TexturedTileSegment otherSegment = allSegments[j];
-                            segmentList[i] = allSegments[j];
-                            foreach (IndexedTRObjectTexture texture in segment.Textures)
-                            {
-                                if (!otherSegment.IsObjectTextureFor(texture.Index))
-                                {
-                                    otherSegment.AddTexture(texture);
-                                }
-                            }
-                        }
-                    }
-                }
-
-                packer.AddRectangles(allSegments);
-
-                return packer.Pack(true);
+                return i;
             }
         }
+        return -1;
+    }
 
-        protected virtual void MergeObjectTextures()
+    protected void RemapMeshTextures(TRMesh[] meshes, Dictionary<int, int> indexMap)
+    {
+        foreach (TRMesh mesh in meshes)
         {
-            // Add each ObjectTexture to the level and store a map of old index to new index.
-            // Make use of any invalid texture first because we are limited to 2048 entries
-            List<TRObjectTexture> levelObjectTextures = GetExistingObjectTextures().ToList();
-            Queue<int> reusableIndices = new Queue<int>(GetInvalidObjectTextureIndices());
-
-            Dictionary<D, Dictionary<int, int>> indexMap = new Dictionary<D, Dictionary<int, int>>();
-            foreach (D definition in _definitions)
+            foreach (TRFace4 rect in mesh.TexturedRectangles)
             {
-                if (!_importSegments.ContainsKey(definition))
-                {
-                    continue;
-                }
-
-                indexMap[definition] = new Dictionary<int, int>();
-                foreach (TexturedTileSegment segment in _importSegments[definition])
-                {
-                    foreach (AbstractIndexedTRTexture texture in segment.Textures)
-                    {
-                        if (!(texture is IndexedTRObjectTexture objTexture)) // Sprites handled later
-                        {
-                            continue;
-                        }
-
-                        int newIndex;
-                        if (reusableIndices.Count > 0)
-                        {
-                            newIndex = reusableIndices.Dequeue();
-                            levelObjectTextures[newIndex] = objTexture.Texture;
-                        }
-                        else if (levelObjectTextures.Count < Data.TextureObjectLimit)
-                        {
-                            levelObjectTextures.Add(objTexture.Texture);
-                            newIndex = levelObjectTextures.Count - 1;
-                        }
-                        else
-                        {
-                            throw new PackingException(string.Format("Limit of {0} textures reached.", Data.TextureObjectLimit));
-                        }
-
-                        indexMap[definition][texture.Index] = newIndex;
-                    }
-                }
+                rect.Texture = ConvertTextureReference(rect.Texture, indexMap);
             }
-
-            // Save the new textures in the level
-            WriteObjectTextures(levelObjectTextures);
-
-            // Change the definition's meshes so that the textured rectangles and triangles point
-            // to the correct object texture.
-            RemapMeshTextures(indexMap);
-        }
-
-        protected virtual void MergeSpriteTextures()
-        {
-            List<TRSpriteTexture> levelSpriteTextures = GetExistingSpriteTextures().ToList();
-            List<TRSpriteSequence> levelSpriteSequences = GetExistingSpriteSequences().ToList();
-
-            foreach (D definition in _definitions)
+            foreach (TRFace3 tri in mesh.TexturedTriangles)
             {
-                if (!_importSegments.ContainsKey(definition) || definition.SpriteSequences.Count == 0)
-                {
-                    continue;
-                }
-
-                foreach (E spriteEntity in definition.SpriteSequences.Keys)
-                {
-                    TRSpriteSequence sequence = definition.SpriteSequences[spriteEntity];
-                    sequence.Offset = -1;
-                    levelSpriteSequences.Add(sequence);
-
-                    foreach (int bitmapIndex in definition.SpriteTextures[spriteEntity].Keys)
-                    {
-                        List<IndexedTRSpriteTexture> textures = definition.SpriteTextures[spriteEntity][bitmapIndex];
-
-                        for (int i = 0; i < textures.Count; i++)
-                        {
-                            if (sequence.Offset == -1)
-                            {
-                                // mark the position of the first sprite only
-                                sequence.Offset = (short)levelSpriteTextures.Count;
-                            }
-                            levelSpriteTextures.Add(textures[i].Texture);
-                        }
-                    }
-                }
-            }
-
-            WriteSpriteTextures(levelSpriteTextures);
-            WriteSpriteSequences(levelSpriteSequences);
-        }
-
-        protected abstract IEnumerable<TRSpriteSequence> GetExistingSpriteSequences();
-
-        protected abstract IEnumerable<TRSpriteTexture> GetExistingSpriteTextures();
-
-        protected abstract AbstractTexturePacker<E, L> CreatePacker();
-
-        protected abstract void ProcessRemovals(AbstractTexturePacker<E, L> packer);
-
-        protected abstract IEnumerable<TRObjectTexture> GetExistingObjectTextures();
-
-        protected abstract IEnumerable<int> GetInvalidObjectTextureIndices();
-
-        protected abstract void WriteObjectTextures(IEnumerable<TRObjectTexture> objectTextures);
-
-        protected abstract void WriteSpriteTextures(IEnumerable<TRSpriteTexture> spriteTextures);
-
-        protected abstract void WriteSpriteSequences(IEnumerable<TRSpriteSequence> spriteSequences);
-
-        protected abstract void RemapMeshTextures(Dictionary<D, Dictionary<int, int>> indexMap);
-
-        public abstract void ResetUnusedTextures();
-
-        protected abstract IEnumerable<E> CollateWatchedTextures(IEnumerable<E> watchedEntities, D definition);
-
-        protected virtual void NotifyTextureWatcher()
-        {
-            if (_positionMonitor == null)
-            {
-                return;
-            }
-
-            // Notify if anything has been removed first
-            if (_entitiesToRemove != null)
-            {
-                _positionMonitor.EntityTexturesRemoved(new List<E>(_entitiesToRemove));
-            }
-
-            // If the monitor isn't interested in any new entities, skip the actual processing
-            Dictionary<E, List<int>> watchedTextures = _positionMonitor.GetMonitoredTextureIndices();
-            if (watchedTextures.Count == 0)
-            {
-                return;
-            }
-
-            Dictionary<E, List<PositionedTexture>> textureResults = new Dictionary<E, List<PositionedTexture>>();
-
-            foreach (D definition in _importSegments.Keys)
-            {
-                // Does this definition have any entities we are interested in?
-                List<E> entities = new List<E>();
-                if (watchedTextures.ContainsKey(definition.Alias))
-                {
-                    entities.Add(definition.Alias);
-                }
-
-                // Allow subclasses to add to the list if required
-                entities.AddRange(CollateWatchedTextures(watchedTextures.Keys, definition));
-
-                if (entities.Count == 0)
-                {
-                    continue;
-                }
-
-                foreach (E entity in entities)
-                {
-                    foreach (int watchedIndex in watchedTextures[entity])
-                    {
-                        foreach (TexturedTileSegment segment in _importSegments[definition])
-                        {
-                            AbstractIndexedTRTexture texture = segment.GetTexture(watchedIndex);
-                            if (texture == null)
-                            {
-                                continue;
-                            }
-
-                            if (!textureResults.ContainsKey(entity))
-                            {
-                                textureResults[entity] = new List<PositionedTexture>();
-                            }
-                            textureResults[entity].Add(new PositionedTexture(texture));
-                            break;
-                        }
-                    }
-                }
-            }
-
-            _positionMonitor.MonitoredTexturesPositioned(textureResults);
-        }
-
-        protected int FindMatchingSegment(List<TexturedTileSegment> segments, TexturedTileSegment segment)
-        {
-            for (int i = 0; i < segments.Count; i++)
-            {
-                TexturedTileSegment otherSegment = segments[i];
-                if
-                (
-                    otherSegment.FirstTextureIndex == segment.FirstTextureIndex &&
-                    otherSegment.FirstClassification == segment.FirstClassification
-                )
-                {
-                    return i;
-                }
-            }
-            return -1;
-        }
-
-        protected void RemapMeshTextures(TRMesh[] meshes, Dictionary<int, int> indexMap)
-        {
-            foreach (TRMesh mesh in meshes)
-            {
-                foreach (TRFace4 rect in mesh.TexturedRectangles)
-                {
-                    rect.Texture = ConvertTextureReference(rect.Texture, indexMap);
-                }
-                foreach (TRFace3 tri in mesh.TexturedTriangles)
-                {
-                    tri.Texture = ConvertTextureReference(tri.Texture, indexMap);
-                }
+                tri.Texture = ConvertTextureReference(tri.Texture, indexMap);
             }
         }
+    }
 
-        protected ushort ConvertTextureReference(ushort textureReference, Dictionary<int, int> indexMap)
+    protected ushort ConvertTextureReference(ushort textureReference, Dictionary<int, int> indexMap)
+    {
+        if (indexMap.ContainsKey(textureReference))
         {
-            if (indexMap.ContainsKey(textureReference))
-            {
-                return (ushort)indexMap[textureReference];
-            }
-            return 0;
+            return (ushort)indexMap[textureReference];
         }
+        return 0;
     }
 }

--- a/TRModelTransporter/Handlers/Textures/AbstractTextureImportHandler.cs
+++ b/TRModelTransporter/Handlers/Textures/AbstractTextureImportHandler.cs
@@ -41,7 +41,7 @@ public abstract class AbstractTextureImportHandler<E, L, D>
         PackingResult<TexturedTile, TexturedTileSegment> packingResult = Pack();
         if (packingResult.OrphanCount > 0)
         {
-            List<string> entityNames = new List<string>();
+            List<string> entityNames = new();
             foreach (D def in _definitions)
             {
                 entityNames.Add(def.Entity.ToString());
@@ -71,7 +71,7 @@ public abstract class AbstractTextureImportHandler<E, L, D>
         _importSegments = new Dictionary<D, List<TexturedTileSegment>>();
 
         // Track existing sprite sequences to avoid duplication
-        List<TRSpriteSequence> spriteSequences = new List<TRSpriteSequence>(GetExistingSpriteSequences());
+        List<TRSpriteSequence> spriteSequences = new(GetExistingSpriteSequences());
         foreach (D definition in _definitions)
         {
             if (!definition.HasGraphics || definition.IsDependencyOnly)
@@ -80,7 +80,7 @@ public abstract class AbstractTextureImportHandler<E, L, D>
             }
 
             _importSegments[definition] = new List<TexturedTileSegment>();
-            using (BitmapGraphics bg = new BitmapGraphics(definition.Bitmap))
+            using (BitmapGraphics bg = new(definition.Bitmap))
             {
                 foreach (int segmentIndex in definition.ObjectTextures.Keys)
                 {
@@ -99,7 +99,7 @@ public abstract class AbstractTextureImportHandler<E, L, D>
                     }
                 }
 
-                List<E> spriteEntities = new List<E>(definition.SpriteSequences.Keys);
+                List<E> spriteEntities = new(definition.SpriteSequences.Keys);
                 foreach (E spriteEntity in spriteEntities)
                 {
                     TRSpriteSequence existingSequence = spriteSequences.Find(s => s.SpriteID == Convert.ToInt32(spriteEntity));
@@ -147,7 +147,7 @@ public abstract class AbstractTextureImportHandler<E, L, D>
 
             ProcessRemovals(packer);
 
-            List<TexturedTileSegment> allSegments = new List<TexturedTileSegment>();
+            List<TexturedTileSegment> allSegments = new();
             foreach (List<TexturedTileSegment> segmentList in _importSegments.Values)
             {
                 // We only add unique segments, so if another segment already exists, 
@@ -188,9 +188,9 @@ public abstract class AbstractTextureImportHandler<E, L, D>
         // Add each ObjectTexture to the level and store a map of old index to new index.
         // Make use of any invalid texture first because we are limited to 2048 entries
         List<TRObjectTexture> levelObjectTextures = GetExistingObjectTextures().ToList();
-        Queue<int> reusableIndices = new Queue<int>(GetInvalidObjectTextureIndices());
+        Queue<int> reusableIndices = new(GetInvalidObjectTextureIndices());
 
-        Dictionary<D, Dictionary<int, int>> indexMap = new Dictionary<D, Dictionary<int, int>>();
+        Dictionary<D, Dictionary<int, int>> indexMap = new();
         foreach (D definition in _definitions)
         {
             if (!_importSegments.ContainsKey(definition))
@@ -320,12 +320,12 @@ public abstract class AbstractTextureImportHandler<E, L, D>
             return;
         }
 
-        Dictionary<E, List<PositionedTexture>> textureResults = new Dictionary<E, List<PositionedTexture>>();
+        Dictionary<E, List<PositionedTexture>> textureResults = new();
 
         foreach (D definition in _importSegments.Keys)
         {
             // Does this definition have any entities we are interested in?
-            List<E> entities = new List<E>();
+            List<E> entities = new();
             if (watchedTextures.ContainsKey(definition.Alias))
             {
                 entities.Add(definition.Alias);

--- a/TRModelTransporter/Handlers/Textures/AbstractTextureImportHandler.cs
+++ b/TRModelTransporter/Handlers/Textures/AbstractTextureImportHandler.cs
@@ -163,7 +163,7 @@ public abstract class AbstractTextureImportHandler<E, L, D>
                 {
                     TexturedTileSegment otherSegment = allSegments[j];
                     segmentList[i] = allSegments[j];
-                    foreach (IndexedTRObjectTexture texture in segment.Textures)
+                    foreach (AbstractIndexedTRTexture texture in segment.Textures)
                     {
                         if (!otherSegment.IsObjectTextureFor(texture.Index))
                         {

--- a/TRModelTransporter/Handlers/Textures/AbstractTextureImportHandler.cs
+++ b/TRModelTransporter/Handlers/Textures/AbstractTextureImportHandler.cs
@@ -1,8 +1,5 @@
 ﻿using RectanglePacker.Events;
-using System;
-using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
 using TRLevelControl.Model;
 using TRModelTransporter.Data;
 using TRModelTransporter.Model;

--- a/TRModelTransporter/Handlers/Textures/TR1/TR1TextureExportHandler.cs
+++ b/TRModelTransporter/Handlers/Textures/TR1/TR1TextureExportHandler.cs
@@ -4,18 +4,17 @@ using TRLevelControl.Model.Enums;
 using TRModelTransporter.Model.Definitions;
 using TRModelTransporter.Packing;
 
-namespace TRModelTransporter.Handlers.Textures
-{
-    public class TR1TextureExportHandler : AbstractTextureExportHandler<TREntities, TR1Level, TR1ModelDefinition>
-    {
-        protected override AbstractTexturePacker<TREntities, TR1Level> CreatePacker()
-        {
-            return new TR1TexturePacker(_level, _classifier);
-        }
+namespace TRModelTransporter.Handlers.Textures;
 
-        protected override TRSpriteSequence GetSprite(TREntities entity)
-        {
-            return _level.SpriteSequences.ToList().Find(s => s.SpriteID == (int)entity);
-        }
+public class TR1TextureExportHandler : AbstractTextureExportHandler<TREntities, TR1Level, TR1ModelDefinition>
+{
+    protected override AbstractTexturePacker<TREntities, TR1Level> CreatePacker()
+    {
+        return new TR1TexturePacker(_level, _classifier);
+    }
+
+    protected override TRSpriteSequence GetSprite(TREntities entity)
+    {
+        return _level.SpriteSequences.ToList().Find(s => s.SpriteID == (int)entity);
     }
 }

--- a/TRModelTransporter/Handlers/Textures/TR1/TR1TextureExportHandler.cs
+++ b/TRModelTransporter/Handlers/Textures/TR1/TR1TextureExportHandler.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using TRLevelControl.Model;
+﻿using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;
 using TRModelTransporter.Model.Definitions;
 using TRModelTransporter.Packing;

--- a/TRModelTransporter/Handlers/Textures/TR1/TR1TextureImportHandler.cs
+++ b/TRModelTransporter/Handlers/Textures/TR1/TR1TextureImportHandler.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using TRLevelControl.Model;
+﻿using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;
 using TRModelTransporter.Helpers;
 using TRModelTransporter.Model.Definitions;

--- a/TRModelTransporter/Handlers/Textures/TR1/TR1TextureImportHandler.cs
+++ b/TRModelTransporter/Handlers/Textures/TR1/TR1TextureImportHandler.cs
@@ -7,142 +7,141 @@ using TRModelTransporter.Model.Definitions;
 using TRModelTransporter.Packing;
 using TRTexture16Importer.Helpers;
 
-namespace TRModelTransporter.Handlers.Textures
+namespace TRModelTransporter.Handlers.Textures;
+
+public class TR1TextureImportHandler : AbstractTextureImportHandler<TREntities, TR1Level, TR1ModelDefinition>
 {
-    public class TR1TextureImportHandler : AbstractTextureImportHandler<TREntities, TR1Level, TR1ModelDefinition>
+    public TR1PaletteManager PaletteManager { get; set; }
+
+    protected override IEnumerable<TRSpriteSequence> GetExistingSpriteSequences()
     {
-        public TR1PaletteManager PaletteManager { get; set; }
-
-        protected override IEnumerable<TRSpriteSequence> GetExistingSpriteSequences()
+        // Allow replacing the Explosion sequence in Vilcabamba (it's there but empty)
+        List<TRSpriteSequence> sequences = _level.SpriteSequences.ToList();
+        TRSpriteSequence explosion = sequences.Find(s => s.SpriteID == (int)TREntities.Explosion1_S_H);
+        if (explosion != null && explosion.NegativeLength == -1)
         {
-            // Allow replacing the Explosion sequence in Vilcabamba (it's there but empty)
-            List<TRSpriteSequence> sequences = _level.SpriteSequences.ToList();
-            TRSpriteSequence explosion = sequences.Find(s => s.SpriteID == (int)TREntities.Explosion1_S_H);
-            if (explosion != null && explosion.NegativeLength == -1)
+            sequences.Remove(explosion);
+        }
+        return sequences;
+    }
+
+    protected override void WriteSpriteSequences(IEnumerable<TRSpriteSequence> spriteSequences)
+    {
+        _level.SpriteSequences = spriteSequences.ToArray();
+        _level.NumSpriteSequences = (uint)_level.SpriteSequences.Length;
+    }
+
+    protected override IEnumerable<TRSpriteTexture> GetExistingSpriteTextures()
+    {
+        return _level.SpriteTextures.ToList();
+    }
+
+    protected override void WriteSpriteTextures(IEnumerable<TRSpriteTexture> spriteTextures)
+    {
+        _level.SpriteTextures = spriteTextures.ToArray();
+        _level.NumSpriteTextures = (uint)_level.SpriteTextures.Length;
+    }
+
+    protected override AbstractTexturePacker<TREntities, TR1Level> CreatePacker()
+    {
+        return new TR1TexturePacker(_level)
+        {
+            PaletteManager = PaletteManager
+        };
+    }
+
+    protected override void ProcessRemovals(AbstractTexturePacker<TREntities, TR1Level> packer)
+    {
+        List<TREntities> removals = new List<TREntities>();
+        if (_clearUnusedSprites)
+        {
+            removals.Add(TREntities.Map_M_U);
+        }
+
+        if (_entitiesToRemove != null)
+        {
+            removals.AddRange(_entitiesToRemove);
+        }
+        packer.RemoveModelSegments(removals, _textureRemap);
+
+        if (_clearUnusedSprites)
+        {
+            RemoveUnusedSprites(packer);
+        }
+    }
+
+    private void RemoveUnusedSprites(AbstractTexturePacker<TREntities, TR1Level> packer)
+    {
+        List<TREntities> unusedItems = new List<TREntities>
+        {
+            TREntities.PistolAmmo_S_P,
+            TREntities.Map_M_U
+        };
+
+        ISet<TREntities> allEntities = new HashSet<TREntities>();
+        for (int i = 0; i < _level.Entities.Length; i++)
+        {
+            allEntities.Add((TREntities)_level.Entities[i].TypeID);
+        }
+
+        for (int i = unusedItems.Count - 1; i >= 0; i--)
+        {
+            if (allEntities.Contains(unusedItems[i]))
             {
-                sequences.Remove(explosion);
+                unusedItems.RemoveAt(i);
             }
-            return sequences;
         }
 
-        protected override void WriteSpriteSequences(IEnumerable<TRSpriteSequence> spriteSequences)
+        packer.RemoveSpriteSegments(unusedItems);
+    }
+
+    protected override IEnumerable<TRObjectTexture> GetExistingObjectTextures()
+    {
+        return _level.ObjectTextures.ToList();
+    }
+
+    protected override IEnumerable<int> GetInvalidObjectTextureIndices()
+    {
+        return _level.GetInvalidObjectTextureIndices();
+    }
+
+    protected override void WriteObjectTextures(IEnumerable<TRObjectTexture> objectTextures)
+    {
+        _level.ObjectTextures = objectTextures.ToArray();
+        _level.NumObjectTextures = (uint)_level.ObjectTextures.Length;
+    }
+
+    protected override void RemapMeshTextures(Dictionary<TR1ModelDefinition, Dictionary<int, int>> indexMap)
+    {
+        foreach (TR1ModelDefinition definition in indexMap.Keys)
         {
-            _level.SpriteSequences = spriteSequences.ToArray();
-            _level.NumSpriteSequences = (uint)_level.SpriteSequences.Length;
-        }
-
-        protected override IEnumerable<TRSpriteTexture> GetExistingSpriteTextures()
-        {
-            return _level.SpriteTextures.ToList();
-        }
-
-        protected override void WriteSpriteTextures(IEnumerable<TRSpriteTexture> spriteTextures)
-        {
-            _level.SpriteTextures = spriteTextures.ToArray();
-            _level.NumSpriteTextures = (uint)_level.SpriteTextures.Length;
-        }
-
-        protected override AbstractTexturePacker<TREntities, TR1Level> CreatePacker()
-        {
-            return new TR1TexturePacker(_level)
+            foreach (TRMesh mesh in definition.Meshes)
             {
-                PaletteManager = PaletteManager
-            };
-        }
-
-        protected override void ProcessRemovals(AbstractTexturePacker<TREntities, TR1Level> packer)
-        {
-            List<TREntities> removals = new List<TREntities>();
-            if (_clearUnusedSprites)
-            {
-                removals.Add(TREntities.Map_M_U);
-            }
-
-            if (_entitiesToRemove != null)
-            {
-                removals.AddRange(_entitiesToRemove);
-            }
-            packer.RemoveModelSegments(removals, _textureRemap);
-
-            if (_clearUnusedSprites)
-            {
-                RemoveUnusedSprites(packer);
-            }
-        }
-
-        private void RemoveUnusedSprites(AbstractTexturePacker<TREntities, TR1Level> packer)
-        {
-            List<TREntities> unusedItems = new List<TREntities>
-            {
-                TREntities.PistolAmmo_S_P,
-                TREntities.Map_M_U
-            };
-
-            ISet<TREntities> allEntities = new HashSet<TREntities>();
-            for (int i = 0; i < _level.Entities.Length; i++)
-            {
-                allEntities.Add((TREntities)_level.Entities[i].TypeID);
-            }
-
-            for (int i = unusedItems.Count - 1; i >= 0; i--)
-            {
-                if (allEntities.Contains(unusedItems[i]))
+                foreach (TRFace4 rect in mesh.TexturedRectangles)
                 {
-                    unusedItems.RemoveAt(i);
+                    rect.Texture = ConvertTextureReference(rect.Texture, indexMap[definition]);
                 }
-            }
-
-            packer.RemoveSpriteSegments(unusedItems);
-        }
-
-        protected override IEnumerable<TRObjectTexture> GetExistingObjectTextures()
-        {
-            return _level.ObjectTextures.ToList();
-        }
-
-        protected override IEnumerable<int> GetInvalidObjectTextureIndices()
-        {
-            return _level.GetInvalidObjectTextureIndices();
-        }
-
-        protected override void WriteObjectTextures(IEnumerable<TRObjectTexture> objectTextures)
-        {
-            _level.ObjectTextures = objectTextures.ToArray();
-            _level.NumObjectTextures = (uint)_level.ObjectTextures.Length;
-        }
-
-        protected override void RemapMeshTextures(Dictionary<TR1ModelDefinition, Dictionary<int, int>> indexMap)
-        {
-            foreach (TR1ModelDefinition definition in indexMap.Keys)
-            {
-                foreach (TRMesh mesh in definition.Meshes)
+                foreach (TRFace3 tri in mesh.TexturedTriangles)
                 {
-                    foreach (TRFace4 rect in mesh.TexturedRectangles)
-                    {
-                        rect.Texture = ConvertTextureReference(rect.Texture, indexMap[definition]);
-                    }
-                    foreach (TRFace3 tri in mesh.TexturedTriangles)
-                    {
-                        tri.Texture = ConvertTextureReference(tri.Texture, indexMap[definition]);
-                    }
+                    tri.Texture = ConvertTextureReference(tri.Texture, indexMap[definition]);
                 }
             }
         }
+    }
 
-        public override void ResetUnusedTextures()
-        {
-            // Patch - this doesn't break the game, but it prevents the level being
-            // opened in trview. Some textures will now be unused, but rather than
-            // removing them and having to reindex everything that points to the
-            // the object textures, we'll just reset them to atlas 0, and set all
-            // coordinates to 0.
+    public override void ResetUnusedTextures()
+    {
+        // Patch - this doesn't break the game, but it prevents the level being
+        // opened in trview. Some textures will now be unused, but rather than
+        // removing them and having to reindex everything that points to the
+        // the object textures, we'll just reset them to atlas 0, and set all
+        // coordinates to 0.
 
-            _level.ResetUnusedTextures();
-        }
+        _level.ResetUnusedTextures();
+    }
 
-        protected override IEnumerable<TREntities> CollateWatchedTextures(IEnumerable<TREntities> watchedEntities, TR1ModelDefinition definition)
-        {
-            return new List<TREntities>();
-        }
+    protected override IEnumerable<TREntities> CollateWatchedTextures(IEnumerable<TREntities> watchedEntities, TR1ModelDefinition definition)
+    {
+        return new List<TREntities>();
     }
 }

--- a/TRModelTransporter/Handlers/Textures/TR1/TR1TextureImportHandler.cs
+++ b/TRModelTransporter/Handlers/Textures/TR1/TR1TextureImportHandler.cs
@@ -50,7 +50,7 @@ public class TR1TextureImportHandler : AbstractTextureImportHandler<TREntities, 
 
     protected override void ProcessRemovals(AbstractTexturePacker<TREntities, TR1Level> packer)
     {
-        List<TREntities> removals = new List<TREntities>();
+        List<TREntities> removals = new();
         if (_clearUnusedSprites)
         {
             removals.Add(TREntities.Map_M_U);
@@ -70,7 +70,7 @@ public class TR1TextureImportHandler : AbstractTextureImportHandler<TREntities, 
 
     private void RemoveUnusedSprites(AbstractTexturePacker<TREntities, TR1Level> packer)
     {
-        List<TREntities> unusedItems = new List<TREntities>
+        List<TREntities> unusedItems = new()
         {
             TREntities.PistolAmmo_S_P,
             TREntities.Map_M_U

--- a/TRModelTransporter/Handlers/Textures/TR2/TR2TextureExportHandler.cs
+++ b/TRModelTransporter/Handlers/Textures/TR2/TR2TextureExportHandler.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using TRLevelControl.Model;
+﻿using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;
 using TRModelTransporter.Model.Definitions;
 using TRModelTransporter.Packing;

--- a/TRModelTransporter/Handlers/Textures/TR2/TR2TextureExportHandler.cs
+++ b/TRModelTransporter/Handlers/Textures/TR2/TR2TextureExportHandler.cs
@@ -4,18 +4,17 @@ using TRLevelControl.Model.Enums;
 using TRModelTransporter.Model.Definitions;
 using TRModelTransporter.Packing;
 
-namespace TRModelTransporter.Handlers
-{
-    public class TR2TextureExportHandler : AbstractTextureExportHandler<TR2Entities, TR2Level, TR2ModelDefinition>
-    {
-        protected override AbstractTexturePacker<TR2Entities, TR2Level> CreatePacker()
-        {
-            return new TR2TexturePacker(_level, _classifier);
-        }
+namespace TRModelTransporter.Handlers;
 
-        protected override TRSpriteSequence GetSprite(TR2Entities entity)
-        {
-            return _level.SpriteSequences.ToList().Find(s => s.SpriteID == (int)entity);
-        }
+public class TR2TextureExportHandler : AbstractTextureExportHandler<TR2Entities, TR2Level, TR2ModelDefinition>
+{
+    protected override AbstractTexturePacker<TR2Entities, TR2Level> CreatePacker()
+    {
+        return new TR2TexturePacker(_level, _classifier);
+    }
+
+    protected override TRSpriteSequence GetSprite(TR2Entities entity)
+    {
+        return _level.SpriteSequences.ToList().Find(s => s.SpriteID == (int)entity);
     }
 }

--- a/TRModelTransporter/Handlers/Textures/TR2/TR2TextureImportHandler.cs
+++ b/TRModelTransporter/Handlers/Textures/TR2/TR2TextureImportHandler.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using TRLevelControl.Model;
+﻿using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;
 using TRModelTransporter.Helpers;
 using TRModelTransporter.Model.Definitions;

--- a/TRModelTransporter/Handlers/Textures/TR2/TR2TextureImportHandler.cs
+++ b/TRModelTransporter/Handlers/Textures/TR2/TR2TextureImportHandler.cs
@@ -37,7 +37,7 @@ public class TR2TextureImportHandler : AbstractTextureImportHandler<TR2Entities,
 
     protected override void ProcessRemovals(AbstractTexturePacker<TR2Entities, TR2Level> packer)
     {
-        List<TR2Entities> removals = new List<TR2Entities>();
+        List<TR2Entities> removals = new();
         if (_clearUnusedSprites)
         {
             removals.Add(TR2Entities.Map_M_U);
@@ -71,7 +71,7 @@ public class TR2TextureImportHandler : AbstractTextureImportHandler<TR2Entities,
         // We need to ensure that if these models are present in any level, that the sprite sequences for the blasts point
         // to the same as the grenade blast instead.
 
-        List<TR2Entities> flameEnemies = new List<TR2Entities>
+        List<TR2Entities> flameEnemies = new()
         {
             TR2Entities.FlamethrowerGoon, TR2Entities.DragonExplosionEmitter_N
         };
@@ -116,7 +116,7 @@ public class TR2TextureImportHandler : AbstractTextureImportHandler<TR2Entities,
 
     private void RemoveUnusedSprites(AbstractTexturePacker<TR2Entities, TR2Level> packer)
     {
-        List<TR2Entities> unusedItems = new List<TR2Entities>
+        List<TR2Entities> unusedItems = new()
         {
             TR2Entities.PistolAmmo_S_P,
             TR2Entities.Map_M_U,
@@ -183,7 +183,7 @@ public class TR2TextureImportHandler : AbstractTextureImportHandler<TR2Entities,
     {
         // Ensure the likes of the flamethrower having been imported triggers the fact that
         // the flame sprite sequence has been positioned.
-        List<TR2Entities> entities = new List<TR2Entities>();
+        List<TR2Entities> entities = new();
         foreach (TR2Entities spriteEntity in definition.SpriteSequences.Keys)
         {
             if (watchedEntities.Contains(spriteEntity))

--- a/TRModelTransporter/Handlers/Textures/TR2/TR2TextureImportHandler.cs
+++ b/TRModelTransporter/Handlers/Textures/TR2/TR2TextureImportHandler.cs
@@ -6,195 +6,194 @@ using TRModelTransporter.Helpers;
 using TRModelTransporter.Model.Definitions;
 using TRModelTransporter.Packing;
 
-namespace TRModelTransporter.Handlers
+namespace TRModelTransporter.Handlers;
+
+public class TR2TextureImportHandler : AbstractTextureImportHandler<TR2Entities, TR2Level, TR2ModelDefinition>
 {
-    public class TR2TextureImportHandler : AbstractTextureImportHandler<TR2Entities, TR2Level, TR2ModelDefinition>
+    protected override IEnumerable<TRSpriteSequence> GetExistingSpriteSequences()
     {
-        protected override IEnumerable<TRSpriteSequence> GetExistingSpriteSequences()
+        return _level.SpriteSequences;
+    }
+
+    protected override void WriteSpriteSequences(IEnumerable<TRSpriteSequence> spriteSequences)
+    {
+        _level.SpriteSequences = spriteSequences.ToArray();
+        _level.NumSpriteSequences = (uint)_level.SpriteSequences.Length;
+    }
+
+    protected override IEnumerable<TRSpriteTexture> GetExistingSpriteTextures()
+    {
+        return _level.SpriteTextures.ToList();
+    }
+
+    protected override void WriteSpriteTextures(IEnumerable<TRSpriteTexture> spriteTextures)
+    {
+        _level.SpriteTextures = spriteTextures.ToArray();
+        _level.NumSpriteTextures = (uint)_level.SpriteTextures.Length;
+    }
+
+    protected override AbstractTexturePacker<TR2Entities, TR2Level> CreatePacker()
+    {
+        return new TR2TexturePacker(_level);
+    }
+
+    protected override void ProcessRemovals(AbstractTexturePacker<TR2Entities, TR2Level> packer)
+    {
+        List<TR2Entities> removals = new List<TR2Entities>();
+        if (_clearUnusedSprites)
         {
-            return _level.SpriteSequences;
+            removals.Add(TR2Entities.Map_M_U);
         }
 
-        protected override void WriteSpriteSequences(IEnumerable<TRSpriteSequence> spriteSequences)
-        {
-            _level.SpriteSequences = spriteSequences.ToArray();
-            _level.NumSpriteSequences = (uint)_level.SpriteSequences.Length;
-        }
+        // Marco is in Floaters by default but he isn't used. Removing the textures will break precompiled deduplication
+        // so this remains unimplemented for the time being.
+        //List<TRModel> models = _level.Models.ToList();
+        //if (models.Find(m => m.ID == (uint)TR2Entities.MarcoBartoli) != null && models.Find(m => m.ID == (uint)TR2Entities.DragonBack_H) == null)
+        //{
+        //    removals.Add(TR2Entities.MarcoBartoli);
+        //}
 
-        protected override IEnumerable<TRSpriteTexture> GetExistingSpriteTextures()
+        if (_entitiesToRemove != null)
         {
-            return _level.SpriteTextures.ToList();
+            removals.AddRange(_entitiesToRemove);
         }
+        packer.RemoveModelSegments(removals, _textureRemap);
 
-        protected override void WriteSpriteTextures(IEnumerable<TRSpriteTexture> spriteTextures)
+        ApplyFlamePatch();
+
+        if (_clearUnusedSprites)
         {
-            _level.SpriteTextures = spriteTextures.ToArray();
-            _level.NumSpriteTextures = (uint)_level.SpriteTextures.Length;
+            RemoveUnusedSprites(packer);
         }
+    }
 
-        protected override AbstractTexturePacker<TR2Entities, TR2Level> CreatePacker()
-        {
-            return new TR2TexturePacker(_level);
-        }
+    private void ApplyFlamePatch()
+    {
+        // TextureDeduplicator will have removed the extra flame blasts present in DA and Lair (Flamethrower and Dragon).
+        // We need to ensure that if these models are present in any level, that the sprite sequences for the blasts point
+        // to the same as the grenade blast instead.
 
-        protected override void ProcessRemovals(AbstractTexturePacker<TR2Entities, TR2Level> packer)
+        List<TR2Entities> flameEnemies = new List<TR2Entities>
         {
-            List<TR2Entities> removals = new List<TR2Entities>();
-            if (_clearUnusedSprites)
+            TR2Entities.FlamethrowerGoon, TR2Entities.DragonExplosionEmitter_N
+        };
+
+        if
+        (
+            _definitions.ToList().FindIndex(d => flameEnemies.Contains(d.Entity)) != -1 ||
+            _level.Models.ToList().FindIndex(m => flameEnemies.Contains((TR2Entities)m.ID)) != -1
+        )
+        {
+            List<TRSpriteSequence> sequences = _level.SpriteSequences.ToList();
+            int blastSequence = sequences.FindIndex(s => s.SpriteID == (int)TR2Entities.FireBlast_S_H);
+            int grenadeSequence = sequences.FindIndex(s => s.SpriteID == (int)TR2Entities.Explosion_S_H);
+
+            if (grenadeSequence != -1)
             {
-                removals.Add(TR2Entities.Map_M_U);
-            }
-
-            // Marco is in Floaters by default but he isn't used. Removing the textures will break precompiled deduplication
-            // so this remains unimplemented for the time being.
-            //List<TRModel> models = _level.Models.ToList();
-            //if (models.Find(m => m.ID == (uint)TR2Entities.MarcoBartoli) != null && models.Find(m => m.ID == (uint)TR2Entities.DragonBack_H) == null)
-            //{
-            //    removals.Add(TR2Entities.MarcoBartoli);
-            //}
-
-            if (_entitiesToRemove != null)
-            {
-                removals.AddRange(_entitiesToRemove);
-            }
-            packer.RemoveModelSegments(removals, _textureRemap);
-
-            ApplyFlamePatch();
-
-            if (_clearUnusedSprites)
-            {
-                RemoveUnusedSprites(packer);
-            }
-        }
-
-        private void ApplyFlamePatch()
-        {
-            // TextureDeduplicator will have removed the extra flame blasts present in DA and Lair (Flamethrower and Dragon).
-            // We need to ensure that if these models are present in any level, that the sprite sequences for the blasts point
-            // to the same as the grenade blast instead.
-
-            List<TR2Entities> flameEnemies = new List<TR2Entities>
-            {
-                TR2Entities.FlamethrowerGoon, TR2Entities.DragonExplosionEmitter_N
-            };
-
-            if
-            (
-                _definitions.ToList().FindIndex(d => flameEnemies.Contains(d.Entity)) != -1 ||
-                _level.Models.ToList().FindIndex(m => flameEnemies.Contains((TR2Entities)m.ID)) != -1
-            )
-            {
-                List<TRSpriteSequence> sequences = _level.SpriteSequences.ToList();
-                int blastSequence = sequences.FindIndex(s => s.SpriteID == (int)TR2Entities.FireBlast_S_H);
-                int grenadeSequence = sequences.FindIndex(s => s.SpriteID == (int)TR2Entities.Explosion_S_H);
-
-                if (grenadeSequence != -1)
+                if (blastSequence == -1)
                 {
-                    if (blastSequence == -1)
+                    TRSpriteSequence grenadeBlast = sequences[grenadeSequence];
+                    sequences.Add(new TRSpriteSequence
                     {
-                        TRSpriteSequence grenadeBlast = sequences[grenadeSequence];
-                        sequences.Add(new TRSpriteSequence
-                        {
-                            SpriteID = (int)TR2Entities.FireBlast_S_H,
-                            NegativeLength = grenadeBlast.NegativeLength,
-                            Offset = grenadeBlast.Offset
-                        });
+                        SpriteID = (int)TR2Entities.FireBlast_S_H,
+                        NegativeLength = grenadeBlast.NegativeLength,
+                        Offset = grenadeBlast.Offset
+                    });
 
-                        _level.SpriteSequences = sequences.ToArray();
-                        _level.NumSpriteSequences++;
-                    }
-                    else
+                    _level.SpriteSequences = sequences.ToArray();
+                    _level.NumSpriteSequences++;
+                }
+                else
+                {
+                    // #275 Rather than just pointing the blast sequence offset to the grenade sequence offset,
+                    // retain the original sprite texture objects but just remap where they point in the tiles.
+                    for (int i = 0; i < sequences[grenadeSequence].NegativeLength * -1; i++)
                     {
-                        // #275 Rather than just pointing the blast sequence offset to the grenade sequence offset,
-                        // retain the original sprite texture objects but just remap where they point in the tiles.
-                        for (int i = 0; i < sequences[grenadeSequence].NegativeLength * -1; i++)
-                        {
-                            _level.SpriteTextures[_level.SpriteSequences[blastSequence].Offset + i] = _level.SpriteTextures[_level.SpriteSequences[grenadeSequence].Offset + i];
-                        }
+                        _level.SpriteTextures[_level.SpriteSequences[blastSequence].Offset + i] = _level.SpriteTextures[_level.SpriteSequences[grenadeSequence].Offset + i];
                     }
                 }
             }
         }
+    }
 
-        private void RemoveUnusedSprites(AbstractTexturePacker<TR2Entities, TR2Level> packer)
+    private void RemoveUnusedSprites(AbstractTexturePacker<TR2Entities, TR2Level> packer)
+    {
+        List<TR2Entities> unusedItems = new List<TR2Entities>
         {
-            List<TR2Entities> unusedItems = new List<TR2Entities>
-            {
-                TR2Entities.PistolAmmo_S_P,
-                TR2Entities.Map_M_U,
-                TR2Entities.GrayDisk_S_H
-            };
+            TR2Entities.PistolAmmo_S_P,
+            TR2Entities.Map_M_U,
+            TR2Entities.GrayDisk_S_H
+        };
 
-            ISet<TR2Entities> allEntities = new HashSet<TR2Entities>();
-            for (int i = 0; i < _level.Entities.Length; i++)
+        ISet<TR2Entities> allEntities = new HashSet<TR2Entities>();
+        for (int i = 0; i < _level.Entities.Length; i++)
+        {
+            allEntities.Add((TR2Entities)_level.Entities[i].TypeID);
+        }
+
+        for (int i = unusedItems.Count - 1; i >= 0; i--)
+        {
+            if (unusedItems[i] != TR2Entities.GrayDisk_S_H && allEntities.Contains(unusedItems[i]))
             {
-                allEntities.Add((TR2Entities)_level.Entities[i].TypeID);
+                unusedItems.RemoveAt(i);
             }
+        }
 
-            for (int i = unusedItems.Count - 1; i >= 0; i--)
+        packer.RemoveSpriteSegments(unusedItems);
+    }
+
+    protected override IEnumerable<TRObjectTexture> GetExistingObjectTextures()
+    {
+        return _level.ObjectTextures.ToList();
+    }
+
+    protected override IEnumerable<int> GetInvalidObjectTextureIndices()
+    {
+        return _level.GetInvalidObjectTextureIndices();
+    }
+
+    protected override void WriteObjectTextures(IEnumerable<TRObjectTexture> objectTextures)
+    {
+        _level.ObjectTextures = objectTextures.ToArray();
+        _level.NumObjectTextures = (uint)_level.ObjectTextures.Length;
+    }
+
+    protected override void RemapMeshTextures(Dictionary<TR2ModelDefinition, Dictionary<int, int>> indexMap)
+    {
+        foreach (TR2ModelDefinition definition in indexMap.Keys)
+        {
+            foreach (TRMesh mesh in definition.Meshes)
             {
-                if (unusedItems[i] != TR2Entities.GrayDisk_S_H && allEntities.Contains(unusedItems[i]))
+                foreach (TRFace4 rect in mesh.TexturedRectangles)
                 {
-                    unusedItems.RemoveAt(i);
+                    rect.Texture = ConvertTextureReference(rect.Texture, indexMap[definition]);
+                }
+                foreach (TRFace3 tri in mesh.TexturedTriangles)
+                {
+                    tri.Texture = ConvertTextureReference(tri.Texture, indexMap[definition]);
                 }
             }
-
-            packer.RemoveSpriteSegments(unusedItems);
         }
+    }
 
-        protected override IEnumerable<TRObjectTexture> GetExistingObjectTextures()
-        {
-            return _level.ObjectTextures.ToList();
-        }
+    public override void ResetUnusedTextures()
+    {
+        _level.ResetUnusedTextures();
+    }
 
-        protected override IEnumerable<int> GetInvalidObjectTextureIndices()
+    protected override IEnumerable<TR2Entities> CollateWatchedTextures(IEnumerable<TR2Entities> watchedEntities, TR2ModelDefinition definition)
+    {
+        // Ensure the likes of the flamethrower having been imported triggers the fact that
+        // the flame sprite sequence has been positioned.
+        List<TR2Entities> entities = new List<TR2Entities>();
+        foreach (TR2Entities spriteEntity in definition.SpriteSequences.Keys)
         {
-            return _level.GetInvalidObjectTextureIndices();
-        }
-
-        protected override void WriteObjectTextures(IEnumerable<TRObjectTexture> objectTextures)
-        {
-            _level.ObjectTextures = objectTextures.ToArray();
-            _level.NumObjectTextures = (uint)_level.ObjectTextures.Length;
-        }
-
-        protected override void RemapMeshTextures(Dictionary<TR2ModelDefinition, Dictionary<int, int>> indexMap)
-        {
-            foreach (TR2ModelDefinition definition in indexMap.Keys)
+            if (watchedEntities.Contains(spriteEntity))
             {
-                foreach (TRMesh mesh in definition.Meshes)
-                {
-                    foreach (TRFace4 rect in mesh.TexturedRectangles)
-                    {
-                        rect.Texture = ConvertTextureReference(rect.Texture, indexMap[definition]);
-                    }
-                    foreach (TRFace3 tri in mesh.TexturedTriangles)
-                    {
-                        tri.Texture = ConvertTextureReference(tri.Texture, indexMap[definition]);
-                    }
-                }
+                entities.Add(spriteEntity);
             }
         }
 
-        public override void ResetUnusedTextures()
-        {
-            _level.ResetUnusedTextures();
-        }
-
-        protected override IEnumerable<TR2Entities> CollateWatchedTextures(IEnumerable<TR2Entities> watchedEntities, TR2ModelDefinition definition)
-        {
-            // Ensure the likes of the flamethrower having been imported triggers the fact that
-            // the flame sprite sequence has been positioned.
-            List<TR2Entities> entities = new List<TR2Entities>();
-            foreach (TR2Entities spriteEntity in definition.SpriteSequences.Keys)
-            {
-                if (watchedEntities.Contains(spriteEntity))
-                {
-                    entities.Add(spriteEntity);
-                }
-            }
-
-            return entities;
-        }
+        return entities;
     }
 }

--- a/TRModelTransporter/Handlers/Textures/TR3/TR3TextureExportHandler.cs
+++ b/TRModelTransporter/Handlers/Textures/TR3/TR3TextureExportHandler.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using TRLevelControl.Model;
+﻿using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;
 using TRModelTransporter.Model.Definitions;
 using TRModelTransporter.Packing;

--- a/TRModelTransporter/Handlers/Textures/TR3/TR3TextureExportHandler.cs
+++ b/TRModelTransporter/Handlers/Textures/TR3/TR3TextureExportHandler.cs
@@ -4,17 +4,16 @@ using TRLevelControl.Model.Enums;
 using TRModelTransporter.Model.Definitions;
 using TRModelTransporter.Packing;
 
-namespace TRModelTransporter.Handlers
+namespace TRModelTransporter.Handlers;
+
+public class TR3TextureExportHandler : AbstractTextureExportHandler<TR3Entities, TR3Level, TR3ModelDefinition>
 {
-    public class TR3TextureExportHandler : AbstractTextureExportHandler<TR3Entities, TR3Level, TR3ModelDefinition>
+    protected override AbstractTexturePacker<TR3Entities, TR3Level> CreatePacker()
     {
-        protected override AbstractTexturePacker<TR3Entities, TR3Level> CreatePacker()
-        {
-            return new TR3TexturePacker(_level, _classifier);
-        }
-        protected override TRSpriteSequence GetSprite(TR3Entities entity)
-        {
-            return _level.SpriteSequences.ToList().Find(s => s.SpriteID == (int)entity);
-        }
+        return new TR3TexturePacker(_level, _classifier);
+    }
+    protected override TRSpriteSequence GetSprite(TR3Entities entity)
+    {
+        return _level.SpriteSequences.ToList().Find(s => s.SpriteID == (int)entity);
     }
 }

--- a/TRModelTransporter/Handlers/Textures/TR3/TR3TextureImportHandler.cs
+++ b/TRModelTransporter/Handlers/Textures/TR3/TR3TextureImportHandler.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using TRLevelControl.Model;
+﻿using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;
 using TRModelTransporter.Helpers;
 using TRModelTransporter.Model.Definitions;

--- a/TRModelTransporter/Handlers/Textures/TR3/TR3TextureImportHandler.cs
+++ b/TRModelTransporter/Handlers/Textures/TR3/TR3TextureImportHandler.cs
@@ -37,7 +37,7 @@ public class TR3TextureImportHandler : AbstractTextureImportHandler<TR3Entities,
 
     protected override void ProcessRemovals(AbstractTexturePacker<TR3Entities, TR3Level> packer)
     {
-        List<TR3Entities> removals = new List<TR3Entities>();
+        List<TR3Entities> removals = new();
         if (_clearUnusedSprites)
         {
             removals.Add(TR3Entities.Map_H);
@@ -57,7 +57,7 @@ public class TR3TextureImportHandler : AbstractTextureImportHandler<TR3Entities,
 
     private void RemoveUnusedSprites(AbstractTexturePacker<TR3Entities, TR3Level> packer)
     {
-        List<TR3Entities> unusedItems = new List<TR3Entities>
+        List<TR3Entities> unusedItems = new()
         {
             TR3Entities.PistolAmmo_M_H,
             TR3Entities.Map_H,

--- a/TRModelTransporter/Handlers/Textures/TR3/TR3TextureImportHandler.cs
+++ b/TRModelTransporter/Handlers/Textures/TR3/TR3TextureImportHandler.cs
@@ -6,125 +6,124 @@ using TRModelTransporter.Helpers;
 using TRModelTransporter.Model.Definitions;
 using TRModelTransporter.Packing;
 
-namespace TRModelTransporter.Handlers
+namespace TRModelTransporter.Handlers;
+
+public class TR3TextureImportHandler : AbstractTextureImportHandler<TR3Entities, TR3Level, TR3ModelDefinition>
 {
-    public class TR3TextureImportHandler : AbstractTextureImportHandler<TR3Entities, TR3Level, TR3ModelDefinition>
+    protected override IEnumerable<TRSpriteSequence> GetExistingSpriteSequences()
     {
-        protected override IEnumerable<TRSpriteSequence> GetExistingSpriteSequences()
+        return _level.SpriteSequences;
+    }
+
+    protected override void WriteSpriteSequences(IEnumerable<TRSpriteSequence> spriteSequences)
+    {
+        _level.SpriteSequences = spriteSequences.ToArray();
+        _level.NumSpriteSequences = (uint)_level.SpriteSequences.Length;
+    }
+
+    protected override IEnumerable<TRSpriteTexture> GetExistingSpriteTextures()
+    {
+        return _level.SpriteTextures.ToList();
+    }
+
+    protected override void WriteSpriteTextures(IEnumerable<TRSpriteTexture> spriteTextures)
+    {
+        _level.SpriteTextures = spriteTextures.ToArray();
+        _level.NumSpriteTextures = (uint)_level.SpriteTextures.Length;
+    }
+
+    protected override AbstractTexturePacker<TR3Entities, TR3Level> CreatePacker()
+    {
+        return new TR3TexturePacker(_level);
+    }
+
+    protected override void ProcessRemovals(AbstractTexturePacker<TR3Entities, TR3Level> packer)
+    {
+        List<TR3Entities> removals = new List<TR3Entities>();
+        if (_clearUnusedSprites)
         {
-            return _level.SpriteSequences;
+            removals.Add(TR3Entities.Map_H);
         }
 
-        protected override void WriteSpriteSequences(IEnumerable<TRSpriteSequence> spriteSequences)
+        if (_entitiesToRemove != null)
         {
-            _level.SpriteSequences = spriteSequences.ToArray();
-            _level.NumSpriteSequences = (uint)_level.SpriteSequences.Length;
+            removals.AddRange(_entitiesToRemove);
+        }
+        packer.RemoveModelSegments(removals, _textureRemap);
+
+        if (_clearUnusedSprites)
+        {
+            RemoveUnusedSprites(packer);
+        }
+    }
+
+    private void RemoveUnusedSprites(AbstractTexturePacker<TR3Entities, TR3Level> packer)
+    {
+        List<TR3Entities> unusedItems = new List<TR3Entities>
+        {
+            TR3Entities.PistolAmmo_M_H,
+            TR3Entities.Map_H,
+            TR3Entities.Disc_H
+        };
+
+        ISet<TR3Entities> allEntities = new HashSet<TR3Entities>();
+        for (int i = 0; i < _level.Entities.Length; i++)
+        {
+            allEntities.Add((TR3Entities)_level.Entities[i].TypeID);
         }
 
-        protected override IEnumerable<TRSpriteTexture> GetExistingSpriteTextures()
+        for (int i = unusedItems.Count - 1; i >= 0; i--)
         {
-            return _level.SpriteTextures.ToList();
-        }
-
-        protected override void WriteSpriteTextures(IEnumerable<TRSpriteTexture> spriteTextures)
-        {
-            _level.SpriteTextures = spriteTextures.ToArray();
-            _level.NumSpriteTextures = (uint)_level.SpriteTextures.Length;
-        }
-
-        protected override AbstractTexturePacker<TR3Entities, TR3Level> CreatePacker()
-        {
-            return new TR3TexturePacker(_level);
-        }
-
-        protected override void ProcessRemovals(AbstractTexturePacker<TR3Entities, TR3Level> packer)
-        {
-            List<TR3Entities> removals = new List<TR3Entities>();
-            if (_clearUnusedSprites)
+            if (unusedItems[i] != TR3Entities.Disc_H && allEntities.Contains(unusedItems[i]))
             {
-                removals.Add(TR3Entities.Map_H);
+                unusedItems.RemoveAt(i);
             }
-
-            if (_entitiesToRemove != null)
-            {
-                removals.AddRange(_entitiesToRemove);
-            }
-            packer.RemoveModelSegments(removals, _textureRemap);
-
-            if (_clearUnusedSprites)
-            {
-                RemoveUnusedSprites(packer);
-            }
         }
 
-        private void RemoveUnusedSprites(AbstractTexturePacker<TR3Entities, TR3Level> packer)
+        packer.RemoveSpriteSegments(unusedItems);
+    }
+
+    protected override IEnumerable<TRObjectTexture> GetExistingObjectTextures()
+    {
+        return _level.ObjectTextures.ToList();
+    }
+
+    protected override IEnumerable<int> GetInvalidObjectTextureIndices()
+    {
+        return _level.GetInvalidObjectTextureIndices();
+    }
+
+    protected override void WriteObjectTextures(IEnumerable<TRObjectTexture> objectTextures)
+    {
+        _level.ObjectTextures = objectTextures.ToArray();
+        _level.NumObjectTextures = (uint)_level.ObjectTextures.Length;
+    }
+
+    protected override void RemapMeshTextures(Dictionary<TR3ModelDefinition, Dictionary<int, int>> indexMap)
+    {
+        foreach (TR3ModelDefinition definition in indexMap.Keys)
         {
-            List<TR3Entities> unusedItems = new List<TR3Entities>
+            foreach (TRMesh mesh in definition.Meshes)
             {
-                TR3Entities.PistolAmmo_M_H,
-                TR3Entities.Map_H,
-                TR3Entities.Disc_H
-            };
-
-            ISet<TR3Entities> allEntities = new HashSet<TR3Entities>();
-            for (int i = 0; i < _level.Entities.Length; i++)
-            {
-                allEntities.Add((TR3Entities)_level.Entities[i].TypeID);
-            }
-
-            for (int i = unusedItems.Count - 1; i >= 0; i--)
-            {
-                if (unusedItems[i] != TR3Entities.Disc_H && allEntities.Contains(unusedItems[i]))
+                foreach (TRFace4 rect in mesh.TexturedRectangles)
                 {
-                    unusedItems.RemoveAt(i);
+                    rect.Texture = ConvertTextureReference(rect.Texture, indexMap[definition]);
                 }
-            }
-
-            packer.RemoveSpriteSegments(unusedItems);
-        }
-
-        protected override IEnumerable<TRObjectTexture> GetExistingObjectTextures()
-        {
-            return _level.ObjectTextures.ToList();
-        }
-
-        protected override IEnumerable<int> GetInvalidObjectTextureIndices()
-        {
-            return _level.GetInvalidObjectTextureIndices();
-        }
-
-        protected override void WriteObjectTextures(IEnumerable<TRObjectTexture> objectTextures)
-        {
-            _level.ObjectTextures = objectTextures.ToArray();
-            _level.NumObjectTextures = (uint)_level.ObjectTextures.Length;
-        }
-
-        protected override void RemapMeshTextures(Dictionary<TR3ModelDefinition, Dictionary<int, int>> indexMap)
-        {
-            foreach (TR3ModelDefinition definition in indexMap.Keys)
-            {
-                foreach (TRMesh mesh in definition.Meshes)
+                foreach (TRFace3 tri in mesh.TexturedTriangles)
                 {
-                    foreach (TRFace4 rect in mesh.TexturedRectangles)
-                    {
-                        rect.Texture = ConvertTextureReference(rect.Texture, indexMap[definition]);
-                    }
-                    foreach (TRFace3 tri in mesh.TexturedTriangles)
-                    {
-                        tri.Texture = ConvertTextureReference(tri.Texture, indexMap[definition]);
-                    }
+                    tri.Texture = ConvertTextureReference(tri.Texture, indexMap[definition]);
                 }
             }
         }
+    }
 
-        public override void ResetUnusedTextures()
-        {
-            _level.ResetUnusedTextures();
-        }
+    public override void ResetUnusedTextures()
+    {
+        _level.ResetUnusedTextures();
+    }
 
-        protected override IEnumerable<TR3Entities> CollateWatchedTextures(IEnumerable<TR3Entities> watchedEntities, TR3ModelDefinition definition)
-        {
-            return new List<TR3Entities>();
-        }
+    protected override IEnumerable<TR3Entities> CollateWatchedTextures(IEnumerable<TR3Entities> watchedEntities, TR3ModelDefinition definition)
+    {
+        return new List<TR3Entities>();
     }
 }

--- a/TRModelTransporter/Helpers/TRModelExtensions.cs
+++ b/TRModelTransporter/Helpers/TRModelExtensions.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using TRLevelControl.Model;
+﻿using TRLevelControl.Model;
 
 namespace TRModelTransporter.Helpers;
 

--- a/TRModelTransporter/Helpers/TRModelExtensions.cs
+++ b/TRModelTransporter/Helpers/TRModelExtensions.cs
@@ -4,7 +4,7 @@ namespace TRModelTransporter.Helpers;
 
 public static class TRModelExtensions
 {
-    private static readonly FixedFloat16 _nullCoord = new FixedFloat16 { Fraction = 0, Whole = 0 };
+    private static readonly FixedFloat16 _nullCoord = new() { Fraction = 0, Whole = 0 };
 
     public static void ResetUnusedTextures(this TR1Level level)
     {
@@ -109,7 +109,7 @@ public static class TRModelExtensions
 
     private static List<int> GetInvalidObjectTextureIndices(TRObjectTexture[] objectTextures)
     {
-        List<int> reusableIndices = new List<int>();
+        List<int> reusableIndices = new();
         for (int i = 0; i < objectTextures.Length; i++)
         {
             if (!objectTextures[i].IsValid())

--- a/TRModelTransporter/Helpers/TRModelExtensions.cs
+++ b/TRModelTransporter/Helpers/TRModelExtensions.cs
@@ -2,256 +2,255 @@
 using System.Linq;
 using TRLevelControl.Model;
 
-namespace TRModelTransporter.Helpers
+namespace TRModelTransporter.Helpers;
+
+public static class TRModelExtensions
 {
-    public static class TRModelExtensions
+    private static readonly FixedFloat16 _nullCoord = new FixedFloat16 { Fraction = 0, Whole = 0 };
+
+    public static void ResetUnusedTextures(this TR1Level level)
     {
-        private static readonly FixedFloat16 _nullCoord = new FixedFloat16 { Fraction = 0, Whole = 0 };
+        ResetUnusedObjectTextures(level.ObjectTextures);
+        ResetUnusedSpriteTextures(level.SpriteTextures);
+    }
 
-        public static void ResetUnusedTextures(this TR1Level level)
-        {
-            ResetUnusedObjectTextures(level.ObjectTextures);
-            ResetUnusedSpriteTextures(level.SpriteTextures);
-        }
+    public static void ResetUnusedTextures(this TR2Level level)
+    {
+        ResetUnusedObjectTextures(level.ObjectTextures);
+        ResetUnusedSpriteTextures(level.SpriteTextures);
+    }
 
-        public static void ResetUnusedTextures(this TR2Level level)
-        {
-            ResetUnusedObjectTextures(level.ObjectTextures);
-            ResetUnusedSpriteTextures(level.SpriteTextures);
-        }
+    public static void ResetUnusedTextures(this TR3Level level)
+    {
+        ResetUnusedObjectTextures(level.ObjectTextures);
+        ResetUnusedSpriteTextures(level.SpriteTextures);
+    }
 
-        public static void ResetUnusedTextures(this TR3Level level)
+    private static void ResetUnusedObjectTextures(IEnumerable<TRObjectTexture> objectTextures)
+    {
+        foreach (TRObjectTexture texture in objectTextures)
         {
-            ResetUnusedObjectTextures(level.ObjectTextures);
-            ResetUnusedSpriteTextures(level.SpriteTextures);
-        }
-
-        private static void ResetUnusedObjectTextures(IEnumerable<TRObjectTexture> objectTextures)
-        {
-            foreach (TRObjectTexture texture in objectTextures)
+            if (texture.AtlasAndFlag == ushort.MaxValue)
             {
-                if (texture.AtlasAndFlag == ushort.MaxValue)
-                {
-                    texture.Invalidate();
-                }
+                texture.Invalidate();
             }
         }
+    }
 
-        private static void ResetUnusedSpriteTextures(IEnumerable<TRSpriteTexture> spriteTextures)
+    private static void ResetUnusedSpriteTextures(IEnumerable<TRSpriteTexture> spriteTextures)
+    {
+        foreach (TRSpriteTexture texture in spriteTextures)
         {
-            foreach (TRSpriteTexture texture in spriteTextures)
+            if (texture.Atlas == ushort.MaxValue)
             {
-                if (texture.Atlas == ushort.MaxValue)
-                {
-                    texture.Invalidate();
-                }
+                texture.Invalidate();
             }
         }
+    }
 
-        // See TextureTransportHandler.ResetUnusedTextures
-        public static bool IsValid(this TRObjectTexture texture)
+    // See TextureTransportHandler.ResetUnusedTextures
+    public static bool IsValid(this TRObjectTexture texture)
+    {
+        if (texture.AtlasAndFlag == 0)
         {
-            if (texture.AtlasAndFlag == 0)
-            {
-                int coords = 0;
-                foreach (TRObjectTextureVert vert in texture.Vertices)
-                {
-                    coords += vert.XCoordinate.Whole + vert.XCoordinate.Fraction + vert.YCoordinate.Whole + vert.XCoordinate.Fraction;
-                }
-                return coords > 0;
-            }
-
-            return texture.AtlasAndFlag != ushort.MaxValue;
-        }
-
-        public static void Invalidate(this TRObjectTexture texture)
-        {
-            texture.AtlasAndFlag = 0;
+            int coords = 0;
             foreach (TRObjectTextureVert vert in texture.Vertices)
             {
-                vert.XCoordinate = vert.YCoordinate = _nullCoord;
+                coords += vert.XCoordinate.Whole + vert.XCoordinate.Fraction + vert.YCoordinate.Whole + vert.XCoordinate.Fraction;
             }
+            return coords > 0;
         }
 
-        // See TextureTransportHandler.ResetUnusedTextures
-        public static bool IsValid(this TRSpriteTexture texture)
+        return texture.AtlasAndFlag != ushort.MaxValue;
+    }
+
+    public static void Invalidate(this TRObjectTexture texture)
+    {
+        texture.AtlasAndFlag = 0;
+        foreach (TRObjectTextureVert vert in texture.Vertices)
         {
-            if (texture.Atlas == 0)
-            {
-                if (texture.X == 0 && texture.Y == 0 && texture.Width == 1 && texture.Height == 1)
-                {
-                    return false;
-                }
-            }
-
-            return texture.Atlas != ushort.MaxValue;
+            vert.XCoordinate = vert.YCoordinate = _nullCoord;
         }
+    }
 
-        public static void Invalidate(this TRSpriteTexture texture)
+    // See TextureTransportHandler.ResetUnusedTextures
+    public static bool IsValid(this TRSpriteTexture texture)
+    {
+        if (texture.Atlas == 0)
         {
-            texture.Atlas = 0;
-            texture.X = texture.Y = 0;
-            texture.Width = texture.Height = 1;
+            if (texture.X == 0 && texture.Y == 0 && texture.Width == 1 && texture.Height == 1)
+            {
+                return false;
+            }
         }
 
-        public static List<int> GetInvalidObjectTextureIndices(this TR1Level level)
+        return texture.Atlas != ushort.MaxValue;
+    }
+
+    public static void Invalidate(this TRSpriteTexture texture)
+    {
+        texture.Atlas = 0;
+        texture.X = texture.Y = 0;
+        texture.Width = texture.Height = 1;
+    }
+
+    public static List<int> GetInvalidObjectTextureIndices(this TR1Level level)
+    {
+        return GetInvalidObjectTextureIndices(level.ObjectTextures);
+    }
+
+    public static List<int> GetInvalidObjectTextureIndices(this TR2Level level)
+    {
+        return GetInvalidObjectTextureIndices(level.ObjectTextures);
+    }
+
+    public static List<int> GetInvalidObjectTextureIndices(this TR3Level level)
+    {
+        return GetInvalidObjectTextureIndices(level.ObjectTextures);
+    }
+
+    private static List<int> GetInvalidObjectTextureIndices(TRObjectTexture[] objectTextures)
+    {
+        List<int> reusableIndices = new List<int>();
+        for (int i = 0; i < objectTextures.Length; i++)
         {
-            return GetInvalidObjectTextureIndices(level.ObjectTextures);
+            if (!objectTextures[i].IsValid())
+            {
+                reusableIndices.Add(i);
+            }
         }
+        return reusableIndices;
+    }
 
-        public static List<int> GetInvalidObjectTextureIndices(this TR2Level level)
+    // Given a precompiled dictionary of old texture index to new, this will ensure that
+    // all Meshes, RoomData and AnimatedTextures point to the new correct index.
+    public static void ReindexTextures(this TR2Level level, Dictionary<int, int> indexMap, bool defaultToOriginal = true)
+    {
+        if (indexMap.Count == 0)
         {
-            return GetInvalidObjectTextureIndices(level.ObjectTextures);
+            return;
         }
 
-        public static List<int> GetInvalidObjectTextureIndices(this TR3Level level)
+        foreach (TRMesh mesh in level.Meshes)
         {
-            return GetInvalidObjectTextureIndices(level.ObjectTextures);
+            foreach (TRFace4 rect in mesh.TexturedRectangles)
+            {
+                rect.Texture = ConvertTextureReference(rect.Texture, indexMap, defaultToOriginal);
+            }
+            foreach (TRFace3 tri in mesh.TexturedTriangles)
+            {
+                tri.Texture = ConvertTextureReference(tri.Texture, indexMap, defaultToOriginal);
+            }
         }
 
-        private static List<int> GetInvalidObjectTextureIndices(TRObjectTexture[] objectTextures)
+        foreach (TR2Room room in level.Rooms)
         {
-            List<int> reusableIndices = new List<int>();
-            for (int i = 0; i < objectTextures.Length; i++)
+            foreach (TRFace4 rect in room.RoomData.Rectangles)
             {
-                if (!objectTextures[i].IsValid())
-                {
-                    reusableIndices.Add(i);
-                }
+                rect.Texture = ConvertTextureReference(rect.Texture, indexMap, defaultToOriginal);
             }
-            return reusableIndices;
+            foreach (TRFace3 tri in room.RoomData.Triangles)
+            {
+                tri.Texture = ConvertTextureReference(tri.Texture, indexMap, defaultToOriginal);
+            }
         }
 
-        // Given a precompiled dictionary of old texture index to new, this will ensure that
-        // all Meshes, RoomData and AnimatedTextures point to the new correct index.
-        public static void ReindexTextures(this TR2Level level, Dictionary<int, int> indexMap, bool defaultToOriginal = true)
+        // #137 Ensure animated textures are reindexed too (these are just groups of texture indices)
+        // They have to remain unique it seems, otherwise the animation speed is too fast, so while we
+        // have removed the duplicated textures, we can re-add duplicate texture objects while there is 
+        // enough space in that array.
+        List<TRObjectTexture> textures = level.ObjectTextures.ToList();
+        foreach (TRAnimatedTexture anim in level.AnimatedTextures)
         {
-            if (indexMap.Count == 0)
+            for (int i = 0; i < anim.Textures.Length; i++)
             {
-                return;
+                anim.Textures[i] = ConvertTextureReference(anim.Textures[i], indexMap, defaultToOriginal);
             }
 
-            foreach (TRMesh mesh in level.Meshes)
+            ushort previousIndex = anim.Textures[0];
+            for (int i = 1; i < anim.Textures.Length; i++)
             {
-                foreach (TRFace4 rect in mesh.TexturedRectangles)
+                if (anim.Textures[i] == previousIndex && textures.Count < 2048)
                 {
-                    rect.Texture = ConvertTextureReference(rect.Texture, indexMap, defaultToOriginal);
+                    textures.Add(textures[anim.Textures[i]]);
+                    anim.Textures[i] = (ushort)(textures.Count - 1);
                 }
-                foreach (TRFace3 tri in mesh.TexturedTriangles)
-                {
-                    tri.Texture = ConvertTextureReference(tri.Texture, indexMap, defaultToOriginal);
-                }
-            }
-
-            foreach (TR2Room room in level.Rooms)
-            {
-                foreach (TRFace4 rect in room.RoomData.Rectangles)
-                {
-                    rect.Texture = ConvertTextureReference(rect.Texture, indexMap, defaultToOriginal);
-                }
-                foreach (TRFace3 tri in room.RoomData.Triangles)
-                {
-                    tri.Texture = ConvertTextureReference(tri.Texture, indexMap, defaultToOriginal);
-                }
-            }
-
-            // #137 Ensure animated textures are reindexed too (these are just groups of texture indices)
-            // They have to remain unique it seems, otherwise the animation speed is too fast, so while we
-            // have removed the duplicated textures, we can re-add duplicate texture objects while there is 
-            // enough space in that array.
-            List<TRObjectTexture> textures = level.ObjectTextures.ToList();
-            foreach (TRAnimatedTexture anim in level.AnimatedTextures)
-            {
-                for (int i = 0; i < anim.Textures.Length; i++)
-                {
-                    anim.Textures[i] = ConvertTextureReference(anim.Textures[i], indexMap, defaultToOriginal);
-                }
-
-                ushort previousIndex = anim.Textures[0];
-                for (int i = 1; i < anim.Textures.Length; i++)
-                {
-                    if (anim.Textures[i] == previousIndex && textures.Count < 2048)
-                    {
-                        textures.Add(textures[anim.Textures[i]]);
-                        anim.Textures[i] = (ushort)(textures.Count - 1);
-                    }
-                    previousIndex = anim.Textures[i];
-                }
-            }
-
-            if (textures.Count > level.NumObjectTextures)
-            {
-                level.ObjectTextures = textures.ToArray();
-                level.NumObjectTextures = (uint)textures.Count;
+                previousIndex = anim.Textures[i];
             }
         }
 
-        public static void ReindexTextures(this TR3Level level, Dictionary<int, int> indexMap, bool defaultToOriginal = true)
+        if (textures.Count > level.NumObjectTextures)
         {
-            if (indexMap.Count == 0)
-            {
-                return;
-            }
-
-            foreach (TRMesh mesh in level.Meshes)
-            {
-                foreach (TRFace4 rect in mesh.TexturedRectangles)
-                {
-                    rect.Texture = ConvertTextureReference(rect.Texture, indexMap, defaultToOriginal);
-                }
-                foreach (TRFace3 tri in mesh.TexturedTriangles)
-                {
-                    tri.Texture = ConvertTextureReference(tri.Texture, indexMap, defaultToOriginal);
-                }
-            }
-
-            foreach (TR3Room room in level.Rooms)
-            {
-                foreach (TRFace4 rect in room.RoomData.Rectangles)
-                {
-                    rect.Texture = ConvertTextureReference(rect.Texture, indexMap, defaultToOriginal);
-                }
-                foreach (TRFace3 tri in room.RoomData.Triangles)
-                {
-                    tri.Texture = ConvertTextureReference(tri.Texture, indexMap, defaultToOriginal);
-                }
-            }
-
-            List<TRObjectTexture> textures = level.ObjectTextures.ToList();
-            foreach (TRAnimatedTexture anim in level.AnimatedTextures)
-            {
-                for (int i = 0; i < anim.Textures.Length; i++)
-                {
-                    anim.Textures[i] = ConvertTextureReference(anim.Textures[i], indexMap, defaultToOriginal);
-                }
-
-                ushort previousIndex = anim.Textures[0];
-                for (int i = 1; i < anim.Textures.Length; i++)
-                {
-                    if (anim.Textures[i] == previousIndex && textures.Count < 2048)
-                    {
-                        textures.Add(textures[anim.Textures[i]]);
-                        anim.Textures[i] = (ushort)(textures.Count - 1);
-                    }
-                    previousIndex = anim.Textures[i];
-                }
-            }
-
-            if (textures.Count > level.NumObjectTextures)
-            {
-                level.ObjectTextures = textures.ToArray();
-                level.NumObjectTextures = (uint)textures.Count;
-            }
+            level.ObjectTextures = textures.ToArray();
+            level.NumObjectTextures = (uint)textures.Count;
         }
+    }
 
-        private static ushort ConvertTextureReference(ushort textureReference, Dictionary<int, int> indexMap, bool defaultToOriginal)
+    public static void ReindexTextures(this TR3Level level, Dictionary<int, int> indexMap, bool defaultToOriginal = true)
+    {
+        if (indexMap.Count == 0)
         {
-            if (indexMap.ContainsKey(textureReference))
+            return;
+        }
+
+        foreach (TRMesh mesh in level.Meshes)
+        {
+            foreach (TRFace4 rect in mesh.TexturedRectangles)
             {
-                return (ushort)indexMap[textureReference];
+                rect.Texture = ConvertTextureReference(rect.Texture, indexMap, defaultToOriginal);
+            }
+            foreach (TRFace3 tri in mesh.TexturedTriangles)
+            {
+                tri.Texture = ConvertTextureReference(tri.Texture, indexMap, defaultToOriginal);
+            }
+        }
+
+        foreach (TR3Room room in level.Rooms)
+        {
+            foreach (TRFace4 rect in room.RoomData.Rectangles)
+            {
+                rect.Texture = ConvertTextureReference(rect.Texture, indexMap, defaultToOriginal);
+            }
+            foreach (TRFace3 tri in room.RoomData.Triangles)
+            {
+                tri.Texture = ConvertTextureReference(tri.Texture, indexMap, defaultToOriginal);
+            }
+        }
+
+        List<TRObjectTexture> textures = level.ObjectTextures.ToList();
+        foreach (TRAnimatedTexture anim in level.AnimatedTextures)
+        {
+            for (int i = 0; i < anim.Textures.Length; i++)
+            {
+                anim.Textures[i] = ConvertTextureReference(anim.Textures[i], indexMap, defaultToOriginal);
             }
 
-            return defaultToOriginal ? textureReference : (ushort)0;
+            ushort previousIndex = anim.Textures[0];
+            for (int i = 1; i < anim.Textures.Length; i++)
+            {
+                if (anim.Textures[i] == previousIndex && textures.Count < 2048)
+                {
+                    textures.Add(textures[anim.Textures[i]]);
+                    anim.Textures[i] = (ushort)(textures.Count - 1);
+                }
+                previousIndex = anim.Textures[i];
+            }
         }
+
+        if (textures.Count > level.NumObjectTextures)
+        {
+            level.ObjectTextures = textures.ToArray();
+            level.NumObjectTextures = (uint)textures.Count;
+        }
+    }
+
+    private static ushort ConvertTextureReference(ushort textureReference, Dictionary<int, int> indexMap, bool defaultToOriginal)
+    {
+        if (indexMap.ContainsKey(textureReference))
+        {
+            return (ushort)indexMap[textureReference];
+        }
+
+        return defaultToOriginal ? textureReference : (ushort)0;
     }
 }

--- a/TRModelTransporter/Helpers/TRTextureReverseAreaComparer.cs
+++ b/TRModelTransporter/Helpers/TRTextureReverseAreaComparer.cs
@@ -1,13 +1,12 @@
 ﻿using System.Collections.Generic;
 using TRModelTransporter.Model.Textures;
 
-namespace TRModelTransporter.Helpers
+namespace TRModelTransporter.Helpers;
+
+public class TRTextureReverseAreaComparer : IComparer<AbstractIndexedTRTexture>
 {
-    public class TRTextureReverseAreaComparer : IComparer<AbstractIndexedTRTexture>
+    public int Compare(AbstractIndexedTRTexture t1, AbstractIndexedTRTexture t2)
     {
-        public int Compare(AbstractIndexedTRTexture t1, AbstractIndexedTRTexture t2)
-        {
-            return t2.Area.CompareTo(t1.Area);
-        }
+        return t2.Area.CompareTo(t1.Area);
     }
 }

--- a/TRModelTransporter/Helpers/TRTextureReverseAreaComparer.cs
+++ b/TRModelTransporter/Helpers/TRTextureReverseAreaComparer.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using TRModelTransporter.Model.Textures;
+﻿using TRModelTransporter.Model.Textures;
 
 namespace TRModelTransporter.Helpers;
 

--- a/TRModelTransporter/Model/AbstractTRModelDefinition.cs
+++ b/TRModelTransporter/Model/AbstractTRModelDefinition.cs
@@ -1,6 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
 using System.Drawing;
 using TRLevelControl.Model;
 using TRModelTransporter.Model.Textures;

--- a/TRModelTransporter/Model/AbstractTRModelDefinition.cs
+++ b/TRModelTransporter/Model/AbstractTRModelDefinition.cs
@@ -26,9 +26,6 @@ public abstract class AbstractTRModelDefinition<E> : IDisposable where E : Enum
 
     public void Dispose()
     {
-        if (Bitmap != null)
-        {
-            Bitmap.Dispose();
-        }
+        Bitmap?.Dispose();
     }
 }

--- a/TRModelTransporter/Model/AbstractTRModelDefinition.cs
+++ b/TRModelTransporter/Model/AbstractTRModelDefinition.cs
@@ -27,5 +27,6 @@ public abstract class AbstractTRModelDefinition<E> : IDisposable where E : Enum
     public void Dispose()
     {
         Bitmap?.Dispose();
+        GC.SuppressFinalize(this);
     }
 }

--- a/TRModelTransporter/Model/AbstractTRModelDefinition.cs
+++ b/TRModelTransporter/Model/AbstractTRModelDefinition.cs
@@ -5,33 +5,32 @@ using System.Drawing;
 using TRLevelControl.Model;
 using TRModelTransporter.Model.Textures;
 
-namespace TRModelTransporter.Model
+namespace TRModelTransporter.Model;
+
+public abstract class AbstractTRModelDefinition<E> : IDisposable where E : Enum
 {
-    public abstract class AbstractTRModelDefinition<E> : IDisposable where E : Enum
+    [JsonIgnore]
+    public abstract E Entity { get; }
+    [JsonIgnore]
+    public E Alias { get; set; }
+    [JsonIgnore]
+    public Bitmap Bitmap { get; set; }
+    [JsonIgnore]
+    public bool HasGraphics => ObjectTextures.Count > 0;
+    [JsonIgnore]
+    public bool IsDependencyOnly { get; set; }
+
+    public E[] Dependencies { get; set; }        
+    public Dictionary<int, List<IndexedTRObjectTexture>> ObjectTextures { get; set; }
+    public Dictionary<E, Dictionary<int, List<IndexedTRSpriteTexture>>> SpriteTextures { get; set; }
+    public Dictionary<E, TRSpriteSequence> SpriteSequences { get; set; }
+    public Rectangle[] TextureSegments { get; set; }
+
+    public void Dispose()
     {
-        [JsonIgnore]
-        public abstract E Entity { get; }
-        [JsonIgnore]
-        public E Alias { get; set; }
-        [JsonIgnore]
-        public Bitmap Bitmap { get; set; }
-        [JsonIgnore]
-        public bool HasGraphics => ObjectTextures.Count > 0;
-        [JsonIgnore]
-        public bool IsDependencyOnly { get; set; }
-
-        public E[] Dependencies { get; set; }        
-        public Dictionary<int, List<IndexedTRObjectTexture>> ObjectTextures { get; set; }
-        public Dictionary<E, Dictionary<int, List<IndexedTRSpriteTexture>>> SpriteTextures { get; set; }
-        public Dictionary<E, TRSpriteSequence> SpriteSequences { get; set; }
-        public Rectangle[] TextureSegments { get; set; }
-
-        public void Dispose()
+        if (Bitmap != null)
         {
-            if (Bitmap != null)
-            {
-                Bitmap.Dispose();
-            }
+            Bitmap.Dispose();
         }
     }
 }

--- a/TRModelTransporter/Model/Animations/TR1PackedAnimation.cs
+++ b/TRModelTransporter/Model/Animations/TR1PackedAnimation.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using TRLevelControl.Model;
+﻿using TRLevelControl.Model;
 using TRModelTransporter.Model.Sound;
 
 namespace TRModelTransporter.Model.Animations;

--- a/TRModelTransporter/Model/Animations/TR1PackedAnimation.cs
+++ b/TRModelTransporter/Model/Animations/TR1PackedAnimation.cs
@@ -2,23 +2,22 @@
 using TRLevelControl.Model;
 using TRModelTransporter.Model.Sound;
 
-namespace TRModelTransporter.Model.Animations
+namespace TRModelTransporter.Model.Animations;
+
+public class TR1PackedAnimation
 {
-    public class TR1PackedAnimation
+    public TRAnimation Animation { get; set; }
+    public Dictionary<int, TRAnimDispatch> AnimationDispatches { get; set; }
+    public Dictionary<int, TR1PackedAnimationCommand> Commands { get; set; }
+    public TR1PackedSound Sound { get; set; }
+
+    public List<TRStateChange> StateChanges { get; set; }
+
+    public TR1PackedAnimation()
     {
-        public TRAnimation Animation { get; set; }
-        public Dictionary<int, TRAnimDispatch> AnimationDispatches { get; set; }
-        public Dictionary<int, TR1PackedAnimationCommand> Commands { get; set; }
-        public TR1PackedSound Sound { get; set; }
-
-        public List<TRStateChange> StateChanges { get; set; }
-
-        public TR1PackedAnimation()
-        {
-            AnimationDispatches = new Dictionary<int, TRAnimDispatch>();
-            Commands = new Dictionary<int, TR1PackedAnimationCommand>();
-            Sound = new TR1PackedSound();
-            StateChanges = new List<TRStateChange>();
-        }
+        AnimationDispatches = new Dictionary<int, TRAnimDispatch>();
+        Commands = new Dictionary<int, TR1PackedAnimationCommand>();
+        Sound = new TR1PackedSound();
+        StateChanges = new List<TRStateChange>();
     }
 }

--- a/TRModelTransporter/Model/Animations/TR1PackedAnimationCommand.cs
+++ b/TRModelTransporter/Model/Animations/TR1PackedAnimationCommand.cs
@@ -1,10 +1,9 @@
 ﻿using TRLevelControl.Model.Enums;
 
-namespace TRModelTransporter.Model.Animations
+namespace TRModelTransporter.Model.Animations;
+
+public class TR1PackedAnimationCommand
 {
-    public class TR1PackedAnimationCommand
-    {
-        public TRAnimCommandTypes Command { get; set; }
-        public short[] Params { get; set; }
-    }
+    public TRAnimCommandTypes Command { get; set; }
+    public short[] Params { get; set; }
 }

--- a/TRModelTransporter/Model/Animations/TR2PackedAnimation.cs
+++ b/TRModelTransporter/Model/Animations/TR2PackedAnimation.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using TRLevelControl.Model;
+﻿using TRLevelControl.Model;
 using TRModelTransporter.Model.Sound;
 
 namespace TRModelTransporter.Model.Animations;

--- a/TRModelTransporter/Model/Animations/TR2PackedAnimation.cs
+++ b/TRModelTransporter/Model/Animations/TR2PackedAnimation.cs
@@ -2,23 +2,22 @@
 using TRLevelControl.Model;
 using TRModelTransporter.Model.Sound;
 
-namespace TRModelTransporter.Model.Animations
+namespace TRModelTransporter.Model.Animations;
+
+public class TR2PackedAnimation
 {
-    public class TR2PackedAnimation
+    public TRAnimation Animation { get; set; }
+    public Dictionary<int, TRAnimDispatch> AnimationDispatches { get; set; }
+    public Dictionary<int, TR1PackedAnimationCommand> Commands { get; set; }
+    public TR2PackedSound Sound { get; set; }
+
+    public List<TRStateChange> StateChanges { get; set; }
+
+    public TR2PackedAnimation()
     {
-        public TRAnimation Animation { get; set; }
-        public Dictionary<int, TRAnimDispatch> AnimationDispatches { get; set; }
-        public Dictionary<int, TR1PackedAnimationCommand> Commands { get; set; }
-        public TR2PackedSound Sound { get; set; }
-
-        public List<TRStateChange> StateChanges { get; set; }
-
-        public TR2PackedAnimation()
-        {
-            AnimationDispatches = new Dictionary<int, TRAnimDispatch>();
-            Commands = new Dictionary<int, TR1PackedAnimationCommand>();
-            Sound = new TR2PackedSound();
-            StateChanges = new List<TRStateChange>();
-        }
+        AnimationDispatches = new Dictionary<int, TRAnimDispatch>();
+        Commands = new Dictionary<int, TR1PackedAnimationCommand>();
+        Sound = new TR2PackedSound();
+        StateChanges = new List<TRStateChange>();
     }
 }

--- a/TRModelTransporter/Model/Animations/TR3PackedAnimation.cs
+++ b/TRModelTransporter/Model/Animations/TR3PackedAnimation.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using TRLevelControl.Model;
+﻿using TRLevelControl.Model;
 using TRModelTransporter.Model.Sound;
 
 namespace TRModelTransporter.Model.Animations;

--- a/TRModelTransporter/Model/Animations/TR3PackedAnimation.cs
+++ b/TRModelTransporter/Model/Animations/TR3PackedAnimation.cs
@@ -2,23 +2,22 @@
 using TRLevelControl.Model;
 using TRModelTransporter.Model.Sound;
 
-namespace TRModelTransporter.Model.Animations
+namespace TRModelTransporter.Model.Animations;
+
+public class TR3PackedAnimation
 {
-    public class TR3PackedAnimation
+    public TRAnimation Animation { get; set; }
+    public Dictionary<int, TRAnimDispatch> AnimationDispatches { get; set; }
+    public Dictionary<int, TR1PackedAnimationCommand> Commands { get; set; }
+    public TR3PackedSound Sound { get; set; }
+
+    public List<TRStateChange> StateChanges { get; set; }
+
+    public TR3PackedAnimation()
     {
-        public TRAnimation Animation { get; set; }
-        public Dictionary<int, TRAnimDispatch> AnimationDispatches { get; set; }
-        public Dictionary<int, TR1PackedAnimationCommand> Commands { get; set; }
-        public TR3PackedSound Sound { get; set; }
-
-        public List<TRStateChange> StateChanges { get; set; }
-
-        public TR3PackedAnimation()
-        {
-            AnimationDispatches = new Dictionary<int, TRAnimDispatch>();
-            Commands = new Dictionary<int, TR1PackedAnimationCommand>();
-            Sound = new TR3PackedSound();
-            StateChanges = new List<TRStateChange>();
-        }
+        AnimationDispatches = new Dictionary<int, TRAnimDispatch>();
+        Commands = new Dictionary<int, TR1PackedAnimationCommand>();
+        Sound = new TR3PackedSound();
+        StateChanges = new List<TRStateChange>();
     }
 }

--- a/TRModelTransporter/Model/Definitions/TR1ModelDefinition.cs
+++ b/TRModelTransporter/Model/Definitions/TR1ModelDefinition.cs
@@ -4,28 +4,27 @@ using TRLevelControl.Model.Enums;
 using TRModelTransporter.Model.Animations;
 using TRModelTransporter.Model.Sound;
 
-namespace TRModelTransporter.Model.Definitions
+namespace TRModelTransporter.Model.Definitions;
+
+public class TR1ModelDefinition : AbstractTRModelDefinition<TREntities>
 {
-    public class TR1ModelDefinition : AbstractTRModelDefinition<TREntities>
+    public override TREntities Entity => (TREntities)Model.ID;
+    public Dictionary<int, TR1PackedAnimation> Animations { get; set; }
+    public ushort[] AnimationFrames { get; set; }
+    public TRCinematicFrame[] CinematicFrames { get; set; }
+    public Dictionary<int, TRColour> Colours { get; set; }
+    public TR1PackedSound HardcodedSound { get; set; }
+    public TRMesh[] Meshes { get; set; }
+    public TRMeshTreeNode[] MeshTrees { get; set; }
+    public TRModel Model { get; set; }
+
+    public override bool Equals(object obj)
     {
-        public override TREntities Entity => (TREntities)Model.ID;
-        public Dictionary<int, TR1PackedAnimation> Animations { get; set; }
-        public ushort[] AnimationFrames { get; set; }
-        public TRCinematicFrame[] CinematicFrames { get; set; }
-        public Dictionary<int, TRColour> Colours { get; set; }
-        public TR1PackedSound HardcodedSound { get; set; }
-        public TRMesh[] Meshes { get; set; }
-        public TRMeshTreeNode[] MeshTrees { get; set; }
-        public TRModel Model { get; set; }
+        return obj is TR1ModelDefinition definition && Entity == definition.Entity;
+    }
 
-        public override bool Equals(object obj)
-        {
-            return obj is TR1ModelDefinition definition && Entity == definition.Entity;
-        }
-
-        public override int GetHashCode()
-        {
-            return 1674515507 + Entity.GetHashCode();
-        }
+    public override int GetHashCode()
+    {
+        return 1674515507 + Entity.GetHashCode();
     }
 }

--- a/TRModelTransporter/Model/Definitions/TR1ModelDefinition.cs
+++ b/TRModelTransporter/Model/Definitions/TR1ModelDefinition.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using TRLevelControl.Model;
+﻿using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;
 using TRModelTransporter.Model.Animations;
 using TRModelTransporter.Model.Sound;

--- a/TRModelTransporter/Model/Definitions/TR2ModelDefinition.cs
+++ b/TRModelTransporter/Model/Definitions/TR2ModelDefinition.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using TRLevelControl.Model;
+﻿using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;
 using TRModelTransporter.Model.Animations;
 using TRModelTransporter.Model.Sound;

--- a/TRModelTransporter/Model/Definitions/TR2ModelDefinition.cs
+++ b/TRModelTransporter/Model/Definitions/TR2ModelDefinition.cs
@@ -4,28 +4,27 @@ using TRLevelControl.Model.Enums;
 using TRModelTransporter.Model.Animations;
 using TRModelTransporter.Model.Sound;
 
-namespace TRModelTransporter.Model.Definitions
+namespace TRModelTransporter.Model.Definitions;
+
+public class TR2ModelDefinition : AbstractTRModelDefinition<TR2Entities>
 {
-    public class TR2ModelDefinition : AbstractTRModelDefinition<TR2Entities>
+    public override TR2Entities Entity => (TR2Entities)Model.ID;
+    public Dictionary<int, TR2PackedAnimation> Animations { get; set; }
+    public ushort[] AnimationFrames { get; set; }
+    public TRCinematicFrame[] CinematicFrames { get; set; }
+    public Dictionary<int, TRColour4> Colours { get; set; }
+    public TR2PackedSound HardcodedSound { get; set; }
+    public TRMesh[] Meshes { get; set; }
+    public TRMeshTreeNode[] MeshTrees { get; set; }
+    public TRModel Model { get; set; }
+
+    public override bool Equals(object obj)
     {
-        public override TR2Entities Entity => (TR2Entities)Model.ID;
-        public Dictionary<int, TR2PackedAnimation> Animations { get; set; }
-        public ushort[] AnimationFrames { get; set; }
-        public TRCinematicFrame[] CinematicFrames { get; set; }
-        public Dictionary<int, TRColour4> Colours { get; set; }
-        public TR2PackedSound HardcodedSound { get; set; }
-        public TRMesh[] Meshes { get; set; }
-        public TRMeshTreeNode[] MeshTrees { get; set; }
-        public TRModel Model { get; set; }
+        return obj is TR2ModelDefinition definition && Entity == definition.Entity;
+    }
 
-        public override bool Equals(object obj)
-        {
-            return obj is TR2ModelDefinition definition && Entity == definition.Entity;
-        }
-
-        public override int GetHashCode()
-        {
-            return 1875520522 + Entity.GetHashCode();
-        }
+    public override int GetHashCode()
+    {
+        return 1875520522 + Entity.GetHashCode();
     }
 }

--- a/TRModelTransporter/Model/Definitions/TR3ModelDefinition.cs
+++ b/TRModelTransporter/Model/Definitions/TR3ModelDefinition.cs
@@ -4,28 +4,27 @@ using TRLevelControl.Model.Enums;
 using TRModelTransporter.Model.Animations;
 using TRModelTransporter.Model.Sound;
 
-namespace TRModelTransporter.Model.Definitions
+namespace TRModelTransporter.Model.Definitions;
+
+public class TR3ModelDefinition : AbstractTRModelDefinition<TR3Entities>
 {
-    public class TR3ModelDefinition : AbstractTRModelDefinition<TR3Entities>
+    public override TR3Entities Entity => (TR3Entities)Model.ID;
+    public Dictionary<int, TR3PackedAnimation> Animations { get; set; }
+    public ushort[] AnimationFrames { get; set; }
+    public TRCinematicFrame[] CinematicFrames { get; set; }
+    public Dictionary<int, TRColour4> Colours { get; set; }
+    public TR3PackedSound HardcodedSound { get; set; }
+    public TRMesh[] Meshes { get; set; }
+    public TRMeshTreeNode[] MeshTrees { get; set; }
+    public TRModel Model { get; set; }
+
+    public override bool Equals(object obj)
     {
-        public override TR3Entities Entity => (TR3Entities)Model.ID;
-        public Dictionary<int, TR3PackedAnimation> Animations { get; set; }
-        public ushort[] AnimationFrames { get; set; }
-        public TRCinematicFrame[] CinematicFrames { get; set; }
-        public Dictionary<int, TRColour4> Colours { get; set; }
-        public TR3PackedSound HardcodedSound { get; set; }
-        public TRMesh[] Meshes { get; set; }
-        public TRMeshTreeNode[] MeshTrees { get; set; }
-        public TRModel Model { get; set; }
+        return obj is TR3ModelDefinition definition && Entity == definition.Entity;
+    }
 
-        public override bool Equals(object obj)
-        {
-            return obj is TR3ModelDefinition definition && Entity == definition.Entity;
-        }
-
-        public override int GetHashCode()
-        {
-            return 1075520522 + Entity.GetHashCode();
-        }
+    public override int GetHashCode()
+    {
+        return 1075520522 + Entity.GetHashCode();
     }
 }

--- a/TRModelTransporter/Model/Definitions/TR3ModelDefinition.cs
+++ b/TRModelTransporter/Model/Definitions/TR3ModelDefinition.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using TRLevelControl.Model;
+﻿using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;
 using TRModelTransporter.Model.Animations;
 using TRModelTransporter.Model.Sound;

--- a/TRModelTransporter/Model/Sound/TR1PackedSound.cs
+++ b/TRModelTransporter/Model/Sound/TR1PackedSound.cs
@@ -1,21 +1,20 @@
 ﻿using System.Collections.Generic;
 using TRLevelControl.Model;
 
-namespace TRModelTransporter.Model.Sound
-{
-    public class TR1PackedSound
-    {
-        public Dictionary<ushort, uint[]> SampleIndices { get; set; }
-        public Dictionary<int, TRSoundDetails> SoundDetails { get; set; }
-        public Dictionary<int, short> SoundMapIndices { get; set; }
-        public Dictionary<uint, byte[]> Samples { get; set; }
+namespace TRModelTransporter.Model.Sound;
 
-        public TR1PackedSound()
-        {
-            SampleIndices = new Dictionary<ushort, uint[]>();
-            SoundDetails = new Dictionary<int, TRSoundDetails>();
-            SoundMapIndices = new Dictionary<int, short>();
-            Samples = new Dictionary<uint, byte[]>();
-        }
+public class TR1PackedSound
+{
+    public Dictionary<ushort, uint[]> SampleIndices { get; set; }
+    public Dictionary<int, TRSoundDetails> SoundDetails { get; set; }
+    public Dictionary<int, short> SoundMapIndices { get; set; }
+    public Dictionary<uint, byte[]> Samples { get; set; }
+
+    public TR1PackedSound()
+    {
+        SampleIndices = new Dictionary<ushort, uint[]>();
+        SoundDetails = new Dictionary<int, TRSoundDetails>();
+        SoundMapIndices = new Dictionary<int, short>();
+        Samples = new Dictionary<uint, byte[]>();
     }
 }

--- a/TRModelTransporter/Model/Sound/TR1PackedSound.cs
+++ b/TRModelTransporter/Model/Sound/TR1PackedSound.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using TRLevelControl.Model;
+﻿using TRLevelControl.Model;
 
 namespace TRModelTransporter.Model.Sound;
 

--- a/TRModelTransporter/Model/Sound/TR2PackedSound.cs
+++ b/TRModelTransporter/Model/Sound/TR2PackedSound.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using TRLevelControl.Model;
+﻿using TRLevelControl.Model;
 
 namespace TRModelTransporter.Model.Sound;
 

--- a/TRModelTransporter/Model/Sound/TR2PackedSound.cs
+++ b/TRModelTransporter/Model/Sound/TR2PackedSound.cs
@@ -1,19 +1,18 @@
 ﻿using System.Collections.Generic;
 using TRLevelControl.Model;
 
-namespace TRModelTransporter.Model.Sound
-{
-    public class TR2PackedSound
-    {
-        public Dictionary<ushort, uint[]> SampleIndices { get; set; }
-        public Dictionary<int, TRSoundDetails> SoundDetails { get; set; }
-        public Dictionary<int, short> SoundMapIndices { get; set; }
+namespace TRModelTransporter.Model.Sound;
 
-        public TR2PackedSound()
-        {
-            SampleIndices = new Dictionary<ushort, uint[]>();
-            SoundDetails = new Dictionary<int, TRSoundDetails>();
-            SoundMapIndices = new Dictionary<int, short>();
-        }
+public class TR2PackedSound
+{
+    public Dictionary<ushort, uint[]> SampleIndices { get; set; }
+    public Dictionary<int, TRSoundDetails> SoundDetails { get; set; }
+    public Dictionary<int, short> SoundMapIndices { get; set; }
+
+    public TR2PackedSound()
+    {
+        SampleIndices = new Dictionary<ushort, uint[]>();
+        SoundDetails = new Dictionary<int, TRSoundDetails>();
+        SoundMapIndices = new Dictionary<int, short>();
     }
 }

--- a/TRModelTransporter/Model/Sound/TR3PackedSound.cs
+++ b/TRModelTransporter/Model/Sound/TR3PackedSound.cs
@@ -1,19 +1,18 @@
 ﻿using System.Collections.Generic;
 using TRLevelControl.Model;
 
-namespace TRModelTransporter.Model.Sound
-{
-    public class TR3PackedSound
-    {
-        public Dictionary<ushort, uint[]> SampleIndices { get; set; }
-        public Dictionary<int, TR3SoundDetails> SoundDetails { get; set; }
-        public Dictionary<int, short> SoundMapIndices { get; set; }
+namespace TRModelTransporter.Model.Sound;
 
-        public TR3PackedSound()
-        {
-            SampleIndices = new Dictionary<ushort, uint[]>();
-            SoundDetails = new Dictionary<int, TR3SoundDetails>();
-            SoundMapIndices = new Dictionary<int, short>();
-        }
+public class TR3PackedSound
+{
+    public Dictionary<ushort, uint[]> SampleIndices { get; set; }
+    public Dictionary<int, TR3SoundDetails> SoundDetails { get; set; }
+    public Dictionary<int, short> SoundMapIndices { get; set; }
+
+    public TR3PackedSound()
+    {
+        SampleIndices = new Dictionary<ushort, uint[]>();
+        SoundDetails = new Dictionary<int, TR3SoundDetails>();
+        SoundMapIndices = new Dictionary<int, short>();
     }
 }

--- a/TRModelTransporter/Model/Sound/TR3PackedSound.cs
+++ b/TRModelTransporter/Model/Sound/TR3PackedSound.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using TRLevelControl.Model;
+﻿using TRLevelControl.Model;
 
 namespace TRModelTransporter.Model.Sound;
 

--- a/TRModelTransporter/Model/Textures/AbstractIndexedTRTexture.cs
+++ b/TRModelTransporter/Model/Textures/AbstractIndexedTRTexture.cs
@@ -1,66 +1,65 @@
 ﻿using Newtonsoft.Json;
 using System.Drawing;
 
-namespace TRModelTransporter.Model.Textures
+namespace TRModelTransporter.Model.Textures;
+
+public abstract class AbstractIndexedTRTexture
 {
-    public abstract class AbstractIndexedTRTexture
+    protected Rectangle _bounds;
+    private int _boundsXDiff, _boundsYDiff;
+
+    public int Index { get; set; }
+    public string Classification { get; set; } // a reference to the level the texture originated from
+    [JsonIgnore]
+    public abstract int Atlas { get; set; }
+    [JsonIgnore]
+    public int Area => _bounds.Width * _bounds.Height;
+    [JsonIgnore]
+    public Rectangle Bounds => _bounds;
+
+    public AbstractIndexedTRTexture()
     {
-        protected Rectangle _bounds;
-        private int _boundsXDiff, _boundsYDiff;
-
-        public int Index { get; set; }
-        public string Classification { get; set; } // a reference to the level the texture originated from
-        [JsonIgnore]
-        public abstract int Atlas { get; set; }
-        [JsonIgnore]
-        public int Area => _bounds.Width * _bounds.Height;
-        [JsonIgnore]
-        public Rectangle Bounds => _bounds;
-
-        public AbstractIndexedTRTexture()
-        {
-            _boundsXDiff = 0;
-            _boundsYDiff = 0;
-        }
-
-        public void MoveBy(int xDiff, int yDiff)
-        {
-            _bounds.X += xDiff;
-            _bounds.Y += yDiff;
-
-            _boundsXDiff = xDiff;
-            _boundsYDiff = yDiff;
-        }
-
-        public void Commit(int tileIndex)
-        {
-            Atlas = tileIndex;
-            ApplyBoundsDiff();
-        }
-
-        private void ApplyBoundsDiff()
-        {
-            if (_boundsXDiff != 0 || _boundsYDiff != 0)
-            {
-                ApplyBoundDiffToTexture(_boundsXDiff, _boundsYDiff);
-                _boundsXDiff = _boundsYDiff = 0; // Don't apply again unless we move again
-                //System.Diagnostics.Debug.WriteLine("[" + Index + "] => Atlas " + Atlas + ", " + Bounds);
-            }
-        }
-
-        public virtual void Invalidate()
-        {
-            Atlas = ushort.MaxValue;
-        }
-
-        public virtual bool IsValid()
-        {
-            return Atlas != ushort.MaxValue;
-        }
-
-        protected abstract void GetBoundsFromTexture();
-        protected abstract void ApplyBoundDiffToTexture(int xDiff, int yDiff);
-
-        public abstract AbstractIndexedTRTexture Clone();
+        _boundsXDiff = 0;
+        _boundsYDiff = 0;
     }
+
+    public void MoveBy(int xDiff, int yDiff)
+    {
+        _bounds.X += xDiff;
+        _bounds.Y += yDiff;
+
+        _boundsXDiff = xDiff;
+        _boundsYDiff = yDiff;
+    }
+
+    public void Commit(int tileIndex)
+    {
+        Atlas = tileIndex;
+        ApplyBoundsDiff();
+    }
+
+    private void ApplyBoundsDiff()
+    {
+        if (_boundsXDiff != 0 || _boundsYDiff != 0)
+        {
+            ApplyBoundDiffToTexture(_boundsXDiff, _boundsYDiff);
+            _boundsXDiff = _boundsYDiff = 0; // Don't apply again unless we move again
+            //System.Diagnostics.Debug.WriteLine("[" + Index + "] => Atlas " + Atlas + ", " + Bounds);
+        }
+    }
+
+    public virtual void Invalidate()
+    {
+        Atlas = ushort.MaxValue;
+    }
+
+    public virtual bool IsValid()
+    {
+        return Atlas != ushort.MaxValue;
+    }
+
+    protected abstract void GetBoundsFromTexture();
+    protected abstract void ApplyBoundDiffToTexture(int xDiff, int yDiff);
+
+    public abstract AbstractIndexedTRTexture Clone();
 }

--- a/TRModelTransporter/Model/Textures/AbstractTextureRemapGroup.cs
+++ b/TRModelTransporter/Model/Textures/AbstractTextureRemapGroup.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Linq;
+﻿using System.Drawing;
 using TRModelTransporter.Packing;
 
 namespace TRModelTransporter.Model.Textures;

--- a/TRModelTransporter/Model/Textures/AbstractTextureRemapGroup.cs
+++ b/TRModelTransporter/Model/Textures/AbstractTextureRemapGroup.cs
@@ -4,98 +4,97 @@ using System.Drawing;
 using System.Linq;
 using TRModelTransporter.Packing;
 
-namespace TRModelTransporter.Model.Textures
+namespace TRModelTransporter.Model.Textures;
+
+public abstract class AbstractTextureRemapGroup<E, L> 
+    where E : Enum
+    where L : class
 {
-    public abstract class AbstractTextureRemapGroup<E, L> 
-        where E : Enum
-        where L : class
+    public List<TextureRemap> Remapping { get; set; }
+    public List<TextureDependency<E>> Dependencies { get; set; }
+
+    public AbstractTextureRemapGroup()
     {
-        public List<TextureRemap> Remapping { get; set; }
-        public List<TextureDependency<E>> Dependencies { get; set; }
+        Remapping = new List<TextureRemap>();
+        Dependencies = new List<TextureDependency<E>>();
+    }
 
-        public AbstractTextureRemapGroup()
+    public void CalculateDependencies(L level, E entity)
+    {
+        using (AbstractTexturePacker<E, L> packer = CreatePacker(level))
         {
-            Remapping = new List<TextureRemap>();
-            Dependencies = new List<TextureDependency<E>>();
-        }
-
-        public void CalculateDependencies(L level, E entity)
-        {
-            using (AbstractTexturePacker<E, L> packer = CreatePacker(level))
+            Dictionary<TexturedTile, List<TexturedTileSegment>> entitySegments = packer.GetModelSegments(entity);
+            foreach (E otherEntity in GetModelTypes(level))
             {
-                Dictionary<TexturedTile, List<TexturedTileSegment>> entitySegments = packer.GetModelSegments(entity);
-                foreach (E otherEntity in GetModelTypes(level))
+                if (EqualityComparer<E>.Default.Equals(entity, otherEntity))
                 {
-                    if (EqualityComparer<E>.Default.Equals(entity, otherEntity))
-                    {
-                        continue;
-                    }
+                    continue;
+                }
 
-                    Dictionary<TexturedTile, List<TexturedTileSegment>> modelSegments = packer.GetModelSegments(otherEntity);
+                Dictionary<TexturedTile, List<TexturedTileSegment>> modelSegments = packer.GetModelSegments(otherEntity);
 
-                    foreach (TexturedTile tile in entitySegments.Keys)
+                foreach (TexturedTile tile in entitySegments.Keys)
+                {
+                    if (modelSegments.ContainsKey(tile))
                     {
-                        if (modelSegments.ContainsKey(tile))
+                        List<TexturedTileSegment> matches = entitySegments[tile].FindAll(s1 => modelSegments[tile].Any(s2 => s1 == s2));
+                        foreach (TexturedTileSegment matchedSegment in matches)
                         {
-                            List<TexturedTileSegment> matches = entitySegments[tile].FindAll(s1 => modelSegments[tile].Any(s2 => s1 == s2));
-                            foreach (TexturedTileSegment matchedSegment in matches)
+                            TextureDependency<E> dependency = GetDependency(tile.Index, matchedSegment.Bounds);
+                            if (dependency == null)
                             {
-                                TextureDependency<E> dependency = GetDependency(tile.Index, matchedSegment.Bounds);
-                                if (dependency == null)
+                                dependency = new TextureDependency<E>
                                 {
-                                    dependency = new TextureDependency<E>
-                                    {
-                                        TileIndex = tile.Index,
-                                        Bounds = matchedSegment.Bounds
-                                    };
-                                    Dependencies.Add(dependency);
-                                }
-                                dependency.AddEntity(entity);
-                                dependency.AddEntity(otherEntity);
+                                    TileIndex = tile.Index,
+                                    Bounds = matchedSegment.Bounds
+                                };
+                                Dependencies.Add(dependency);
                             }
+                            dependency.AddEntity(entity);
+                            dependency.AddEntity(otherEntity);
                         }
                     }
                 }
             }
         }
+    }
 
-        protected abstract AbstractTexturePacker<E, L> CreatePacker(L level);
-        protected abstract IEnumerable<E> GetModelTypes(L level);
+    protected abstract AbstractTexturePacker<E, L> CreatePacker(L level);
+    protected abstract IEnumerable<E> GetModelTypes(L level);
 
-        public TextureDependency<E> GetDependency(int tileIndex, Rectangle rectangle)
+    public TextureDependency<E> GetDependency(int tileIndex, Rectangle rectangle)
+    {
+        foreach (TextureDependency<E> dependency in Dependencies)
         {
-            foreach (TextureDependency<E> dependency in Dependencies)
+            if (dependency.TileIndex == tileIndex && dependency.Bounds == rectangle)
             {
-                if (dependency.TileIndex == tileIndex && dependency.Bounds == rectangle)
-                {
-                    return dependency;
-                }
+                return dependency;
             }
-            return null;
         }
+        return null;
+    }
 
-        public TextureDependency<E> GetDependency(int tileIndex, Rectangle rectangle, IEnumerable<E> entities)
+    public TextureDependency<E> GetDependency(int tileIndex, Rectangle rectangle, IEnumerable<E> entities)
+    {
+        foreach (TextureDependency<E> dependency in Dependencies)
         {
-            foreach (TextureDependency<E> dependency in Dependencies)
+            if (dependency.TileIndex == tileIndex && dependency.Bounds == rectangle && dependency.Entities.All(e => entities.Contains(e)))
             {
-                if (dependency.TileIndex == tileIndex && dependency.Bounds == rectangle && dependency.Entities.All(e => entities.Contains(e)))
-                {
-                    return dependency;
-                }
+                return dependency;
             }
-            return null;
         }
+        return null;
+    }
 
-        public bool CanRemoveRectangle(int tileIndex, Rectangle rectangle, IEnumerable<E> entities)
+    public bool CanRemoveRectangle(int tileIndex, Rectangle rectangle, IEnumerable<E> entities)
+    {
+        // Is there a dependency for the given rectangle?
+        TextureDependency<E> dependency = GetDependency(tileIndex, rectangle);
+        if (dependency != null)
         {
-            // Is there a dependency for the given rectangle?
-            TextureDependency<E> dependency = GetDependency(tileIndex, rectangle);
-            if (dependency != null)
-            {
-                // The rectangle can be removed if all of the entities match the dependency
-                return dependency.Entities.All(e => entities.Contains(e));
-            }
-            return true;
+            // The rectangle can be removed if all of the entities match the dependency
+            return dependency.Entities.All(e => entities.Contains(e));
         }
+        return true;
     }
 }

--- a/TRModelTransporter/Model/Textures/ITextureClassifier.cs
+++ b/TRModelTransporter/Model/Textures/ITextureClassifier.cs
@@ -1,7 +1,6 @@
-﻿namespace TRModelTransporter.Model.Textures
+﻿namespace TRModelTransporter.Model.Textures;
+
+public interface ITextureClassifier
 {
-    public interface ITextureClassifier
-    {
-        string GetClassification();
-    }
+    string GetClassification();
 }

--- a/TRModelTransporter/Model/Textures/ITexturePositionMonitor.cs
+++ b/TRModelTransporter/Model/Textures/ITexturePositionMonitor.cs
@@ -1,15 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace TRModelTransporter.Model.Textures
+namespace TRModelTransporter.Model.Textures;
+
+// This allows external callers to monitor specific textures for specific entities by providing a list
+// of texture indices it wants to observe. When the import completes, a map of entity to a list of
+// PositionedTextures will be returned to it for processing as necessary.
+public interface ITexturePositionMonitor<E> where E : Enum
 {
-    // This allows external callers to monitor specific textures for specific entities by providing a list
-    // of texture indices it wants to observe. When the import completes, a map of entity to a list of
-    // PositionedTextures will be returned to it for processing as necessary.
-    public interface ITexturePositionMonitor<E> where E : Enum
-    {
-        Dictionary<E, List<int>> GetMonitoredTextureIndices();
-        void MonitoredTexturesPositioned(Dictionary<E, List<PositionedTexture>> texturePositions);
-        void EntityTexturesRemoved(List<E> entities);
-    }
+    Dictionary<E, List<int>> GetMonitoredTextureIndices();
+    void MonitoredTexturesPositioned(Dictionary<E, List<PositionedTexture>> texturePositions);
+    void EntityTexturesRemoved(List<E> entities);
 }

--- a/TRModelTransporter/Model/Textures/ITexturePositionMonitor.cs
+++ b/TRModelTransporter/Model/Textures/ITexturePositionMonitor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace TRModelTransporter.Model.Textures;
+﻿namespace TRModelTransporter.Model.Textures;
 
 // This allows external callers to monitor specific textures for specific entities by providing a list
 // of texture indices it wants to observe. When the import completes, a map of entity to a list of

--- a/TRModelTransporter/Model/Textures/IndexedTRObjectTexture.cs
+++ b/TRModelTransporter/Model/Textures/IndexedTRObjectTexture.cs
@@ -3,171 +3,170 @@ using System.Drawing;
 using System.Linq;
 using TRLevelControl.Model;
 
-namespace TRModelTransporter.Model.Textures
+namespace TRModelTransporter.Model.Textures;
+
+public class IndexedTRObjectTexture : AbstractIndexedTRTexture
 {
-    public class IndexedTRObjectTexture : AbstractIndexedTRTexture
+    private TRObjectTexture _texture;
+    private Dictionary<TRObjectTextureVert, Point> _vertexPoints;
+
+    public override int Atlas
     {
-        private TRObjectTexture _texture;
-        private Dictionary<TRObjectTextureVert, Point> _vertexPoints;
+        get => _texture.AtlasAndFlag;
+        set => _texture.AtlasAndFlag = (ushort)value;
+    }
 
-        public override int Atlas
+    public TRObjectTexture Texture
+    {
+        get => _texture;
+        set
         {
-            get => _texture.AtlasAndFlag;
-            set => _texture.AtlasAndFlag = (ushort)value;
+            _texture = value;
+            GetBoundsFromTexture();
+        }
+    }
+
+    protected override void GetBoundsFromTexture()
+    {
+        _vertexPoints = new Dictionary<TRObjectTextureVert, Point>();
+        TRObjectTextureVert[] vertices = Texture.Vertices;
+        for (int i = 0; i < vertices.Length; i++)
+        {
+            TRObjectTextureVert vertex = vertices[i];
+            if (i == vertices.Length - 1 && IsTriangleVertex(vertex))
+            {
+                continue;
+            }
+
+            _vertexPoints[vertex] = VertexToPoint(vertex);
         }
 
-        public TRObjectTexture Texture
+        IEnumerable<Point> points = _vertexPoints.Values;
+        int minX = points.Min(p => p.X);
+        int minY = points.Min(p => p.Y);
+        int maxX = points.Max(p => p.X);
+        int maxY = points.Max(p => p.Y);
+
+        _bounds = new Rectangle(new Point(minX, minY), new Size(maxX - minX, maxY - minY));
+    }
+
+    protected override void ApplyBoundDiffToTexture(int xDiff, int yDiff)
+    {
+        // By storing the translated points against the vertices, we can maintain
+        // the correct order when the bounds have moved e.g. some textures load
+        // the graphic as [top-right,bottom-right,bottom-left,top-left], others
+        // as [top-left,top-right.... etc
+
+        List<TRObjectTextureVert> vertices = new List<TRObjectTextureVert>(_vertexPoints.Keys);
+        foreach (TRObjectTextureVert vertex in vertices)
         {
-            get => _texture;
-            set
+            Point p = _vertexPoints[vertex];
+            p.X += xDiff;
+            p.Y += yDiff;
+            ApplyPointToVertex(p, vertex);
+            _vertexPoints[vertex] = p;
+        }
+    }
+
+    private static Point VertexToPoint(TRObjectTextureVert vertex)
+    {
+        int x = vertex.XCoordinate.Fraction;
+        if (vertex.XCoordinate.Whole == 255)
+        {
+            x++;
+        }
+
+        int y = vertex.YCoordinate.Fraction;
+        if (vertex.YCoordinate.Whole == 255)
+        {
+            y++;
+        }
+        return new Point(x, y);
+    }
+
+    private static void ApplyPointToVertex(Point point, TRObjectTextureVert vertex)
+    {
+        int x = point.X;
+        int y = point.Y;
+        if (vertex.XCoordinate.Whole == 255)
+        {
+            x--;
+        }
+
+        if (vertex.YCoordinate.Whole == 255)
+        {
+            y--;
+        }
+
+        vertex.XCoordinate.Fraction = (byte)x;
+        vertex.YCoordinate.Fraction = (byte)y;
+    }
+
+    public bool IsTriangle
+    {
+        get
+        {
+            return _vertexPoints.Count == 3;
+        }
+    }
+
+    private static bool IsTriangleVertex(TRObjectTextureVert vertex)
+    {
+        return vertex.XCoordinate.Fraction == 0 && vertex.XCoordinate.Whole == 0 && vertex.YCoordinate.Fraction == 0 && vertex.YCoordinate.Whole == 0;
+    }
+
+    public override bool Equals(object obj)
+    {
+        if (obj is IndexedTRObjectTexture otherTexture)
+        {
+            if (_vertexPoints.Count == otherTexture._vertexPoints.Count)
             {
-                _texture = value;
-                GetBoundsFromTexture();
+                // Are all the points in the same order?
+                List<Point> points1 = new List<Point>(_vertexPoints.Values);
+                List<Point> points2 = new List<Point>(otherTexture._vertexPoints.Values);
+                return points1.SequenceEqual(points2);
             }
         }
 
-        protected override void GetBoundsFromTexture()
+        return false;
+    }
+
+    public override int GetHashCode()
+    {
+        return 613946457 + EqualityComparer<TRObjectTexture>.Default.GetHashCode(_texture);
+    }
+
+    public override AbstractIndexedTRTexture Clone()
+    {
+        TRObjectTexture copiedTexture = new TRObjectTexture
         {
-            _vertexPoints = new Dictionary<TRObjectTextureVert, Point>();
-            TRObjectTextureVert[] vertices = Texture.Vertices;
-            for (int i = 0; i < vertices.Length; i++)
+            AtlasAndFlag = Texture.AtlasAndFlag,
+            Attribute = Texture.Attribute,
+            Vertices = new TRObjectTextureVert[Texture.Vertices.Length]
+        };
+
+        for (int i = 0; i < Texture.Vertices.Length; i++)
+        {
+            copiedTexture.Vertices[i] = new TRObjectTextureVert
             {
-                TRObjectTextureVert vertex = vertices[i];
-                if (i == vertices.Length - 1 && IsTriangleVertex(vertex))
+                XCoordinate = new FixedFloat16
                 {
-                    continue;
+                    Fraction = Texture.Vertices[i].XCoordinate.Fraction,
+                    Whole = Texture.Vertices[i].XCoordinate.Whole
+                },
+                YCoordinate = new FixedFloat16
+                {
+                    Fraction = Texture.Vertices[i].YCoordinate.Fraction,
+                    Whole = Texture.Vertices[i].YCoordinate.Whole
                 }
-
-                _vertexPoints[vertex] = VertexToPoint(vertex);
-            }
-
-            IEnumerable<Point> points = _vertexPoints.Values;
-            int minX = points.Min(p => p.X);
-            int minY = points.Min(p => p.Y);
-            int maxX = points.Max(p => p.X);
-            int maxY = points.Max(p => p.Y);
-
-            _bounds = new Rectangle(new Point(minX, minY), new Size(maxX - minX, maxY - minY));
-        }
-
-        protected override void ApplyBoundDiffToTexture(int xDiff, int yDiff)
-        {
-            // By storing the translated points against the vertices, we can maintain
-            // the correct order when the bounds have moved e.g. some textures load
-            // the graphic as [top-right,bottom-right,bottom-left,top-left], others
-            // as [top-left,top-right.... etc
-
-            List<TRObjectTextureVert> vertices = new List<TRObjectTextureVert>(_vertexPoints.Keys);
-            foreach (TRObjectTextureVert vertex in vertices)
-            {
-                Point p = _vertexPoints[vertex];
-                p.X += xDiff;
-                p.Y += yDiff;
-                ApplyPointToVertex(p, vertex);
-                _vertexPoints[vertex] = p;
-            }
-        }
-
-        private static Point VertexToPoint(TRObjectTextureVert vertex)
-        {
-            int x = vertex.XCoordinate.Fraction;
-            if (vertex.XCoordinate.Whole == 255)
-            {
-                x++;
-            }
-
-            int y = vertex.YCoordinate.Fraction;
-            if (vertex.YCoordinate.Whole == 255)
-            {
-                y++;
-            }
-            return new Point(x, y);
-        }
-
-        private static void ApplyPointToVertex(Point point, TRObjectTextureVert vertex)
-        {
-            int x = point.X;
-            int y = point.Y;
-            if (vertex.XCoordinate.Whole == 255)
-            {
-                x--;
-            }
-
-            if (vertex.YCoordinate.Whole == 255)
-            {
-                y--;
-            }
-
-            vertex.XCoordinate.Fraction = (byte)x;
-            vertex.YCoordinate.Fraction = (byte)y;
-        }
-
-        public bool IsTriangle
-        {
-            get
-            {
-                return _vertexPoints.Count == 3;
-            }
-        }
-
-        private static bool IsTriangleVertex(TRObjectTextureVert vertex)
-        {
-            return vertex.XCoordinate.Fraction == 0 && vertex.XCoordinate.Whole == 0 && vertex.YCoordinate.Fraction == 0 && vertex.YCoordinate.Whole == 0;
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (obj is IndexedTRObjectTexture otherTexture)
-            {
-                if (_vertexPoints.Count == otherTexture._vertexPoints.Count)
-                {
-                    // Are all the points in the same order?
-                    List<Point> points1 = new List<Point>(_vertexPoints.Values);
-                    List<Point> points2 = new List<Point>(otherTexture._vertexPoints.Values);
-                    return points1.SequenceEqual(points2);
-                }
-            }
-
-            return false;
-        }
-
-        public override int GetHashCode()
-        {
-            return 613946457 + EqualityComparer<TRObjectTexture>.Default.GetHashCode(_texture);
-        }
-
-        public override AbstractIndexedTRTexture Clone()
-        {
-            TRObjectTexture copiedTexture = new TRObjectTexture
-            {
-                AtlasAndFlag = Texture.AtlasAndFlag,
-                Attribute = Texture.Attribute,
-                Vertices = new TRObjectTextureVert[Texture.Vertices.Length]
-            };
-
-            for (int i = 0; i < Texture.Vertices.Length; i++)
-            {
-                copiedTexture.Vertices[i] = new TRObjectTextureVert
-                {
-                    XCoordinate = new FixedFloat16
-                    {
-                        Fraction = Texture.Vertices[i].XCoordinate.Fraction,
-                        Whole = Texture.Vertices[i].XCoordinate.Whole
-                    },
-                    YCoordinate = new FixedFloat16
-                    {
-                        Fraction = Texture.Vertices[i].YCoordinate.Fraction,
-                        Whole = Texture.Vertices[i].YCoordinate.Whole
-                    }
-                };
-            }
-
-            return new IndexedTRObjectTexture
-            {
-                Index = Index,
-                Classification = Classification,
-                Texture = copiedTexture
             };
         }
+
+        return new IndexedTRObjectTexture
+        {
+            Index = Index,
+            Classification = Classification,
+            Texture = copiedTexture
+        };
     }
 }

--- a/TRModelTransporter/Model/Textures/IndexedTRObjectTexture.cs
+++ b/TRModelTransporter/Model/Textures/IndexedTRObjectTexture.cs
@@ -55,7 +55,7 @@ public class IndexedTRObjectTexture : AbstractIndexedTRTexture
         // the graphic as [top-right,bottom-right,bottom-left,top-left], others
         // as [top-left,top-right.... etc
 
-        List<TRObjectTextureVert> vertices = new List<TRObjectTextureVert>(_vertexPoints.Keys);
+        List<TRObjectTextureVert> vertices = new(_vertexPoints.Keys);
         foreach (TRObjectTextureVert vertex in vertices)
         {
             Point p = _vertexPoints[vertex];
@@ -120,8 +120,8 @@ public class IndexedTRObjectTexture : AbstractIndexedTRTexture
             if (_vertexPoints.Count == otherTexture._vertexPoints.Count)
             {
                 // Are all the points in the same order?
-                List<Point> points1 = new List<Point>(_vertexPoints.Values);
-                List<Point> points2 = new List<Point>(otherTexture._vertexPoints.Values);
+                List<Point> points1 = new(_vertexPoints.Values);
+                List<Point> points2 = new(otherTexture._vertexPoints.Values);
                 return points1.SequenceEqual(points2);
             }
         }
@@ -136,7 +136,7 @@ public class IndexedTRObjectTexture : AbstractIndexedTRTexture
 
     public override AbstractIndexedTRTexture Clone()
     {
-        TRObjectTexture copiedTexture = new TRObjectTexture
+        TRObjectTexture copiedTexture = new()
         {
             AtlasAndFlag = Texture.AtlasAndFlag,
             Attribute = Texture.Attribute,

--- a/TRModelTransporter/Model/Textures/IndexedTRObjectTexture.cs
+++ b/TRModelTransporter/Model/Textures/IndexedTRObjectTexture.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Drawing;
-using System.Linq;
+﻿using System.Drawing;
 using TRLevelControl.Model;
 
 namespace TRModelTransporter.Model.Textures;

--- a/TRModelTransporter/Model/Textures/IndexedTRSpriteTexture.cs
+++ b/TRModelTransporter/Model/Textures/IndexedTRSpriteTexture.cs
@@ -1,58 +1,57 @@
 ﻿using System.Drawing;
 using TRLevelControl.Model;
 
-namespace TRModelTransporter.Model.Textures
+namespace TRModelTransporter.Model.Textures;
+
+public class IndexedTRSpriteTexture : AbstractIndexedTRTexture
 {
-    public class IndexedTRSpriteTexture : AbstractIndexedTRTexture
+    private TRSpriteTexture _texture;
+
+    public override int Atlas
     {
-        private TRSpriteTexture _texture;
+        get => _texture.Atlas;
+        set => _texture.Atlas = (ushort)value;
+    }
 
-        public override int Atlas
+    public TRSpriteTexture Texture
+    {
+        get => _texture;
+        set
         {
-            get => _texture.Atlas;
-            set => _texture.Atlas = (ushort)value;
+            _texture = value;
+            GetBoundsFromTexture();
         }
+    }
 
-        public TRSpriteTexture Texture
+    protected override void GetBoundsFromTexture()
+    {
+        _bounds = new Rectangle(Texture.X, Texture.Y, (Texture.Width + 1) / 256, (Texture.Height + 1) / 256);
+    }
+
+    protected override void ApplyBoundDiffToTexture(int xDiff, int yDiff)
+    {
+        Texture.X += (byte)xDiff;
+        Texture.Y += (byte)yDiff;
+    }
+
+    public override AbstractIndexedTRTexture Clone()
+    {
+        return new IndexedTRSpriteTexture
         {
-            get => _texture;
-            set
+            Index = Index,
+            Classification = Classification,
+            Texture = new TRSpriteTexture
             {
-                _texture = value;
-                GetBoundsFromTexture();
+                Atlas = Texture.Atlas,
+                BottomSide = Texture.BottomSide,
+                Height = Texture.Height,
+                Width = Texture.Width,
+                LeftSide = Texture.LeftSide,
+                RightSide = Texture.RightSide,
+                TopSide = Texture.TopSide,
+                X = Texture.X,
+                Y = Texture.Y
             }
-        }
-
-        protected override void GetBoundsFromTexture()
-        {
-            _bounds = new Rectangle(Texture.X, Texture.Y, (Texture.Width + 1) / 256, (Texture.Height + 1) / 256);
-        }
-
-        protected override void ApplyBoundDiffToTexture(int xDiff, int yDiff)
-        {
-            Texture.X += (byte)xDiff;
-            Texture.Y += (byte)yDiff;
-        }
-
-        public override AbstractIndexedTRTexture Clone()
-        {
-            return new IndexedTRSpriteTexture
-            {
-                Index = Index,
-                Classification = Classification,
-                Texture = new TRSpriteTexture
-                {
-                    Atlas = Texture.Atlas,
-                    BottomSide = Texture.BottomSide,
-                    Height = Texture.Height,
-                    Width = Texture.Width,
-                    LeftSide = Texture.LeftSide,
-                    RightSide = Texture.RightSide,
-                    TopSide = Texture.TopSide,
-                    X = Texture.X,
-                    Y = Texture.Y
-                }
-            };
-        }
+        };
     }
 }

--- a/TRModelTransporter/Model/Textures/PositionedTexture.cs
+++ b/TRModelTransporter/Model/Textures/PositionedTexture.cs
@@ -8,7 +8,7 @@ public class PositionedTexture
 
     public int OriginalIndex => _texture.Index;
     public int TileIndex => _texture.Atlas;
-    public Point Position => new Point(_texture.Bounds.X, _texture.Bounds.Y);
+    public Point Position => new(_texture.Bounds.X, _texture.Bounds.Y);
     public Rectangle Bounds => _texture.Bounds;
 
     public PositionedTexture(AbstractIndexedTRTexture texture)

--- a/TRModelTransporter/Model/Textures/PositionedTexture.cs
+++ b/TRModelTransporter/Model/Textures/PositionedTexture.cs
@@ -1,19 +1,18 @@
 ﻿using System.Drawing;
 
-namespace TRModelTransporter.Model.Textures
+namespace TRModelTransporter.Model.Textures;
+
+public class PositionedTexture
 {
-    public class PositionedTexture
+    private readonly AbstractIndexedTRTexture _texture;
+
+    public int OriginalIndex => _texture.Index;
+    public int TileIndex => _texture.Atlas;
+    public Point Position => new Point(_texture.Bounds.X, _texture.Bounds.Y);
+    public Rectangle Bounds => _texture.Bounds;
+
+    public PositionedTexture(AbstractIndexedTRTexture texture)
     {
-        private readonly AbstractIndexedTRTexture _texture;
-
-        public int OriginalIndex => _texture.Index;
-        public int TileIndex => _texture.Atlas;
-        public Point Position => new Point(_texture.Bounds.X, _texture.Bounds.Y);
-        public Rectangle Bounds => _texture.Bounds;
-
-        public PositionedTexture(AbstractIndexedTRTexture texture)
-        {
-            _texture = texture;
-        }
+        _texture = texture;
     }
 }

--- a/TRModelTransporter/Model/Textures/RemapTypes/TR1TextureRemapGroup.cs
+++ b/TRModelTransporter/Model/Textures/RemapTypes/TR1TextureRemapGroup.cs
@@ -3,23 +3,22 @@ using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;
 using TRModelTransporter.Packing;
 
-namespace TRModelTransporter.Model.Textures
-{
-    public class TR1TextureRemapGroup : AbstractTextureRemapGroup<TREntities, TR1Level>
-    {
-        protected override IEnumerable<TREntities> GetModelTypes(TR1Level level)
-        {
-            List<TREntities> types = new List<TREntities>();
-            foreach (TRModel model in level.Models)
-            {
-                types.Add((TREntities)model.ID);
-            }
-            return types;
-        }
+namespace TRModelTransporter.Model.Textures;
 
-        protected override AbstractTexturePacker<TREntities, TR1Level> CreatePacker(TR1Level level)
+public class TR1TextureRemapGroup : AbstractTextureRemapGroup<TREntities, TR1Level>
+{
+    protected override IEnumerable<TREntities> GetModelTypes(TR1Level level)
+    {
+        List<TREntities> types = new List<TREntities>();
+        foreach (TRModel model in level.Models)
         {
-            return new TR1TexturePacker(level);
+            types.Add((TREntities)model.ID);
         }
+        return types;
+    }
+
+    protected override AbstractTexturePacker<TREntities, TR1Level> CreatePacker(TR1Level level)
+    {
+        return new TR1TexturePacker(level);
     }
 }

--- a/TRModelTransporter/Model/Textures/RemapTypes/TR1TextureRemapGroup.cs
+++ b/TRModelTransporter/Model/Textures/RemapTypes/TR1TextureRemapGroup.cs
@@ -8,7 +8,7 @@ public class TR1TextureRemapGroup : AbstractTextureRemapGroup<TREntities, TR1Lev
 {
     protected override IEnumerable<TREntities> GetModelTypes(TR1Level level)
     {
-        List<TREntities> types = new List<TREntities>();
+        List<TREntities> types = new();
         foreach (TRModel model in level.Models)
         {
             types.Add((TREntities)model.ID);

--- a/TRModelTransporter/Model/Textures/RemapTypes/TR1TextureRemapGroup.cs
+++ b/TRModelTransporter/Model/Textures/RemapTypes/TR1TextureRemapGroup.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using TRLevelControl.Model;
+﻿using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;
 using TRModelTransporter.Packing;
 

--- a/TRModelTransporter/Model/Textures/RemapTypes/TR2TextureRemapGroup.cs
+++ b/TRModelTransporter/Model/Textures/RemapTypes/TR2TextureRemapGroup.cs
@@ -8,7 +8,7 @@ public class TR2TextureRemapGroup : AbstractTextureRemapGroup<TR2Entities, TR2Le
 {
     protected override IEnumerable<TR2Entities> GetModelTypes(TR2Level level)
     {
-        List<TR2Entities> types = new List<TR2Entities>();
+        List<TR2Entities> types = new();
         foreach (TRModel model in level.Models)
         {
             types.Add((TR2Entities)model.ID);

--- a/TRModelTransporter/Model/Textures/RemapTypes/TR2TextureRemapGroup.cs
+++ b/TRModelTransporter/Model/Textures/RemapTypes/TR2TextureRemapGroup.cs
@@ -3,23 +3,22 @@ using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;
 using TRModelTransporter.Packing;
 
-namespace TRModelTransporter.Model.Textures
-{
-    public class TR2TextureRemapGroup : AbstractTextureRemapGroup<TR2Entities, TR2Level>
-    {
-        protected override IEnumerable<TR2Entities> GetModelTypes(TR2Level level)
-        {
-            List<TR2Entities> types = new List<TR2Entities>();
-            foreach (TRModel model in level.Models)
-            {
-                types.Add((TR2Entities)model.ID);
-            }
-            return types;
-        }
+namespace TRModelTransporter.Model.Textures;
 
-        protected override AbstractTexturePacker<TR2Entities, TR2Level> CreatePacker(TR2Level level)
+public class TR2TextureRemapGroup : AbstractTextureRemapGroup<TR2Entities, TR2Level>
+{
+    protected override IEnumerable<TR2Entities> GetModelTypes(TR2Level level)
+    {
+        List<TR2Entities> types = new List<TR2Entities>();
+        foreach (TRModel model in level.Models)
         {
-            return new TR2TexturePacker(level);
+            types.Add((TR2Entities)model.ID);
         }
+        return types;
+    }
+
+    protected override AbstractTexturePacker<TR2Entities, TR2Level> CreatePacker(TR2Level level)
+    {
+        return new TR2TexturePacker(level);
     }
 }

--- a/TRModelTransporter/Model/Textures/RemapTypes/TR2TextureRemapGroup.cs
+++ b/TRModelTransporter/Model/Textures/RemapTypes/TR2TextureRemapGroup.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using TRLevelControl.Model;
+﻿using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;
 using TRModelTransporter.Packing;
 

--- a/TRModelTransporter/Model/Textures/RemapTypes/TR3TextureRemapGroup.cs
+++ b/TRModelTransporter/Model/Textures/RemapTypes/TR3TextureRemapGroup.cs
@@ -8,7 +8,7 @@ public class TR3TextureRemapGroup : AbstractTextureRemapGroup<TR3Entities, TR3Le
 {
     protected override IEnumerable<TR3Entities> GetModelTypes(TR3Level level)
     {
-        List<TR3Entities> types = new List<TR3Entities>();
+        List<TR3Entities> types = new();
         foreach (TRModel model in level.Models)
         {
             types.Add((TR3Entities)model.ID);

--- a/TRModelTransporter/Model/Textures/RemapTypes/TR3TextureRemapGroup.cs
+++ b/TRModelTransporter/Model/Textures/RemapTypes/TR3TextureRemapGroup.cs
@@ -3,23 +3,22 @@ using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;
 using TRModelTransporter.Packing;
 
-namespace TRModelTransporter.Model.Textures
-{
-    public class TR3TextureRemapGroup : AbstractTextureRemapGroup<TR3Entities, TR3Level>
-    {
-        protected override IEnumerable<TR3Entities> GetModelTypes(TR3Level level)
-        {
-            List<TR3Entities> types = new List<TR3Entities>();
-            foreach (TRModel model in level.Models)
-            {
-                types.Add((TR3Entities)model.ID);
-            }
-            return types;
-        }
+namespace TRModelTransporter.Model.Textures;
 
-        protected override AbstractTexturePacker<TR3Entities, TR3Level> CreatePacker(TR3Level level)
+public class TR3TextureRemapGroup : AbstractTextureRemapGroup<TR3Entities, TR3Level>
+{
+    protected override IEnumerable<TR3Entities> GetModelTypes(TR3Level level)
+    {
+        List<TR3Entities> types = new List<TR3Entities>();
+        foreach (TRModel model in level.Models)
         {
-            return new TR3TexturePacker(level);
+            types.Add((TR3Entities)model.ID);
         }
+        return types;
+    }
+
+    protected override AbstractTexturePacker<TR3Entities, TR3Level> CreatePacker(TR3Level level)
+    {
+        return new TR3TexturePacker(level);
     }
 }

--- a/TRModelTransporter/Model/Textures/RemapTypes/TR3TextureRemapGroup.cs
+++ b/TRModelTransporter/Model/Textures/RemapTypes/TR3TextureRemapGroup.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using TRLevelControl.Model;
+﻿using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;
 using TRModelTransporter.Packing;
 

--- a/TRModelTransporter/Model/Textures/TextureDependency.cs
+++ b/TRModelTransporter/Model/Textures/TextureDependency.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
+﻿using System.Drawing;
 
 namespace TRModelTransporter.Model.Textures;
 

--- a/TRModelTransporter/Model/Textures/TextureDependency.cs
+++ b/TRModelTransporter/Model/Textures/TextureDependency.cs
@@ -2,25 +2,24 @@
 using System.Collections.Generic;
 using System.Drawing;
 
-namespace TRModelTransporter.Model.Textures
+namespace TRModelTransporter.Model.Textures;
+
+public class TextureDependency<E> where E : Enum
 {
-    public class TextureDependency<E> where E : Enum
+    public List<E> Entities { get; set; }
+    public int TileIndex { get; set; }
+    public Rectangle Bounds { get; set; }
+
+    public TextureDependency()
     {
-        public List<E> Entities { get; set; }
-        public int TileIndex { get; set; }
-        public Rectangle Bounds { get; set; }
+        Entities = new List<E>();
+    }
 
-        public TextureDependency()
+    public void AddEntity(E entity)
+    {
+        if (!Entities.Contains(entity))
         {
-            Entities = new List<E>();
-        }
-
-        public void AddEntity(E entity)
-        {
-            if (!Entities.Contains(entity))
-            {
-                Entities.Add(entity);
-            }
+            Entities.Add(entity);
         }
     }
 }

--- a/TRModelTransporter/Model/Textures/TextureRemap.cs
+++ b/TRModelTransporter/Model/Textures/TextureRemap.cs
@@ -1,15 +1,14 @@
 ﻿using System.Drawing;
 
-namespace TRModelTransporter.Model.Textures
+namespace TRModelTransporter.Model.Textures;
+
+public class TextureRemap
 {
-    public class TextureRemap
-    {
-        public int OriginalTile { get; set; }
-        public int OriginalIndex { get; set; }
-        public Rectangle OriginalBounds { get; set; }
-        public int NewTile { get; set; }
-        public int NewIndex { get; set; }
-        public Rectangle NewBounds { get; set; }
-        public Point AdjustmentPoint { get; set; }
-    }
+    public int OriginalTile { get; set; }
+    public int OriginalIndex { get; set; }
+    public Rectangle OriginalBounds { get; set; }
+    public int NewTile { get; set; }
+    public int NewIndex { get; set; }
+    public Rectangle NewBounds { get; set; }
+    public Point AdjustmentPoint { get; set; }
 }

--- a/TRModelTransporter/Packing/AbstractTexturePacker.cs
+++ b/TRModelTransporter/Packing/AbstractTexturePacker.cs
@@ -359,6 +359,7 @@ public abstract class AbstractTexturePacker<E, L> : AbstractPacker<TexturedTile,
         {
             tile.Dispose();
         }
+        GC.SuppressFinalize(this);
     }
 
     protected override TexturedTile CreateTile()

--- a/TRModelTransporter/Packing/AbstractTexturePacker.cs
+++ b/TRModelTransporter/Packing/AbstractTexturePacker.cs
@@ -1,10 +1,7 @@
 ﻿using RectanglePacker;
 using RectanglePacker.Events;
 using RectanglePacker.Organisation;
-using System;
-using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
 using TRLevelControl.Model;
 using TRModelTransporter.Helpers;
 using TRModelTransporter.Model.Textures;

--- a/TRModelTransporter/Packing/AbstractTexturePacker.cs
+++ b/TRModelTransporter/Packing/AbstractTexturePacker.cs
@@ -90,7 +90,7 @@ public abstract class AbstractTexturePacker<E, L> : AbstractPacker<TexturedTile,
 
     public Dictionary<TexturedTile, List<TexturedTileSegment>> GetModelSegments(E modelEntity)
     {
-        Dictionary<TexturedTile, List<TexturedTileSegment>> segmentMap = new Dictionary<TexturedTile, List<TexturedTileSegment>>();
+        Dictionary<TexturedTile, List<TexturedTileSegment>> segmentMap = new();
         TRMesh[] meshes = GetModelMeshes(modelEntity);
         if (meshes != null)
         {
@@ -110,7 +110,7 @@ public abstract class AbstractTexturePacker<E, L> : AbstractPacker<TexturedTile,
 
     public Dictionary<TexturedTile, List<TexturedTileSegment>> GetObjectTextureSegments(IEnumerable<int> indices)
     {
-        Dictionary<TexturedTile, List<TexturedTileSegment>> segmentMap = new Dictionary<TexturedTile, List<TexturedTileSegment>>();
+        Dictionary<TexturedTile, List<TexturedTileSegment>> segmentMap = new();
         foreach (TexturedTile tile in _tiles)
         {
             List<TexturedTileSegment> segments = tile.GetObjectTextureIndexSegments(indices);
@@ -127,11 +127,11 @@ public abstract class AbstractTexturePacker<E, L> : AbstractPacker<TexturedTile,
 
     public Dictionary<TexturedTile, List<TexturedTileSegment>> GetSpriteSegments(E entity)
     {
-        Dictionary<TexturedTile, List<TexturedTileSegment>> segmentMap = new Dictionary<TexturedTile, List<TexturedTileSegment>>();
+        Dictionary<TexturedTile, List<TexturedTileSegment>> segmentMap = new();
         TRSpriteSequence sequence = GetSpriteSequence(entity);
         if (sequence != null)
         {
-            List<int> indices = new List<int>();
+            List<int> indices = new();
             for (int j = 0; j < sequence.NegativeLength * -1; j++)
             {
                 indices.Add(sequence.Offset + j);
@@ -152,7 +152,7 @@ public abstract class AbstractTexturePacker<E, L> : AbstractPacker<TexturedTile,
 
     public Dictionary<TexturedTile, List<TexturedTileSegment>> GetSpriteTextureSegments(IEnumerable<int> indices)
     {
-        Dictionary<TexturedTile, List<TexturedTileSegment>> segmentMap = new Dictionary<TexturedTile, List<TexturedTileSegment>>();
+        Dictionary<TexturedTile, List<TexturedTileSegment>> segmentMap = new();
         foreach (TexturedTile tile in _tiles)
         {
             List<TexturedTileSegment> segments = tile.GetSpriteTextureIndexSegments(indices);
@@ -245,7 +245,7 @@ public abstract class AbstractTexturePacker<E, L> : AbstractPacker<TexturedTile,
 
         // Perform an exhaustive check against every other model in the level to find shared textures.
 
-        Dictionary<E, Dictionary<TexturedTile, List<TexturedTileSegment>>> candidateSegments = new Dictionary<E, Dictionary<TexturedTile, List<TexturedTileSegment>>>();
+        Dictionary<E, Dictionary<TexturedTile, List<TexturedTileSegment>>> candidateSegments = new();
 
         // First cache each segment for the models we wish to remove
         foreach (E modelEntity in modelEntitiesToRemove)
@@ -304,7 +304,7 @@ public abstract class AbstractTexturePacker<E, L> : AbstractPacker<TexturedTile,
 
     public void RemoveSpriteSegments(IEnumerable<E> entitiesToRemove)
     {
-        Dictionary<E, Dictionary<TexturedTile, List<TexturedTileSegment>>> candidateSegments = new Dictionary<E, Dictionary<TexturedTile, List<TexturedTileSegment>>>();
+        Dictionary<E, Dictionary<TexturedTile, List<TexturedTileSegment>>> candidateSegments = new();
 
         // First cache each segment for the models we wish to remove
         foreach (E entity in entitiesToRemove)

--- a/TRModelTransporter/Packing/AbstractTexturePacker.cs
+++ b/TRModelTransporter/Packing/AbstractTexturePacker.cs
@@ -238,7 +238,7 @@ public abstract class AbstractTexturePacker<E, L> : AbstractPacker<TexturedTile,
 
     public void RemoveModelSegmentsChecked(IEnumerable<E> modelEntitiesToRemove)
     {
-        if (modelEntitiesToRemove.Count() == 0)
+        if (!modelEntitiesToRemove.Any())
         {
             return;
         }

--- a/TRModelTransporter/Packing/AbstractTexturePacker.cs
+++ b/TRModelTransporter/Packing/AbstractTexturePacker.cs
@@ -10,110 +10,94 @@ using TRModelTransporter.Helpers;
 using TRModelTransporter.Model.Textures;
 using TRTexture16Importer.Helpers;
 
-namespace TRModelTransporter.Packing
+namespace TRModelTransporter.Packing;
+
+public abstract class AbstractTexturePacker<E, L> : AbstractPacker<TexturedTile, TexturedTileSegment>, IDisposable
+    where E : Enum
+    where L : class
 {
-    public abstract class AbstractTexturePacker<E, L> : AbstractPacker<TexturedTile, TexturedTileSegment>, IDisposable
-        where E : Enum
-        where L : class
+    public L Level { get; private set; }
+    public abstract uint NumLevelImages { get; }
+
+    protected readonly string _levelClassifier;
+
+    public IReadOnlyList<AbstractIndexedTRTexture> AllTextures => _allTextures;
+
+    private readonly List<AbstractIndexedTRTexture> _allTextures;
+
+    public AbstractTexturePacker()
+        : this(default) { }
+
+    public AbstractTexturePacker(L level, int maximumTiles = 16, ITextureClassifier classifier = null)
     {
-        public L Level { get; private set; }
-        public abstract uint NumLevelImages { get; }
+        TileWidth = 256;
+        TileHeight = 256;
+        MaximumTiles = maximumTiles;
 
-        protected readonly string _levelClassifier;
-
-        public IReadOnlyList<AbstractIndexedTRTexture> AllTextures => _allTextures;
-
-        private readonly List<AbstractIndexedTRTexture> _allTextures;
-
-        public AbstractTexturePacker()
-            : this(default) { }
-
-        public AbstractTexturePacker(L level, int maximumTiles = 16, ITextureClassifier classifier = null)
+        Options = new PackingOptions
         {
-            TileWidth = 256;
-            TileHeight = 256;
-            MaximumTiles = maximumTiles;
+            FillMode = PackingFillMode.Vertical,
+            OrderMode = PackingOrderMode.Height,
+            Order = PackingOrder.Descending,
+            GroupMode = PackingGroupMode.None,
+            StartMethod = PackingStartMethod.EndTile
+        };
 
-            Options = new PackingOptions
+        Level = level;
+        _levelClassifier = classifier == null ? string.Empty : classifier.GetClassification();
+
+        _allTextures = new List<AbstractIndexedTRTexture>();
+
+        if (Level != null)
+        {
+            _allTextures.AddRange(LoadObjectTextures());
+            _allTextures.AddRange(LoadSpriteTextures());
+            _allTextures.Sort(new TRTextureReverseAreaComparer());
+
+            for (int i = 0; i < NumLevelImages; i++)
             {
-                FillMode = PackingFillMode.Vertical,
-                OrderMode = PackingOrderMode.Height,
-                Order = PackingOrder.Descending,
-                GroupMode = PackingGroupMode.None,
-                StartMethod = PackingStartMethod.EndTile
-            };
+                TexturedTile tile = AddTile();
+                tile.BitmapGraphics = new BitmapGraphics(GetTile(i));
+                tile.AllowOverlapping = true; // Allow initially for the likes of Opera House - see tile 3 [128, 128]
+            }
 
-            Level = level;
-            _levelClassifier = classifier == null ? string.Empty : classifier.GetClassification();
-
-            _allTextures = new List<AbstractIndexedTRTexture>();
-
-            if (Level != null)
+            foreach (AbstractIndexedTRTexture texture in _allTextures)
             {
-                _allTextures.AddRange(LoadObjectTextures());
-                _allTextures.AddRange(LoadSpriteTextures());
-                _allTextures.Sort(new TRTextureReverseAreaComparer());
-
-                for (int i = 0; i < NumLevelImages; i++)
-                {
-                    TexturedTile tile = AddTile();
-                    tile.BitmapGraphics = new BitmapGraphics(GetTile(i));
-                    tile.AllowOverlapping = true; // Allow initially for the likes of Opera House - see tile 3 [128, 128]
-                }
-
-                foreach (AbstractIndexedTRTexture texture in _allTextures)
-                {
-                    _tiles[texture.Atlas].AddTexture(texture);
-                }
+                _tiles[texture.Atlas].AddTexture(texture);
             }
         }
+    }
 
-        public PackingResult<TexturedTile, TexturedTileSegment> Pack(bool commitToLevel)
+    public PackingResult<TexturedTile, TexturedTileSegment> Pack(bool commitToLevel)
+    {
+        try
         {
-            try
-            {
-                PackingResult<TexturedTile, TexturedTileSegment> result = Pack();
+            PackingResult<TexturedTile, TexturedTileSegment> result = Pack();
 
-                if (result.OrphanCount == 0 && commitToLevel)
-                {
-                    Commit();
-                    PostCommit();
-                }
-
-                return result;
-            }
-            catch (InvalidOperationException e)
+            if (result.OrphanCount == 0 && commitToLevel)
             {
-                throw new PackingException(e.Message, e);
+                Commit();
+                PostCommit();
             }
+
+            return result;
         }
-
-        protected abstract List<AbstractIndexedTRTexture> LoadObjectTextures();
-        protected abstract List<AbstractIndexedTRTexture> LoadSpriteTextures();
-
-        public Dictionary<TexturedTile, List<TexturedTileSegment>> GetModelSegments(E modelEntity)
+        catch (InvalidOperationException e)
         {
-            Dictionary<TexturedTile, List<TexturedTileSegment>> segmentMap = new Dictionary<TexturedTile, List<TexturedTileSegment>>();
-            TRMesh[] meshes = GetModelMeshes(modelEntity);
-            if (meshes != null)
-            {
-                IEnumerable<int> indices = GetMeshTextureIndices(meshes);
-                foreach (TexturedTile tile in _tiles)
-                {
-                    List<TexturedTileSegment> segments = tile.GetObjectTextureIndexSegments(indices);
-                    if (segments.Count > 0)
-                    {
-                        segmentMap[tile] = segments;
-                    }
-                }
-            }
-
-            return segmentMap;
+            throw new PackingException(e.Message, e);
         }
+    }
 
-        public Dictionary<TexturedTile, List<TexturedTileSegment>> GetObjectTextureSegments(IEnumerable<int> indices)
+    protected abstract List<AbstractIndexedTRTexture> LoadObjectTextures();
+    protected abstract List<AbstractIndexedTRTexture> LoadSpriteTextures();
+
+    public Dictionary<TexturedTile, List<TexturedTileSegment>> GetModelSegments(E modelEntity)
+    {
+        Dictionary<TexturedTile, List<TexturedTileSegment>> segmentMap = new Dictionary<TexturedTile, List<TexturedTileSegment>>();
+        TRMesh[] meshes = GetModelMeshes(modelEntity);
+        if (meshes != null)
         {
-            Dictionary<TexturedTile, List<TexturedTileSegment>> segmentMap = new Dictionary<TexturedTile, List<TexturedTileSegment>>();
+            IEnumerable<int> indices = GetMeshTextureIndices(meshes);
             foreach (TexturedTile tile in _tiles)
             {
                 List<TexturedTileSegment> segments = tile.GetObjectTextureIndexSegments(indices);
@@ -122,40 +106,40 @@ namespace TRModelTransporter.Packing
                     segmentMap[tile] = segments;
                 }
             }
-
-            return segmentMap;
         }
 
-        protected abstract TRMesh[] GetModelMeshes(E modelEntity);
+        return segmentMap;
+    }
 
-        public Dictionary<TexturedTile, List<TexturedTileSegment>> GetSpriteSegments(E entity)
+    public Dictionary<TexturedTile, List<TexturedTileSegment>> GetObjectTextureSegments(IEnumerable<int> indices)
+    {
+        Dictionary<TexturedTile, List<TexturedTileSegment>> segmentMap = new Dictionary<TexturedTile, List<TexturedTileSegment>>();
+        foreach (TexturedTile tile in _tiles)
         {
-            Dictionary<TexturedTile, List<TexturedTileSegment>> segmentMap = new Dictionary<TexturedTile, List<TexturedTileSegment>>();
-            TRSpriteSequence sequence = GetSpriteSequence(entity);
-            if (sequence != null)
+            List<TexturedTileSegment> segments = tile.GetObjectTextureIndexSegments(indices);
+            if (segments.Count > 0)
             {
-                List<int> indices = new List<int>();
-                for (int j = 0; j < sequence.NegativeLength * -1; j++)
-                {
-                    indices.Add(sequence.Offset + j);
-                }
+                segmentMap[tile] = segments;
+            }
+        }
 
-                foreach (TexturedTile tile in _tiles)
-                {
-                    List<TexturedTileSegment> segments = tile.GetSpriteTextureIndexSegments(indices);
-                    if (segments.Count > 0)
-                    {
-                        segmentMap[tile] = segments;
-                    }
-                }
+        return segmentMap;
+    }
+
+    protected abstract TRMesh[] GetModelMeshes(E modelEntity);
+
+    public Dictionary<TexturedTile, List<TexturedTileSegment>> GetSpriteSegments(E entity)
+    {
+        Dictionary<TexturedTile, List<TexturedTileSegment>> segmentMap = new Dictionary<TexturedTile, List<TexturedTileSegment>>();
+        TRSpriteSequence sequence = GetSpriteSequence(entity);
+        if (sequence != null)
+        {
+            List<int> indices = new List<int>();
+            for (int j = 0; j < sequence.NegativeLength * -1; j++)
+            {
+                indices.Add(sequence.Offset + j);
             }
 
-            return segmentMap;
-        }
-
-        public Dictionary<TexturedTile, List<TexturedTileSegment>> GetSpriteTextureSegments(IEnumerable<int> indices)
-        {
-            Dictionary<TexturedTile, List<TexturedTileSegment>> segmentMap = new Dictionary<TexturedTile, List<TexturedTileSegment>>();
             foreach (TexturedTile tile in _tiles)
             {
                 List<TexturedTileSegment> segments = tile.GetSpriteTextureIndexSegments(indices);
@@ -164,209 +148,224 @@ namespace TRModelTransporter.Packing
                     segmentMap[tile] = segments;
                 }
             }
-
-            return segmentMap;
         }
 
-        protected abstract TRSpriteSequence GetSpriteSequence(E entity);
+        return segmentMap;
+    }
 
-        protected IEnumerable<int> GetMeshTextureIndices(TRMesh[] meshes)
+    public Dictionary<TexturedTile, List<TexturedTileSegment>> GetSpriteTextureSegments(IEnumerable<int> indices)
+    {
+        Dictionary<TexturedTile, List<TexturedTileSegment>> segmentMap = new Dictionary<TexturedTile, List<TexturedTileSegment>>();
+        foreach (TexturedTile tile in _tiles)
         {
-            ISet<int> textureIndices = new SortedSet<int>();
-            foreach (TRMesh mesh in meshes)
+            List<TexturedTileSegment> segments = tile.GetSpriteTextureIndexSegments(indices);
+            if (segments.Count > 0)
             {
-                foreach (TRFace4 rect in mesh.TexturedRectangles)
-                {
-                    textureIndices.Add(rect.Texture);
-                }
-                foreach (TRFace3 tri in mesh.TexturedTriangles)
-                {
-                    textureIndices.Add(tri.Texture);
-                }
-            }
-            return textureIndices;
-        }
-
-        public void RemoveModelSegments(IEnumerable<E> modelEntitiesToRemove, AbstractTextureRemapGroup<E, L> remapGroup)
-        {
-            if (remapGroup == null)
-            {
-                RemoveModelSegmentsChecked(modelEntitiesToRemove);
-                return;
-            }
-
-            // TextureRemapGroup will have been precompiled to determine shared textures between entities, so we know
-            // in advance which we cannot remove.
-            foreach (E modelEntity in modelEntitiesToRemove)
-            {
-                Dictionary<TexturedTile, List<TexturedTileSegment>> modelSegments = GetModelSegments(modelEntity);
-                foreach (TexturedTile tile in modelSegments.Keys)
-                {
-                    List<TexturedTileSegment> segments = modelSegments[tile];
-                    for (int i = 0; i < segments.Count; i++)
-                    {
-                        TexturedTileSegment segment = segments[i];
-                        if (remapGroup.CanRemoveRectangle(tile.Index, segment.Bounds, modelEntitiesToRemove))
-                        {
-                            tile.Remove(segment);
-                        }
-                    }
-                }
+                segmentMap[tile] = segments;
             }
         }
 
-        public void RemoveObjectTextureSegments(IEnumerable<int> indices)
+        return segmentMap;
+    }
+
+    protected abstract TRSpriteSequence GetSpriteSequence(E entity);
+
+    protected IEnumerable<int> GetMeshTextureIndices(TRMesh[] meshes)
+    {
+        ISet<int> textureIndices = new SortedSet<int>();
+        foreach (TRMesh mesh in meshes)
         {
-            foreach (TexturedTile tile in _tiles)
+            foreach (TRFace4 rect in mesh.TexturedRectangles)
             {
-                List<TexturedTileSegment> segments = tile.GetObjectTextureIndexSegments(indices);
+                textureIndices.Add(rect.Texture);
+            }
+            foreach (TRFace3 tri in mesh.TexturedTriangles)
+            {
+                textureIndices.Add(tri.Texture);
+            }
+        }
+        return textureIndices;
+    }
+
+    public void RemoveModelSegments(IEnumerable<E> modelEntitiesToRemove, AbstractTextureRemapGroup<E, L> remapGroup)
+    {
+        if (remapGroup == null)
+        {
+            RemoveModelSegmentsChecked(modelEntitiesToRemove);
+            return;
+        }
+
+        // TextureRemapGroup will have been precompiled to determine shared textures between entities, so we know
+        // in advance which we cannot remove.
+        foreach (E modelEntity in modelEntitiesToRemove)
+        {
+            Dictionary<TexturedTile, List<TexturedTileSegment>> modelSegments = GetModelSegments(modelEntity);
+            foreach (TexturedTile tile in modelSegments.Keys)
+            {
+                List<TexturedTileSegment> segments = modelSegments[tile];
                 for (int i = 0; i < segments.Count; i++)
                 {
-                    tile.Remove(segments[i]);
-                }
-            }
-        }
-
-        public void RemoveSpriteTextureSegments(IEnumerable<int> indices)
-        {
-            foreach (TexturedTile tile in _tiles)
-            {
-                List<TexturedTileSegment> segments = tile.GetSpriteTextureIndexSegments(indices);
-                for (int i = 0; i < segments.Count; i++)
-                {
-                    tile.Remove(segments[i]);
-                }
-            }
-        }
-
-        public void RemoveModelSegmentsChecked(IEnumerable<E> modelEntitiesToRemove)
-        {
-            if (modelEntitiesToRemove.Count() == 0)
-            {
-                return;
-            }
-
-            // Perform an exhaustive check against every other model in the level to find shared textures.
-
-            Dictionary<E, Dictionary<TexturedTile, List<TexturedTileSegment>>> candidateSegments = new Dictionary<E, Dictionary<TexturedTile, List<TexturedTileSegment>>>();
-
-            // First cache each segment for the models we wish to remove
-            foreach (E modelEntity in modelEntitiesToRemove)
-            {
-                candidateSegments[modelEntity] = GetModelSegments(modelEntity);
-            }
-
-            // Load the segments for every other model in the level. For each, scan the segments of
-            // the removal candidates. If any is used by any other model, the segment is no longer
-            // a candidate. If the other model that shares it is in the list to remove, it will
-            // remain a candidate.
-            foreach (E otherEntity in GetAllModelTypes())
-            {
-                if (modelEntitiesToRemove.Contains(otherEntity))
-                {
-                    continue;
-                }
-
-                Dictionary<TexturedTile, List<TexturedTileSegment>> modelSegments = GetModelSegments(otherEntity);
-                foreach (E entityToRemove in modelEntitiesToRemove)
-                {
-                    Dictionary<TexturedTile, List<TexturedTileSegment>> entityMap = candidateSegments[entityToRemove];
-                    foreach (TexturedTile tile in entityMap.Keys)
-                    {
-                        if (modelSegments.ContainsKey(tile))
-                        {
-                            int match = entityMap[tile].FindIndex(s1 => modelSegments[tile].Any(s2 => s1 == s2));
-                            if (match != -1)
-                            {
-                                entityMap[tile].RemoveAt(match);
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Tell each tile to remove the candidate segments
-            foreach (Dictionary<TexturedTile, List<TexturedTileSegment>> segmentMap in candidateSegments.Values)
-            {
-                foreach (TexturedTile tile in segmentMap.Keys)
-                {
-                    foreach (TexturedTileSegment segment in segmentMap[tile])
+                    TexturedTileSegment segment = segments[i];
+                    if (remapGroup.CanRemoveRectangle(tile.Index, segment.Bounds, modelEntitiesToRemove))
                     {
                         tile.Remove(segment);
                     }
                 }
             }
         }
+    }
 
-        protected abstract IEnumerable<E> GetAllModelTypes();
-
-        public void RemoveSpriteSegments(E entity)
+    public void RemoveObjectTextureSegments(IEnumerable<int> indices)
+    {
+        foreach (TexturedTile tile in _tiles)
         {
-            RemoveSpriteSegments(new E[] { entity });
+            List<TexturedTileSegment> segments = tile.GetObjectTextureIndexSegments(indices);
+            for (int i = 0; i < segments.Count; i++)
+            {
+                tile.Remove(segments[i]);
+            }
+        }
+    }
+
+    public void RemoveSpriteTextureSegments(IEnumerable<int> indices)
+    {
+        foreach (TexturedTile tile in _tiles)
+        {
+            List<TexturedTileSegment> segments = tile.GetSpriteTextureIndexSegments(indices);
+            for (int i = 0; i < segments.Count; i++)
+            {
+                tile.Remove(segments[i]);
+            }
+        }
+    }
+
+    public void RemoveModelSegmentsChecked(IEnumerable<E> modelEntitiesToRemove)
+    {
+        if (modelEntitiesToRemove.Count() == 0)
+        {
+            return;
         }
 
-        public void RemoveSpriteSegments(IEnumerable<E> entitiesToRemove)
-        {
-            Dictionary<E, Dictionary<TexturedTile, List<TexturedTileSegment>>> candidateSegments = new Dictionary<E, Dictionary<TexturedTile, List<TexturedTileSegment>>>();
+        // Perform an exhaustive check against every other model in the level to find shared textures.
 
-            // First cache each segment for the models we wish to remove
-            foreach (E entity in entitiesToRemove)
+        Dictionary<E, Dictionary<TexturedTile, List<TexturedTileSegment>>> candidateSegments = new Dictionary<E, Dictionary<TexturedTile, List<TexturedTileSegment>>>();
+
+        // First cache each segment for the models we wish to remove
+        foreach (E modelEntity in modelEntitiesToRemove)
+        {
+            candidateSegments[modelEntity] = GetModelSegments(modelEntity);
+        }
+
+        // Load the segments for every other model in the level. For each, scan the segments of
+        // the removal candidates. If any is used by any other model, the segment is no longer
+        // a candidate. If the other model that shares it is in the list to remove, it will
+        // remain a candidate.
+        foreach (E otherEntity in GetAllModelTypes())
+        {
+            if (modelEntitiesToRemove.Contains(otherEntity))
             {
-                candidateSegments[entity] = GetSpriteSegments(entity);
+                continue;
             }
 
-            // Tell each tile to remove the candidate segments
-            foreach (Dictionary<TexturedTile, List<TexturedTileSegment>> segmentMap in candidateSegments.Values)
+            Dictionary<TexturedTile, List<TexturedTileSegment>> modelSegments = GetModelSegments(otherEntity);
+            foreach (E entityToRemove in modelEntitiesToRemove)
             {
-                foreach (TexturedTile tile in segmentMap.Keys)
+                Dictionary<TexturedTile, List<TexturedTileSegment>> entityMap = candidateSegments[entityToRemove];
+                foreach (TexturedTile tile in entityMap.Keys)
                 {
-                    foreach (TexturedTileSegment segment in segmentMap[tile])
+                    if (modelSegments.ContainsKey(tile))
                     {
-                        tile.Remove(segment);
+                        int match = entityMap[tile].FindIndex(s1 => modelSegments[tile].Any(s2 => s1 == s2));
+                        if (match != -1)
+                        {
+                            entityMap[tile].RemoveAt(match);
+                        }
                     }
                 }
             }
         }
 
-        public abstract Bitmap GetTile(int tileIndex);
-
-        protected abstract void CreateImageSpace(uint count);
-
-        public abstract void SetTile(int tileIndex, Bitmap bitmap);
-
-        private void Commit()
+        // Tell each tile to remove the candidate segments
+        foreach (Dictionary<TexturedTile, List<TexturedTileSegment>> segmentMap in candidateSegments.Values)
         {
-            if (_tiles.Count > NumLevelImages)
+            foreach (TexturedTile tile in segmentMap.Keys)
             {
-                CreateImageSpace((uint)_tiles.Count - NumLevelImages);
-            }
-
-            for (int i = 0; i < _tiles.Count; i++)
-            {
-                TexturedTile tile = _tiles[i];
-                if (!tile.BitmapChanged)
+                foreach (TexturedTileSegment segment in segmentMap[tile])
                 {
-                    continue;
+                    tile.Remove(segment);
                 }
-
-                tile.Commit();
-                SetTile(i, tile.BitmapGraphics.Bitmap);
             }
         }
+    }
 
-        protected virtual void PostCommit() { }
+    protected abstract IEnumerable<E> GetAllModelTypes();
 
-        public void Dispose()
+    public void RemoveSpriteSegments(E entity)
+    {
+        RemoveSpriteSegments(new E[] { entity });
+    }
+
+    public void RemoveSpriteSegments(IEnumerable<E> entitiesToRemove)
+    {
+        Dictionary<E, Dictionary<TexturedTile, List<TexturedTileSegment>>> candidateSegments = new Dictionary<E, Dictionary<TexturedTile, List<TexturedTileSegment>>>();
+
+        // First cache each segment for the models we wish to remove
+        foreach (E entity in entitiesToRemove)
         {
-            foreach (TexturedTile tile in _tiles)
+            candidateSegments[entity] = GetSpriteSegments(entity);
+        }
+
+        // Tell each tile to remove the candidate segments
+        foreach (Dictionary<TexturedTile, List<TexturedTileSegment>> segmentMap in candidateSegments.Values)
+        {
+            foreach (TexturedTile tile in segmentMap.Keys)
             {
-                tile.Dispose();
+                foreach (TexturedTileSegment segment in segmentMap[tile])
+                {
+                    tile.Remove(segment);
+                }
             }
         }
+    }
 
-        protected override TexturedTile CreateTile()
+    public abstract Bitmap GetTile(int tileIndex);
+
+    protected abstract void CreateImageSpace(uint count);
+
+    public abstract void SetTile(int tileIndex, Bitmap bitmap);
+
+    private void Commit()
+    {
+        if (_tiles.Count > NumLevelImages)
         {
-            return new TexturedTile();
+            CreateImageSpace((uint)_tiles.Count - NumLevelImages);
         }
+
+        for (int i = 0; i < _tiles.Count; i++)
+        {
+            TexturedTile tile = _tiles[i];
+            if (!tile.BitmapChanged)
+            {
+                continue;
+            }
+
+            tile.Commit();
+            SetTile(i, tile.BitmapGraphics.Bitmap);
+        }
+    }
+
+    protected virtual void PostCommit() { }
+
+    public void Dispose()
+    {
+        foreach (TexturedTile tile in _tiles)
+        {
+            tile.Dispose();
+        }
+    }
+
+    protected override TexturedTile CreateTile()
+    {
+        return new TexturedTile();
     }
 }

--- a/TRModelTransporter/Packing/DefaultTexturePacker.cs
+++ b/TRModelTransporter/Packing/DefaultTexturePacker.cs
@@ -4,43 +4,42 @@ using System;
 using System.Collections.Generic;
 using TRModelTransporter.Model.Textures;
 
-namespace TRModelTransporter.Packing
+namespace TRModelTransporter.Packing;
+
+public class DefaultTexturePacker : AbstractPacker<TexturedTile, TexturedTileSegment>, IDisposable
 {
-    public class DefaultTexturePacker : AbstractPacker<TexturedTile, TexturedTileSegment>, IDisposable
+    public IReadOnlyList<AbstractIndexedTRTexture> AllTextures => _allTextures;
+
+    private readonly List<AbstractIndexedTRTexture> _allTextures;
+
+    public DefaultTexturePacker()
     {
-        public IReadOnlyList<AbstractIndexedTRTexture> AllTextures => _allTextures;
+        TileWidth = 256;
+        TileHeight = 256;
+        MaximumTiles = 16;
 
-        private readonly List<AbstractIndexedTRTexture> _allTextures;
-
-        public DefaultTexturePacker()
+        Options = new PackingOptions
         {
-            TileWidth = 256;
-            TileHeight = 256;
-            MaximumTiles = 16;
+            FillMode = PackingFillMode.Vertical,
+            OrderMode = PackingOrderMode.Height,
+            Order = PackingOrder.Descending,
+            GroupMode = PackingGroupMode.None,
+            StartMethod = PackingStartMethod.EndTile
+        };
 
-            Options = new PackingOptions
-            {
-                FillMode = PackingFillMode.Vertical,
-                OrderMode = PackingOrderMode.Height,
-                Order = PackingOrder.Descending,
-                GroupMode = PackingGroupMode.None,
-                StartMethod = PackingStartMethod.EndTile
-            };
+        _allTextures = new List<AbstractIndexedTRTexture>();
+    }
 
-            _allTextures = new List<AbstractIndexedTRTexture>();
-        }
-
-        public void Dispose()
+    public void Dispose()
+    {
+        foreach (TexturedTile tile in _tiles)
         {
-            foreach (TexturedTile tile in _tiles)
-            {
-                tile.Dispose();
-            }
+            tile.Dispose();
         }
+    }
 
-        protected override TexturedTile CreateTile()
-        {
-            return new TexturedTile();
-        }
+    protected override TexturedTile CreateTile()
+    {
+        return new TexturedTile();
     }
 }

--- a/TRModelTransporter/Packing/DefaultTexturePacker.cs
+++ b/TRModelTransporter/Packing/DefaultTexturePacker.cs
@@ -34,6 +34,7 @@ public class DefaultTexturePacker : AbstractPacker<TexturedTile, TexturedTileSeg
         {
             tile.Dispose();
         }
+        GC.SuppressFinalize(this);
     }
 
     protected override TexturedTile CreateTile()

--- a/TRModelTransporter/Packing/DefaultTexturePacker.cs
+++ b/TRModelTransporter/Packing/DefaultTexturePacker.cs
@@ -1,7 +1,5 @@
 ﻿using RectanglePacker;
 using RectanglePacker.Organisation;
-using System;
-using System.Collections.Generic;
 using TRModelTransporter.Model.Textures;
 
 namespace TRModelTransporter.Packing;

--- a/TRModelTransporter/Packing/PackingException.cs
+++ b/TRModelTransporter/Packing/PackingException.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace TRModelTransporter.Packing;
+﻿namespace TRModelTransporter.Packing;
 
 public class PackingException : Exception
 {

--- a/TRModelTransporter/Packing/PackingException.cs
+++ b/TRModelTransporter/Packing/PackingException.cs
@@ -1,16 +1,15 @@
 ﻿using System;
 
-namespace TRModelTransporter.Packing
+namespace TRModelTransporter.Packing;
+
+public class PackingException : Exception
 {
-    public class PackingException : Exception
-    {
-        public PackingException()
-            : base() { }
+    public PackingException()
+        : base() { }
 
-        public PackingException(string message)
-            : base(message) { }
+    public PackingException(string message)
+        : base(message) { }
 
-        public PackingException(string message, Exception innerException)
-            : base(message, innerException) { }
-    }
+    public PackingException(string message, Exception innerException)
+        : base(message, innerException) { }
 }

--- a/TRModelTransporter/Packing/TexturedTile.cs
+++ b/TRModelTransporter/Packing/TexturedTile.cs
@@ -147,10 +147,7 @@ public class TexturedTile : DefaultTile<TexturedTileSegment>, IDisposable
 
     public void Dispose()
     {
-        if (BitmapGraphics != null)
-        {
-            BitmapGraphics.Dispose();
-        }
+        BitmapGraphics?.Dispose();
 
         foreach (TexturedTileSegment segment in _rectangles)
         {

--- a/TRModelTransporter/Packing/TexturedTile.cs
+++ b/TRModelTransporter/Packing/TexturedTile.cs
@@ -1,6 +1,4 @@
 ﻿using RectanglePacker.Defaults;
-using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
 using TRModelTransporter.Model.Textures;

--- a/TRModelTransporter/Packing/TexturedTile.cs
+++ b/TRModelTransporter/Packing/TexturedTile.cs
@@ -139,10 +139,7 @@ public class TexturedTile : DefaultTile<TexturedTileSegment>, IDisposable
 
     private void CheckBitmapStatus()
     {
-        if (BitmapGraphics == null)
-        {
-            BitmapGraphics = new BitmapGraphics(new Bitmap(Width, Height, PixelFormat.Format32bppArgb));
-        }
+        BitmapGraphics ??= new(new Bitmap(Width, Height, PixelFormat.Format32bppArgb));
     }
 
     public void Dispose()

--- a/TRModelTransporter/Packing/TexturedTile.cs
+++ b/TRModelTransporter/Packing/TexturedTile.cs
@@ -6,158 +6,157 @@ using System.Drawing.Imaging;
 using TRModelTransporter.Model.Textures;
 using TRTexture16Importer.Helpers;
 
-namespace TRModelTransporter.Packing
+namespace TRModelTransporter.Packing;
+
+public class TexturedTile : DefaultTile<TexturedTileSegment>, IDisposable
 {
-    public class TexturedTile : DefaultTile<TexturedTileSegment>, IDisposable
+    private BitmapGraphics _graphics;
+    public BitmapGraphics BitmapGraphics
     {
-        private BitmapGraphics _graphics;
-        public BitmapGraphics BitmapGraphics
+        get => _graphics;
+        set
         {
-            get => _graphics;
-            set
+            _graphics = value;
+            // Listen to on-the-fly bitmap changes
+            _graphics.GraphicChanged += (object sender, EventArgs e) =>
             {
-                _graphics = value;
-                // Listen to on-the-fly bitmap changes
-                _graphics.GraphicChanged += (object sender, EventArgs e) =>
-                {
-                    _graphicChanged = true;
-                };
+                _graphicChanged = true;
+            };
+        }
+    }
+
+    // Some room textures in Opera House (at least) overlap, so we need to 
+    // allow this when initialising the tiles.
+    public bool AllowOverlapping
+    {
+        get => _allowOverlapping;
+        set => _allowOverlapping = value;
+    }
+
+    public bool BitmapChanged => _segmentAdded || _segmentRemoved || _graphicChanged;
+    private bool _segmentAdded, _segmentRemoved, _graphicChanged;
+
+    public TexturedTile()
+    {
+        _segmentAdded = _segmentRemoved = _graphicChanged = false;
+    }
+
+    public void AddTexture(AbstractIndexedTRTexture texture)
+    {
+        foreach (TexturedTileSegment segment in Rectangles)
+        {
+            if (segment.Bounds.Contains(texture.Bounds))
+            {
+                // If so, just map the texture to the same segment
+                segment.AddTexture(texture);
+                return;
             }
         }
 
-        // Some room textures in Opera House (at least) overlap, so we need to 
-        // allow this when initialising the tiles.
-        public bool AllowOverlapping
-        {
-            get => _allowOverlapping;
-            set => _allowOverlapping = value;
-        }
+        // Otherwise, make a new segment
+        TexturedTileSegment newSegment = new TexturedTileSegment(texture, BitmapGraphics.Extract(texture.Bounds));
+        base.Add(newSegment, texture.Bounds.X, texture.Bounds.Y);
+    }
 
-        public bool BitmapChanged => _segmentAdded || _segmentRemoved || _graphicChanged;
-        private bool _segmentAdded, _segmentRemoved, _graphicChanged;
-
-        public TexturedTile()
-        {
-            _segmentAdded = _segmentRemoved = _graphicChanged = false;
-        }
-
-        public void AddTexture(AbstractIndexedTRTexture texture)
+    public List<TexturedTileSegment> GetObjectTextureIndexSegments(IEnumerable<int> indices)
+    {
+        List<TexturedTileSegment> segments = new List<TexturedTileSegment>();
+        foreach (int index in indices)
         {
             foreach (TexturedTileSegment segment in Rectangles)
             {
-                if (segment.Bounds.Contains(texture.Bounds))
+                if (segment.IsObjectTextureFor(index) && !segments.Contains(segment))
                 {
-                    // If so, just map the texture to the same segment
-                    segment.AddTexture(texture);
-                    return;
+                    segments.Add(segment);
                 }
             }
-
-            // Otherwise, make a new segment
-            TexturedTileSegment newSegment = new TexturedTileSegment(texture, BitmapGraphics.Extract(texture.Bounds));
-            base.Add(newSegment, texture.Bounds.X, texture.Bounds.Y);
         }
+        return segments;
+    }
 
-        public List<TexturedTileSegment> GetObjectTextureIndexSegments(IEnumerable<int> indices)
-        {
-            List<TexturedTileSegment> segments = new List<TexturedTileSegment>();
-            foreach (int index in indices)
-            {
-                foreach (TexturedTileSegment segment in Rectangles)
-                {
-                    if (segment.IsObjectTextureFor(index) && !segments.Contains(segment))
-                    {
-                        segments.Add(segment);
-                    }
-                }
-            }
-            return segments;
-        }
-
-        public List<TexturedTileSegment> GetSpriteTextureIndexSegments(IEnumerable<int> indices)
-        {
-            List<TexturedTileSegment> segments = new List<TexturedTileSegment>();
-            foreach (int index in indices)
-            {
-                foreach (TexturedTileSegment segment in Rectangles)
-                {
-                    if (segment.IsSpriteTextureFor(index) && !segments.Contains(segment))
-                    {
-                        segments.Add(segment);
-                    }
-                }
-            }
-            return segments;
-        }
-
-        public void Commit()
+    public List<TexturedTileSegment> GetSpriteTextureIndexSegments(IEnumerable<int> indices)
+    {
+        List<TexturedTileSegment> segments = new List<TexturedTileSegment>();
+        foreach (int index in indices)
         {
             foreach (TexturedTileSegment segment in Rectangles)
             {
-                segment.Commit(Index);
+                if (segment.IsSpriteTextureFor(index) && !segments.Contains(segment))
+                {
+                    segments.Add(segment);
+                }
             }
         }
+        return segments;
+    }
 
-        protected override bool Add(TexturedTileSegment segment, int x, int y)
+    public void Commit()
+    {
+        foreach (TexturedTileSegment segment in Rectangles)
         {
-            bool added = base.Add(segment, x, y);
-            if (added)
-            {
-                CheckBitmapStatus();
-                BitmapGraphics.Import(segment.Bitmap, segment.MappedBounds);
+            segment.Commit(Index);
+        }
+    }
 
-                segment.Bind();
-                _segmentAdded = true;
-            }
-            return added;
+    protected override bool Add(TexturedTileSegment segment, int x, int y)
+    {
+        bool added = base.Add(segment, x, y);
+        if (added)
+        {
+            CheckBitmapStatus();
+            BitmapGraphics.Import(segment.Bitmap, segment.MappedBounds);
+
+            segment.Bind();
+            _segmentAdded = true;
+        }
+        return added;
+    }
+
+    public override bool Remove(TexturedTileSegment segment)
+    {
+        bool removed = base.Remove(segment);
+        if (removed)
+        {
+            CheckBitmapStatus();
+            BitmapGraphics.Delete(segment.Bounds);
+            segment.Unbind();
+            _segmentRemoved = true;
+        }
+        return removed;
+    }
+
+    public override void PackingStarted()
+    {
+        // No overlapping during actual packing
+        AllowOverlapping = false;
+
+        // Only if a segment has been removed prior to packing having
+        // started do we keep a hold of that fact. This prevents the
+        // bitmap being saved back to the level if it's unchanged.
+        if (!_segmentRemoved)
+        {
+            _segmentAdded = _segmentRemoved = false;
+        }
+    }
+
+    private void CheckBitmapStatus()
+    {
+        if (BitmapGraphics == null)
+        {
+            BitmapGraphics = new BitmapGraphics(new Bitmap(Width, Height, PixelFormat.Format32bppArgb));
+        }
+    }
+
+    public void Dispose()
+    {
+        if (BitmapGraphics != null)
+        {
+            BitmapGraphics.Dispose();
         }
 
-        public override bool Remove(TexturedTileSegment segment)
+        foreach (TexturedTileSegment segment in _rectangles)
         {
-            bool removed = base.Remove(segment);
-            if (removed)
-            {
-                CheckBitmapStatus();
-                BitmapGraphics.Delete(segment.Bounds);
-                segment.Unbind();
-                _segmentRemoved = true;
-            }
-            return removed;
-        }
-
-        public override void PackingStarted()
-        {
-            // No overlapping during actual packing
-            AllowOverlapping = false;
-
-            // Only if a segment has been removed prior to packing having
-            // started do we keep a hold of that fact. This prevents the
-            // bitmap being saved back to the level if it's unchanged.
-            if (!_segmentRemoved)
-            {
-                _segmentAdded = _segmentRemoved = false;
-            }
-        }
-
-        private void CheckBitmapStatus()
-        {
-            if (BitmapGraphics == null)
-            {
-                BitmapGraphics = new BitmapGraphics(new Bitmap(Width, Height, PixelFormat.Format32bppArgb));
-            }
-        }
-
-        public void Dispose()
-        {
-            if (BitmapGraphics != null)
-            {
-                BitmapGraphics.Dispose();
-            }
-
-            foreach (TexturedTileSegment segment in _rectangles)
-            {
-                segment.Dispose();
-            }
+            segment.Dispose();
         }
     }
 }

--- a/TRModelTransporter/Packing/TexturedTile.cs
+++ b/TRModelTransporter/Packing/TexturedTile.cs
@@ -52,13 +52,13 @@ public class TexturedTile : DefaultTile<TexturedTileSegment>, IDisposable
         }
 
         // Otherwise, make a new segment
-        TexturedTileSegment newSegment = new TexturedTileSegment(texture, BitmapGraphics.Extract(texture.Bounds));
+        TexturedTileSegment newSegment = new(texture, BitmapGraphics.Extract(texture.Bounds));
         base.Add(newSegment, texture.Bounds.X, texture.Bounds.Y);
     }
 
     public List<TexturedTileSegment> GetObjectTextureIndexSegments(IEnumerable<int> indices)
     {
-        List<TexturedTileSegment> segments = new List<TexturedTileSegment>();
+        List<TexturedTileSegment> segments = new();
         foreach (int index in indices)
         {
             foreach (TexturedTileSegment segment in Rectangles)
@@ -74,7 +74,7 @@ public class TexturedTile : DefaultTile<TexturedTileSegment>, IDisposable
 
     public List<TexturedTileSegment> GetSpriteTextureIndexSegments(IEnumerable<int> indices)
     {
-        List<TexturedTileSegment> segments = new List<TexturedTileSegment>();
+        List<TexturedTileSegment> segments = new();
         foreach (int index in indices)
         {
             foreach (TexturedTileSegment segment in Rectangles)

--- a/TRModelTransporter/Packing/TexturedTile.cs
+++ b/TRModelTransporter/Packing/TexturedTile.cs
@@ -153,5 +153,6 @@ public class TexturedTile : DefaultTile<TexturedTileSegment>, IDisposable
         {
             segment.Dispose();
         }
+        GC.SuppressFinalize(this);
     }
 }

--- a/TRModelTransporter/Packing/TexturedTileSegment.cs
+++ b/TRModelTransporter/Packing/TexturedTileSegment.cs
@@ -134,10 +134,7 @@ public class TexturedTileSegment : DefaultRectangle, IDisposable
 
     public void Dispose()
     {
-        if (Bitmap != null)
-        {
-            Bitmap.Dispose();
-        }
+        Bitmap?.Dispose();
     }
 
     public TexturedTileSegment Clone()

--- a/TRModelTransporter/Packing/TexturedTileSegment.cs
+++ b/TRModelTransporter/Packing/TexturedTileSegment.cs
@@ -142,7 +142,7 @@ public class TexturedTileSegment : DefaultRectangle, IDisposable
 
     public TexturedTileSegment Clone()
     {
-        TexturedTileSegment copy = new TexturedTileSegment(FirstTexture.Clone(), (Bitmap)Bitmap.Clone());
+        TexturedTileSegment copy = new(FirstTexture.Clone(), (Bitmap)Bitmap.Clone());
         for (int i = 1; i < Textures.Count; i++)
         {
             copy.AddTexture(Textures[i].Clone());

--- a/TRModelTransporter/Packing/TexturedTileSegment.cs
+++ b/TRModelTransporter/Packing/TexturedTileSegment.cs
@@ -135,6 +135,7 @@ public class TexturedTileSegment : DefaultRectangle, IDisposable
     public void Dispose()
     {
         Bitmap?.Dispose();
+        GC.SuppressFinalize(this);
     }
 
     public TexturedTileSegment Clone()

--- a/TRModelTransporter/Packing/TexturedTileSegment.cs
+++ b/TRModelTransporter/Packing/TexturedTileSegment.cs
@@ -4,152 +4,151 @@ using System.Collections.Generic;
 using System.Drawing;
 using TRModelTransporter.Model.Textures;
 
-namespace TRModelTransporter.Packing
+namespace TRModelTransporter.Packing;
+
+public class TexturedTileSegment : DefaultRectangle, IDisposable
 {
-    public class TexturedTileSegment : DefaultRectangle, IDisposable
+    public Bitmap Bitmap { get; private set; }
+    public List<AbstractIndexedTRTexture> Textures { get; private set; }
+    public AbstractIndexedTRTexture FirstTexture => Textures[0];
+    public int FirstTextureIndex => FirstTexture.Index;
+    public string FirstClassification => FirstTexture.Classification;
+
+    public TexturedTileSegment(AbstractIndexedTRTexture initialTexture, Bitmap bitmap)
+        : base(initialTexture.Bounds)
     {
-        public Bitmap Bitmap { get; private set; }
-        public List<AbstractIndexedTRTexture> Textures { get; private set; }
-        public AbstractIndexedTRTexture FirstTexture => Textures[0];
-        public int FirstTextureIndex => FirstTexture.Index;
-        public string FirstClassification => FirstTexture.Classification;
+        Bitmap = bitmap;
+        Textures = new List<AbstractIndexedTRTexture>();
+        AddTexture(initialTexture);
+    }
 
-        public TexturedTileSegment(AbstractIndexedTRTexture initialTexture, Bitmap bitmap)
-            : base(initialTexture.Bounds)
+    public void AddTexture(AbstractIndexedTRTexture texture)
+    {
+        Textures.Add(texture);
+    }
+
+    public bool IsObjectTextureFor(int textureIndex)
+    {
+        if (Textures.Count == 0 || Textures[0] is IndexedTRSpriteTexture)
         {
-            Bitmap = bitmap;
-            Textures = new List<AbstractIndexedTRTexture>();
-            AddTexture(initialTexture);
+            return false;
         }
+        return IsFor(textureIndex);
+    }
 
-        public void AddTexture(AbstractIndexedTRTexture texture)
+    public bool IsSpriteTextureFor(int textureIndex)
+    {
+        if (Textures.Count == 0 || Textures[0] is IndexedTRObjectTexture)
         {
-            Textures.Add(texture);
+            return false;
         }
+        return IsFor(textureIndex);
+    }
 
-        public bool IsObjectTextureFor(int textureIndex)
+    private bool IsFor(int textureIndex)
+    {
+        return GetTexture(textureIndex) != null;
+    }
+
+    public AbstractIndexedTRTexture GetTexture(int textureIndex)
+    {
+        for (int i = 0; i < Textures.Count; i++)
         {
-            if (Textures.Count == 0 || Textures[0] is IndexedTRSpriteTexture)
+            AbstractIndexedTRTexture texture = Textures[i];
+            if (texture.Index == textureIndex)
             {
-                return false;
-            }
-            return IsFor(textureIndex);
-        }
-
-        public bool IsSpriteTextureFor(int textureIndex)
-        {
-            if (Textures.Count == 0 || Textures[0] is IndexedTRObjectTexture)
-            {
-                return false;
-            }
-            return IsFor(textureIndex);
-        }
-
-        private bool IsFor(int textureIndex)
-        {
-            return GetTexture(textureIndex) != null;
-        }
-
-        public AbstractIndexedTRTexture GetTexture(int textureIndex)
-        {
-            for (int i = 0; i < Textures.Count; i++)
-            {
-                AbstractIndexedTRTexture texture = Textures[i];
-                if (texture.Index == textureIndex)
-                {
-                    return texture;
-                }
-            }
-            return null;
-        }
-
-        // Triggered when successfully mapped onto a tile, so inform
-        // the indexed textures to update their vertices.
-        public void Bind()
-        {
-            MoveTo(MappedX, MappedY);
-        }
-
-        public void MoveTo(Point p, int tileIndex = -1)
-        {
-            MoveTo(p.X, p.Y, tileIndex);
-        }
-
-        public void InheritTextures(TexturedTileSegment otherSegment, Point p, int tileIndex)
-        {
-            // Get the old segment first to reposition its children
-            otherSegment.MoveTo(p, tileIndex);
-
-            // Copy all textures from the old segment into this
-            Textures.AddRange(otherSegment.Textures);
-
-            // Clear the other's list of segments, effectively nullifying it
-            otherSegment.Textures.Clear();
-        }
-
-        // We work out the difference in x/y values here and pass these 
-        // to the child areas to allow them to calculate where they
-        // need to be.
-        public void MoveTo(int x, int y, int tileIndex = -1)
-        {
-            int xDiff = Math.Abs(Bounds.X - x);
-            int yDiff = Math.Abs(Bounds.Y - y);
-
-            if (x < Bounds.X)
-            {
-                xDiff *= -1;
-            }
-            if (y < Bounds.Y)
-            {
-                yDiff *= -1;
-            }
-
-            foreach (AbstractIndexedTRTexture texture in Textures)
-            {
-                texture.MoveBy(xDiff, yDiff);
-                if (tileIndex != -1)
-                {
-                    texture.Commit(tileIndex);
-                }
+                return texture;
             }
         }
+        return null;
+    }
 
-        // Triggered when removed from a tile, so inform
-        // the indexed textures to invalidate themselves.
-        public void Unbind()
+    // Triggered when successfully mapped onto a tile, so inform
+    // the indexed textures to update their vertices.
+    public void Bind()
+    {
+        MoveTo(MappedX, MappedY);
+    }
+
+    public void MoveTo(Point p, int tileIndex = -1)
+    {
+        MoveTo(p.X, p.Y, tileIndex);
+    }
+
+    public void InheritTextures(TexturedTileSegment otherSegment, Point p, int tileIndex)
+    {
+        // Get the old segment first to reposition its children
+        otherSegment.MoveTo(p, tileIndex);
+
+        // Copy all textures from the old segment into this
+        Textures.AddRange(otherSegment.Textures);
+
+        // Clear the other's list of segments, effectively nullifying it
+        otherSegment.Textures.Clear();
+    }
+
+    // We work out the difference in x/y values here and pass these 
+    // to the child areas to allow them to calculate where they
+    // need to be.
+    public void MoveTo(int x, int y, int tileIndex = -1)
+    {
+        int xDiff = Math.Abs(Bounds.X - x);
+        int yDiff = Math.Abs(Bounds.Y - y);
+
+        if (x < Bounds.X)
         {
-            foreach (AbstractIndexedTRTexture texture in Textures)
-            {
-                texture.Invalidate();
-            }
+            xDiff *= -1;
+        }
+        if (y < Bounds.Y)
+        {
+            yDiff *= -1;
         }
 
-        // Triggered when changes are to be saved back to the level.
-        // Index is that of containing tile.
-        public void Commit(int tileIndex)
+        foreach (AbstractIndexedTRTexture texture in Textures)
         {
-            foreach (AbstractIndexedTRTexture texture in Textures)
+            texture.MoveBy(xDiff, yDiff);
+            if (tileIndex != -1)
             {
                 texture.Commit(tileIndex);
             }
         }
+    }
 
-        public void Dispose()
+    // Triggered when removed from a tile, so inform
+    // the indexed textures to invalidate themselves.
+    public void Unbind()
+    {
+        foreach (AbstractIndexedTRTexture texture in Textures)
         {
-            if (Bitmap != null)
-            {
-                Bitmap.Dispose();
-            }
+            texture.Invalidate();
         }
+    }
 
-        public TexturedTileSegment Clone()
+    // Triggered when changes are to be saved back to the level.
+    // Index is that of containing tile.
+    public void Commit(int tileIndex)
+    {
+        foreach (AbstractIndexedTRTexture texture in Textures)
         {
-            TexturedTileSegment copy = new TexturedTileSegment(FirstTexture.Clone(), (Bitmap)Bitmap.Clone());
-            for (int i = 1; i < Textures.Count; i++)
-            {
-                copy.AddTexture(Textures[i].Clone());
-            }
-            return copy;
+            texture.Commit(tileIndex);
         }
+    }
+
+    public void Dispose()
+    {
+        if (Bitmap != null)
+        {
+            Bitmap.Dispose();
+        }
+    }
+
+    public TexturedTileSegment Clone()
+    {
+        TexturedTileSegment copy = new TexturedTileSegment(FirstTexture.Clone(), (Bitmap)Bitmap.Clone());
+        for (int i = 1; i < Textures.Count; i++)
+        {
+            copy.AddTexture(Textures[i].Clone());
+        }
+        return copy;
     }
 }

--- a/TRModelTransporter/Packing/TexturedTileSegment.cs
+++ b/TRModelTransporter/Packing/TexturedTileSegment.cs
@@ -1,6 +1,4 @@
 ﻿using RectanglePacker.Defaults;
-using System;
-using System.Collections.Generic;
 using System.Drawing;
 using TRModelTransporter.Model.Textures;
 

--- a/TRModelTransporter/Packing/Types/TR1TexturePacker.cs
+++ b/TRModelTransporter/Packing/Types/TR1TexturePacker.cs
@@ -22,7 +22,7 @@ public class TR1TexturePacker : AbstractTexturePacker<TREntities, TR1Level>
 
     protected override List<AbstractIndexedTRTexture> LoadObjectTextures()
     {
-        List<AbstractIndexedTRTexture> textures = new List<AbstractIndexedTRTexture>((int)Level.NumObjectTextures);
+        List<AbstractIndexedTRTexture> textures = new((int)Level.NumObjectTextures);
         for (int i = 0; i < Level.NumObjectTextures; i++)
         {
             TRObjectTexture texture = Level.ObjectTextures[i];
@@ -41,7 +41,7 @@ public class TR1TexturePacker : AbstractTexturePacker<TREntities, TR1Level>
 
     protected override List<AbstractIndexedTRTexture> LoadSpriteTextures()
     {
-        List<AbstractIndexedTRTexture> textures = new List<AbstractIndexedTRTexture>((int)Level.NumSpriteTextures);
+        List<AbstractIndexedTRTexture> textures = new((int)Level.NumSpriteTextures);
         for (int i = 0; i < Level.NumSpriteTextures; i++)
         {
             TRSpriteTexture texture = Level.SpriteTextures[i];
@@ -70,7 +70,7 @@ public class TR1TexturePacker : AbstractTexturePacker<TREntities, TR1Level>
 
     protected override IEnumerable<TREntities> GetAllModelTypes()
     {
-        List<TREntities> modelIDs = new List<TREntities>();
+        List<TREntities> modelIDs = new();
         foreach (TRModel model in Level.Models)
         {
             modelIDs.Add((TREntities)model.ID);

--- a/TRModelTransporter/Packing/Types/TR1TexturePacker.cs
+++ b/TRModelTransporter/Packing/Types/TR1TexturePacker.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Drawing;
-using System.Linq;
+﻿using System.Drawing;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;

--- a/TRModelTransporter/Packing/Types/TR1TexturePacker.cs
+++ b/TRModelTransporter/Packing/Types/TR1TexturePacker.cs
@@ -9,113 +9,112 @@ using TRModelTransporter.Model.Textures;
 using TRTexture16Importer;
 using TRTexture16Importer.Helpers;
 
-namespace TRModelTransporter.Packing
+namespace TRModelTransporter.Packing;
+
+public class TR1TexturePacker : AbstractTexturePacker<TREntities, TR1Level>
 {
-    public class TR1TexturePacker : AbstractTexturePacker<TREntities, TR1Level>
+    private const int _maximumTiles = 16;
+
+    public TR1PaletteManager PaletteManager { get; set; }
+
+    public override uint NumLevelImages => Level.NumImages;
+
+    public TR1TexturePacker(TR1Level level, ITextureClassifier classifier = null)
+        : base(level, _maximumTiles, classifier) { }
+
+    protected override List<AbstractIndexedTRTexture> LoadObjectTextures()
     {
-        private const int _maximumTiles = 16;
-
-        public TR1PaletteManager PaletteManager { get; set; }
-
-        public override uint NumLevelImages => Level.NumImages;
-
-        public TR1TexturePacker(TR1Level level, ITextureClassifier classifier = null)
-            : base(level, _maximumTiles, classifier) { }
-
-        protected override List<AbstractIndexedTRTexture> LoadObjectTextures()
+        List<AbstractIndexedTRTexture> textures = new List<AbstractIndexedTRTexture>((int)Level.NumObjectTextures);
+        for (int i = 0; i < Level.NumObjectTextures; i++)
         {
-            List<AbstractIndexedTRTexture> textures = new List<AbstractIndexedTRTexture>((int)Level.NumObjectTextures);
-            for (int i = 0; i < Level.NumObjectTextures; i++)
+            TRObjectTexture texture = Level.ObjectTextures[i];
+            if (texture.IsValid())
             {
-                TRObjectTexture texture = Level.ObjectTextures[i];
-                if (texture.IsValid())
+                textures.Add(new IndexedTRObjectTexture
                 {
-                    textures.Add(new IndexedTRObjectTexture
-                    {
-                        Index = i,
-                        Classification = _levelClassifier,
-                        Texture = texture
-                    });
-                }
+                    Index = i,
+                    Classification = _levelClassifier,
+                    Texture = texture
+                });
             }
-            return textures;
         }
+        return textures;
+    }
 
-        protected override List<AbstractIndexedTRTexture> LoadSpriteTextures()
+    protected override List<AbstractIndexedTRTexture> LoadSpriteTextures()
+    {
+        List<AbstractIndexedTRTexture> textures = new List<AbstractIndexedTRTexture>((int)Level.NumSpriteTextures);
+        for (int i = 0; i < Level.NumSpriteTextures; i++)
         {
-            List<AbstractIndexedTRTexture> textures = new List<AbstractIndexedTRTexture>((int)Level.NumSpriteTextures);
-            for (int i = 0; i < Level.NumSpriteTextures; i++)
+            TRSpriteTexture texture = Level.SpriteTextures[i];
+            if (texture.IsValid())
             {
-                TRSpriteTexture texture = Level.SpriteTextures[i];
-                if (texture.IsValid())
+                textures.Add(new IndexedTRSpriteTexture
                 {
-                    textures.Add(new IndexedTRSpriteTexture
-                    {
-                        Index = i,
-                        Classification = _levelClassifier,
-                        Texture = texture
-                    });
-                }
+                    Index = i,
+                    Classification = _levelClassifier,
+                    Texture = texture
+                });
             }
-            return textures;
+        }
+        return textures;
+    }
+
+    protected override TRMesh[] GetModelMeshes(TREntities modelEntity)
+    {
+        return TRMeshUtilities.GetModelMeshes(Level, modelEntity);
+    }
+
+    protected override TRSpriteSequence GetSpriteSequence(TREntities entity)
+    {
+        return Level.SpriteSequences.ToList().Find(s => s.SpriteID == (int)entity);
+    }
+
+    protected override IEnumerable<TREntities> GetAllModelTypes()
+    {
+        List<TREntities> modelIDs = new List<TREntities>();
+        foreach (TRModel model in Level.Models)
+        {
+            modelIDs.Add((TREntities)model.ID);
+        }
+        return modelIDs;
+    }
+
+    protected override void CreateImageSpace(uint count)
+    {
+        List<TRTexImage8> imgs8 = Level.Images8.ToList();
+
+        for (int i = 0; i < count; i++)
+        {
+            imgs8.Add(new TRTexImage8 { Pixels = new byte[256 * 256] });
         }
 
-        protected override TRMesh[] GetModelMeshes(TREntities modelEntity)
-        {
-            return TRMeshUtilities.GetModelMeshes(Level, modelEntity);
-        }
+        Level.Images8 = imgs8.ToArray();
+        Level.NumImages += count;
+    }
 
-        protected override TRSpriteSequence GetSpriteSequence(TREntities entity)
-        {
-            return Level.SpriteSequences.ToList().Find(s => s.SpriteID == (int)entity);
-        }
+    public override Bitmap GetTile(int tileIndex)
+    {
+        return Level.Images8[tileIndex].ToBitmap(Level.Palette);
+    }
 
-        protected override IEnumerable<TREntities> GetAllModelTypes()
+    public override void SetTile(int tileIndex, Bitmap bitmap)
+    {
+        if (PaletteManager == null)
         {
-            List<TREntities> modelIDs = new List<TREntities>();
-            foreach (TRModel model in Level.Models)
+            PaletteManager = new TR1PaletteManager
             {
-                modelIDs.Add((TREntities)model.ID);
-            }
-            return modelIDs;
+                Level = Level
+            };
         }
+        PaletteManager.ChangedTiles[tileIndex] = bitmap;
+    }
 
-        protected override void CreateImageSpace(uint count)
+    protected override void PostCommit()
+    {
+        if (PaletteManager != null)
         {
-            List<TRTexImage8> imgs8 = Level.Images8.ToList();
-
-            for (int i = 0; i < count; i++)
-            {
-                imgs8.Add(new TRTexImage8 { Pixels = new byte[256 * 256] });
-            }
-
-            Level.Images8 = imgs8.ToArray();
-            Level.NumImages += count;
-        }
-
-        public override Bitmap GetTile(int tileIndex)
-        {
-            return Level.Images8[tileIndex].ToBitmap(Level.Palette);
-        }
-
-        public override void SetTile(int tileIndex, Bitmap bitmap)
-        {
-            if (PaletteManager == null)
-            {
-                PaletteManager = new TR1PaletteManager
-                {
-                    Level = Level
-                };
-            }
-            PaletteManager.ChangedTiles[tileIndex] = bitmap;
-        }
-
-        protected override void PostCommit()
-        {
-            if (PaletteManager != null)
-            {
-                PaletteManager.MergeTiles();
-            }
+            PaletteManager.MergeTiles();
         }
     }
 }

--- a/TRModelTransporter/Packing/Types/TR1TexturePacker.cs
+++ b/TRModelTransporter/Packing/Types/TR1TexturePacker.cs
@@ -110,9 +110,6 @@ public class TR1TexturePacker : AbstractTexturePacker<TREntities, TR1Level>
 
     protected override void PostCommit()
     {
-        if (PaletteManager != null)
-        {
-            PaletteManager.MergeTiles();
-        }
+        PaletteManager?.MergeTiles();
     }
 }

--- a/TRModelTransporter/Packing/Types/TR1TexturePacker.cs
+++ b/TRModelTransporter/Packing/Types/TR1TexturePacker.cs
@@ -98,13 +98,10 @@ public class TR1TexturePacker : AbstractTexturePacker<TREntities, TR1Level>
 
     public override void SetTile(int tileIndex, Bitmap bitmap)
     {
-        if (PaletteManager == null)
+        PaletteManager ??= new TR1PaletteManager
         {
-            PaletteManager = new TR1PaletteManager
-            {
-                Level = Level
-            };
-        }
+            Level = Level
+        };
         PaletteManager.ChangedTiles[tileIndex] = bitmap;
     }
 

--- a/TRModelTransporter/Packing/Types/TR2TexturePacker.cs
+++ b/TRModelTransporter/Packing/Types/TR2TexturePacker.cs
@@ -8,99 +8,98 @@ using TRModelTransporter.Helpers;
 using TRModelTransporter.Model.Textures;
 using TRTexture16Importer;
 
-namespace TRModelTransporter.Packing
+namespace TRModelTransporter.Packing;
+
+public class TR2TexturePacker : AbstractTexturePacker<TR2Entities, TR2Level>
 {
-    public class TR2TexturePacker : AbstractTexturePacker<TR2Entities, TR2Level>
+    private const int _maximumTiles = 16;
+
+    public override uint NumLevelImages => Level.NumImages;
+
+    public TR2TexturePacker(TR2Level level, ITextureClassifier classifier = null)
+        : base(level, _maximumTiles, classifier) { }
+
+    protected override List<AbstractIndexedTRTexture> LoadObjectTextures()
     {
-        private const int _maximumTiles = 16;
-
-        public override uint NumLevelImages => Level.NumImages;
-
-        public TR2TexturePacker(TR2Level level, ITextureClassifier classifier = null)
-            : base(level, _maximumTiles, classifier) { }
-
-        protected override List<AbstractIndexedTRTexture> LoadObjectTextures()
+        List<AbstractIndexedTRTexture> textures = new List<AbstractIndexedTRTexture>((int)Level.NumObjectTextures);
+        for (int i = 0; i < Level.NumObjectTextures; i++)
         {
-            List<AbstractIndexedTRTexture> textures = new List<AbstractIndexedTRTexture>((int)Level.NumObjectTextures);
-            for (int i = 0; i < Level.NumObjectTextures; i++)
+            TRObjectTexture texture = Level.ObjectTextures[i];
+            if (texture.IsValid())
             {
-                TRObjectTexture texture = Level.ObjectTextures[i];
-                if (texture.IsValid())
+                textures.Add(new IndexedTRObjectTexture
                 {
-                    textures.Add(new IndexedTRObjectTexture
-                    {
-                        Index = i,
-                        Classification = _levelClassifier,
-                        Texture = texture
-                    });
-                }
+                    Index = i,
+                    Classification = _levelClassifier,
+                    Texture = texture
+                });
             }
-            return textures;
         }
+        return textures;
+    }
 
-        protected override List<AbstractIndexedTRTexture> LoadSpriteTextures()
+    protected override List<AbstractIndexedTRTexture> LoadSpriteTextures()
+    {
+        List<AbstractIndexedTRTexture> textures = new List<AbstractIndexedTRTexture>((int)Level.NumSpriteTextures);
+        for (int i = 0; i < Level.NumSpriteTextures; i++)
         {
-            List<AbstractIndexedTRTexture> textures = new List<AbstractIndexedTRTexture>((int)Level.NumSpriteTextures);
-            for (int i = 0; i < Level.NumSpriteTextures; i++)
+            TRSpriteTexture texture = Level.SpriteTextures[i];
+            if (texture.IsValid())
             {
-                TRSpriteTexture texture = Level.SpriteTextures[i];
-                if (texture.IsValid())
+                textures.Add(new IndexedTRSpriteTexture
                 {
-                    textures.Add(new IndexedTRSpriteTexture
-                    {
-                        Index = i,
-                        Classification = _levelClassifier,
-                        Texture = texture
-                    });
-                }
+                    Index = i,
+                    Classification = _levelClassifier,
+                    Texture = texture
+                });
             }
-            return textures;
         }
+        return textures;
+    }
 
-        protected override TRMesh[] GetModelMeshes(TR2Entities modelEntity)
+    protected override TRMesh[] GetModelMeshes(TR2Entities modelEntity)
+    {
+        return TRMeshUtilities.GetModelMeshes(Level, modelEntity);
+    }
+
+    protected override TRSpriteSequence GetSpriteSequence(TR2Entities entity)
+    {
+        return Level.SpriteSequences.ToList().Find(s => s.SpriteID == (int)entity);
+    }
+
+    protected override IEnumerable<TR2Entities> GetAllModelTypes()
+    {
+        List<TR2Entities> modelIDs = new List<TR2Entities>();
+        foreach (TRModel model in Level.Models)
         {
-            return TRMeshUtilities.GetModelMeshes(Level, modelEntity);
+            modelIDs.Add((TR2Entities)model.ID);
         }
+        return modelIDs;
+    }
 
-        protected override TRSpriteSequence GetSpriteSequence(TR2Entities entity)
+    protected override void CreateImageSpace(uint count)
+    {
+        List<TRTexImage16> imgs16 = Level.Images16.ToList();
+        List<TRTexImage8> imgs8 = Level.Images8.ToList();
+
+        for (int i = 0; i < count; i++)
         {
-            return Level.SpriteSequences.ToList().Find(s => s.SpriteID == (int)entity);
+            imgs16.Add(new TRTexImage16());
+            imgs8.Add(new TRTexImage8 { Pixels = new byte[256 * 256] });
         }
 
-        protected override IEnumerable<TR2Entities> GetAllModelTypes()
-        {
-            List<TR2Entities> modelIDs = new List<TR2Entities>();
-            foreach (TRModel model in Level.Models)
-            {
-                modelIDs.Add((TR2Entities)model.ID);
-            }
-            return modelIDs;
-        }
+        Level.Images16 = imgs16.ToArray();
+        Level.Images8 = imgs8.ToArray();
+        Level.NumImages += count;
+    }
 
-        protected override void CreateImageSpace(uint count)
-        {
-            List<TRTexImage16> imgs16 = Level.Images16.ToList();
-            List<TRTexImage8> imgs8 = Level.Images8.ToList();
+    public override Bitmap GetTile(int tileIndex)
+    {
+        return Level.Images16[tileIndex].ToBitmap();
+    }
 
-            for (int i = 0; i < count; i++)
-            {
-                imgs16.Add(new TRTexImage16());
-                imgs8.Add(new TRTexImage8 { Pixels = new byte[256 * 256] });
-            }
-
-            Level.Images16 = imgs16.ToArray();
-            Level.Images8 = imgs8.ToArray();
-            Level.NumImages += count;
-        }
-
-        public override Bitmap GetTile(int tileIndex)
-        {
-            return Level.Images16[tileIndex].ToBitmap();
-        }
-
-        public override void SetTile(int tileIndex, Bitmap bitmap)
-        {
-            Level.Images16[tileIndex].Pixels = TextureUtilities.ImportFromBitmap(bitmap);
-        }
+    public override void SetTile(int tileIndex, Bitmap bitmap)
+    {
+        Level.Images16[tileIndex].Pixels = TextureUtilities.ImportFromBitmap(bitmap);
     }
 }

--- a/TRModelTransporter/Packing/Types/TR2TexturePacker.cs
+++ b/TRModelTransporter/Packing/Types/TR2TexturePacker.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Drawing;
-using System.Linq;
+﻿using System.Drawing;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;

--- a/TRModelTransporter/Packing/Types/TR2TexturePacker.cs
+++ b/TRModelTransporter/Packing/Types/TR2TexturePacker.cs
@@ -19,7 +19,7 @@ public class TR2TexturePacker : AbstractTexturePacker<TR2Entities, TR2Level>
 
     protected override List<AbstractIndexedTRTexture> LoadObjectTextures()
     {
-        List<AbstractIndexedTRTexture> textures = new List<AbstractIndexedTRTexture>((int)Level.NumObjectTextures);
+        List<AbstractIndexedTRTexture> textures = new((int)Level.NumObjectTextures);
         for (int i = 0; i < Level.NumObjectTextures; i++)
         {
             TRObjectTexture texture = Level.ObjectTextures[i];
@@ -38,7 +38,7 @@ public class TR2TexturePacker : AbstractTexturePacker<TR2Entities, TR2Level>
 
     protected override List<AbstractIndexedTRTexture> LoadSpriteTextures()
     {
-        List<AbstractIndexedTRTexture> textures = new List<AbstractIndexedTRTexture>((int)Level.NumSpriteTextures);
+        List<AbstractIndexedTRTexture> textures = new((int)Level.NumSpriteTextures);
         for (int i = 0; i < Level.NumSpriteTextures; i++)
         {
             TRSpriteTexture texture = Level.SpriteTextures[i];
@@ -67,7 +67,7 @@ public class TR2TexturePacker : AbstractTexturePacker<TR2Entities, TR2Level>
 
     protected override IEnumerable<TR2Entities> GetAllModelTypes()
     {
-        List<TR2Entities> modelIDs = new List<TR2Entities>();
+        List<TR2Entities> modelIDs = new();
         foreach (TRModel model in Level.Models)
         {
             modelIDs.Add((TR2Entities)model.ID);

--- a/TRModelTransporter/Packing/Types/TR3TexturePacker.cs
+++ b/TRModelTransporter/Packing/Types/TR3TexturePacker.cs
@@ -19,7 +19,7 @@ public class TR3TexturePacker : AbstractTexturePacker<TR3Entities, TR3Level>
 
     protected override List<AbstractIndexedTRTexture> LoadObjectTextures()
     {
-        List<AbstractIndexedTRTexture> textures = new List<AbstractIndexedTRTexture>((int)Level.NumObjectTextures);
+        List<AbstractIndexedTRTexture> textures = new((int)Level.NumObjectTextures);
         for (int i = 0; i < Level.NumObjectTextures; i++)
         {
             TRObjectTexture texture = Level.ObjectTextures[i];
@@ -38,7 +38,7 @@ public class TR3TexturePacker : AbstractTexturePacker<TR3Entities, TR3Level>
 
     protected override List<AbstractIndexedTRTexture> LoadSpriteTextures()
     {
-        List<AbstractIndexedTRTexture> textures = new List<AbstractIndexedTRTexture>((int)Level.NumSpriteTextures);
+        List<AbstractIndexedTRTexture> textures = new((int)Level.NumSpriteTextures);
         for (int i = 0; i < Level.NumSpriteTextures; i++)
         {
             TRSpriteTexture texture = Level.SpriteTextures[i];
@@ -67,7 +67,7 @@ public class TR3TexturePacker : AbstractTexturePacker<TR3Entities, TR3Level>
 
     protected override IEnumerable<TR3Entities> GetAllModelTypes()
     {
-        List<TR3Entities> modelIDs = new List<TR3Entities>();
+        List<TR3Entities> modelIDs = new();
         foreach (TRModel model in Level.Models)
         {
             modelIDs.Add((TR3Entities)model.ID);

--- a/TRModelTransporter/Packing/Types/TR3TexturePacker.cs
+++ b/TRModelTransporter/Packing/Types/TR3TexturePacker.cs
@@ -8,99 +8,98 @@ using TRModelTransporter.Helpers;
 using TRModelTransporter.Model.Textures;
 using TRTexture16Importer;
 
-namespace TRModelTransporter.Packing
+namespace TRModelTransporter.Packing;
+
+public class TR3TexturePacker : AbstractTexturePacker<TR3Entities, TR3Level>
 {
-    public class TR3TexturePacker : AbstractTexturePacker<TR3Entities, TR3Level>
+    private const int _maximumTiles = 32;
+
+    public override uint NumLevelImages => Level.NumImages;
+
+    public TR3TexturePacker(TR3Level level, ITextureClassifier classifier = null)
+        : base(level, _maximumTiles, classifier) { }
+
+    protected override List<AbstractIndexedTRTexture> LoadObjectTextures()
     {
-        private const int _maximumTiles = 32;
-
-        public override uint NumLevelImages => Level.NumImages;
-
-        public TR3TexturePacker(TR3Level level, ITextureClassifier classifier = null)
-            : base(level, _maximumTiles, classifier) { }
-
-        protected override List<AbstractIndexedTRTexture> LoadObjectTextures()
+        List<AbstractIndexedTRTexture> textures = new List<AbstractIndexedTRTexture>((int)Level.NumObjectTextures);
+        for (int i = 0; i < Level.NumObjectTextures; i++)
         {
-            List<AbstractIndexedTRTexture> textures = new List<AbstractIndexedTRTexture>((int)Level.NumObjectTextures);
-            for (int i = 0; i < Level.NumObjectTextures; i++)
+            TRObjectTexture texture = Level.ObjectTextures[i];
+            if (texture.IsValid())
             {
-                TRObjectTexture texture = Level.ObjectTextures[i];
-                if (texture.IsValid())
+                textures.Add(new IndexedTRObjectTexture
                 {
-                    textures.Add(new IndexedTRObjectTexture
-                    {
-                        Index = i,
-                        Classification = _levelClassifier,
-                        Texture = texture
-                    });
-                }
+                    Index = i,
+                    Classification = _levelClassifier,
+                    Texture = texture
+                });
             }
-            return textures;
         }
+        return textures;
+    }
 
-        protected override List<AbstractIndexedTRTexture> LoadSpriteTextures()
+    protected override List<AbstractIndexedTRTexture> LoadSpriteTextures()
+    {
+        List<AbstractIndexedTRTexture> textures = new List<AbstractIndexedTRTexture>((int)Level.NumSpriteTextures);
+        for (int i = 0; i < Level.NumSpriteTextures; i++)
         {
-            List<AbstractIndexedTRTexture> textures = new List<AbstractIndexedTRTexture>((int)Level.NumSpriteTextures);
-            for (int i = 0; i < Level.NumSpriteTextures; i++)
+            TRSpriteTexture texture = Level.SpriteTextures[i];
+            if (texture.IsValid())
             {
-                TRSpriteTexture texture = Level.SpriteTextures[i];
-                if (texture.IsValid())
+                textures.Add(new IndexedTRSpriteTexture
                 {
-                    textures.Add(new IndexedTRSpriteTexture
-                    {
-                        Index = i,
-                        Classification = _levelClassifier,
-                        Texture = texture
-                    });
-                }
+                    Index = i,
+                    Classification = _levelClassifier,
+                    Texture = texture
+                });
             }
-            return textures;
         }
+        return textures;
+    }
 
-        protected override TRMesh[] GetModelMeshes(TR3Entities modelEntity)
+    protected override TRMesh[] GetModelMeshes(TR3Entities modelEntity)
+    {
+        return TRMeshUtilities.GetModelMeshes(Level, modelEntity);
+    }
+
+    protected override TRSpriteSequence GetSpriteSequence(TR3Entities entity)
+    {
+        return Level.SpriteSequences.ToList().Find(s => s.SpriteID == (int)entity);
+    }
+
+    protected override IEnumerable<TR3Entities> GetAllModelTypes()
+    {
+        List<TR3Entities> modelIDs = new List<TR3Entities>();
+        foreach (TRModel model in Level.Models)
         {
-            return TRMeshUtilities.GetModelMeshes(Level, modelEntity);
+            modelIDs.Add((TR3Entities)model.ID);
         }
+        return modelIDs;
+    }
 
-        protected override TRSpriteSequence GetSpriteSequence(TR3Entities entity)
+    protected override void CreateImageSpace(uint count)
+    {
+        List<TRTexImage16> imgs16 = Level.Images16.ToList();
+        List<TRTexImage8> imgs8 = Level.Images8.ToList();
+
+        for (int i = 0; i < count; i++)
         {
-            return Level.SpriteSequences.ToList().Find(s => s.SpriteID == (int)entity);
+            imgs16.Add(new TRTexImage16());
+            imgs8.Add(new TRTexImage8 { Pixels = new byte[256 * 256] });
         }
 
-        protected override IEnumerable<TR3Entities> GetAllModelTypes()
-        {
-            List<TR3Entities> modelIDs = new List<TR3Entities>();
-            foreach (TRModel model in Level.Models)
-            {
-                modelIDs.Add((TR3Entities)model.ID);
-            }
-            return modelIDs;
-        }
+        Level.Images16 = imgs16.ToArray();
+        Level.Images8 = imgs8.ToArray();
+        Level.NumImages += count;
+    }
 
-        protected override void CreateImageSpace(uint count)
-        {
-            List<TRTexImage16> imgs16 = Level.Images16.ToList();
-            List<TRTexImage8> imgs8 = Level.Images8.ToList();
+    public override Bitmap GetTile(int tileIndex)
+    {
+        return Level.Images16[tileIndex].ToBitmap();
+    }
 
-            for (int i = 0; i < count; i++)
-            {
-                imgs16.Add(new TRTexImage16());
-                imgs8.Add(new TRTexImage8 { Pixels = new byte[256 * 256] });
-            }
-
-            Level.Images16 = imgs16.ToArray();
-            Level.Images8 = imgs8.ToArray();
-            Level.NumImages += count;
-        }
-
-        public override Bitmap GetTile(int tileIndex)
-        {
-            return Level.Images16[tileIndex].ToBitmap();
-        }
-
-        public override void SetTile(int tileIndex, Bitmap bitmap)
-        {
-            Level.Images16[tileIndex].Pixels = TextureUtilities.ImportFromBitmap(bitmap);
-        }
+    public override void SetTile(int tileIndex, Bitmap bitmap)
+    {
+        Level.Images16[tileIndex].Pixels = TextureUtilities.ImportFromBitmap(bitmap);
     }
 }

--- a/TRModelTransporter/Packing/Types/TR3TexturePacker.cs
+++ b/TRModelTransporter/Packing/Types/TR3TexturePacker.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Drawing;
-using System.Linq;
+﻿using System.Drawing;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;

--- a/TRModelTransporter/Transport/AbstractTRModelExporter.cs
+++ b/TRModelTransporter/Transport/AbstractTRModelExporter.cs
@@ -89,7 +89,7 @@ public abstract class AbstractTRModelExporter<E, L, D> : AbstractTRModelTranspor
 
     private void ExportDependencies(D definition)
     {
-        List<E> dependencies = new List<E>(Data.GetModelDependencies(definition.Alias));
+        List<E> dependencies = new(Data.GetModelDependencies(definition.Alias));
         definition.Dependencies = dependencies.ToArray();
     }
 
@@ -101,7 +101,7 @@ public abstract class AbstractTRModelExporter<E, L, D> : AbstractTRModelTranspor
         {
             foreach (IndexedTRObjectTexture texture in textureList)
             {
-                Dictionary<TRObjectTextureVert, Point> points = new Dictionary<TRObjectTextureVert, Point>();
+                Dictionary<TRObjectTextureVert, Point> points = new();
                 foreach (TRObjectTextureVert vertex in texture.Texture.Vertices)
                 {
                     int x = vertex.XCoordinate.Fraction;

--- a/TRModelTransporter/Transport/AbstractTRModelExporter.cs
+++ b/TRModelTransporter/Transport/AbstractTRModelExporter.cs
@@ -1,10 +1,6 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
-using System.IO;
-using System.Linq;
 using TRLevelControl.Model;
 using TRModelTransporter.Events;
 using TRModelTransporter.Handlers;

--- a/TRModelTransporter/Transport/AbstractTRModelExporter.cs
+++ b/TRModelTransporter/Transport/AbstractTRModelExporter.cs
@@ -13,130 +13,129 @@ using TRModelTransporter.Model.Textures;
 using TRModelTransporter.Utilities;
 using TRTexture16Importer.Textures;
 
-namespace TRModelTransporter.Transport
+namespace TRModelTransporter.Transport;
+
+public abstract class AbstractTRModelExporter<E, L, D> : AbstractTRModelTransport<E, L, D>
+    where E : Enum
+    where L : class
+    where D : AbstractTRModelDefinition<E>
 {
-    public abstract class AbstractTRModelExporter<E, L, D> : AbstractTRModelTransport<E, L, D>
-        where E : Enum
-        where L : class
-        where D : AbstractTRModelDefinition<E>
+    protected static readonly string _defaultSegmentsFolder = @"Resources\ModelSegments";
+
+    public bool ExportIndividualSegments { get; set; }
+    public string SegmentsDataFolder { get; set; }
+
+    public ITextureClassifier TextureClassifier { get; set; }
+
+    protected AbstractTextureExportHandler<E, L, D> _textureHandler;
+
+    public AbstractTRModelExporter()
     {
-        protected static readonly string _defaultSegmentsFolder = @"Resources\ModelSegments";
+        SegmentsDataFolder = _defaultSegmentsFolder;
+        _textureHandler = CreateTextureHandler();
+    }
 
-        public bool ExportIndividualSegments { get; set; }
-        public string SegmentsDataFolder { get; set; }
+    protected abstract AbstractTextureExportHandler<E, L, D> CreateTextureHandler();
 
-        public ITextureClassifier TextureClassifier { get; set; }
-
-        protected AbstractTextureExportHandler<E, L, D> _textureHandler;
-
-        public AbstractTRModelExporter()
+    public D Export(L level, E entity)
+    {
+        EventHandler<SegmentEventArgs> segmentDelegate = null;
+        EventHandler<TRTextureRemapEventArgs> segmentRemapped = null;
+        List<StaticTextureTarget> duplicateClips = null;
+        string segmentDir = Path.Combine(SegmentsDataFolder, entity.ToString());
+        if (ExportIndividualSegments)
         {
-            SegmentsDataFolder = _defaultSegmentsFolder;
-            _textureHandler = CreateTextureHandler();
-        }
-
-        protected abstract AbstractTextureExportHandler<E, L, D> CreateTextureHandler();
-
-        public D Export(L level, E entity)
-        {
-            EventHandler<SegmentEventArgs> segmentDelegate = null;
-            EventHandler<TRTextureRemapEventArgs> segmentRemapped = null;
-            List<StaticTextureTarget> duplicateClips = null;
-            string segmentDir = Path.Combine(SegmentsDataFolder, entity.ToString());
-            if (ExportIndividualSegments)
+            if (Directory.Exists(segmentDir))
             {
-                if (Directory.Exists(segmentDir))
-                {
-                    Directory.Delete(segmentDir, true);
-                }
-                Directory.CreateDirectory(segmentDir);
-
-                _textureHandler.SegmentExported += segmentDelegate = delegate (object sender, SegmentEventArgs e)
-                {
-                    e.Bitmap.Save(Path.Combine(segmentDir, e.SegmentIndex + ".png"), ImageFormat.Png);
-                };
-
-                duplicateClips = new List<StaticTextureTarget>();
-                _textureHandler.SegmentRemapped += segmentRemapped = delegate (object sender, TRTextureRemapEventArgs e)
-                {
-                    duplicateClips.Add(new StaticTextureTarget
-                    {
-                        Segment = e.NewSegment.FirstTextureIndex,
-                        Tile = e.OldTile.Index,
-                        X = e.OldBounds.X,
-                        Y = e.OldBounds.Y,
-                        Clip = new Rectangle(e.AdjustmentPoint.X - e.NewBounds.X, e.AdjustmentPoint.Y - e.NewBounds.Y, e.OldBounds.Width, e.OldBounds.Height)
-                    });
-                };
+                Directory.Delete(segmentDir, true);
             }
+            Directory.CreateDirectory(segmentDir);
 
-            PreDefinitionCreation(level, entity);
-            D definition = CreateModelDefinition(level, entity);
-            ExportDependencies(definition);
-            ModelExportReady(definition);
-            StoreDefinition(definition);
-
-            if (ExportIndividualSegments)
+            _textureHandler.SegmentExported += segmentDelegate = delegate (object sender, SegmentEventArgs e)
             {
-                _textureHandler.SegmentExported -= segmentDelegate;
-                _textureHandler.SegmentRemapped -= segmentRemapped;
+                e.Bitmap.Save(Path.Combine(segmentDir, e.SegmentIndex + ".png"), ImageFormat.Png);
+            };
 
-                File.WriteAllText(Path.Combine(segmentDir, "DuplicateClips.json"), JsonConvert.SerializeObject(duplicateClips, Formatting.Indented));
-            }
-
-            return definition;
-        }
-
-        protected virtual void PreDefinitionCreation(L level, E modelEntity) { }
-        protected abstract D CreateModelDefinition(L level, E modelEntity);
-        protected virtual void ModelExportReady(D definition) { }
-
-        private void ExportDependencies(D definition)
-        {
-            List<E> dependencies = new List<E>(Data.GetModelDependencies(definition.Alias));
-            definition.Dependencies = dependencies.ToArray();
-        }
-
-        protected void AmendDXtre3DTextures(D definition)
-        {
-            // Dxtre3D can produce faulty UV mapping which can cause casting issues
-            // when used in model IO, so fix coordinates at this stage.
-            foreach (List<IndexedTRObjectTexture> textureList in definition.ObjectTextures.Values)
+            duplicateClips = new List<StaticTextureTarget>();
+            _textureHandler.SegmentRemapped += segmentRemapped = delegate (object sender, TRTextureRemapEventArgs e)
             {
-                foreach (IndexedTRObjectTexture texture in textureList)
+                duplicateClips.Add(new StaticTextureTarget
                 {
-                    Dictionary<TRObjectTextureVert, Point> points = new Dictionary<TRObjectTextureVert, Point>();
-                    foreach (TRObjectTextureVert vertex in texture.Texture.Vertices)
-                    {
-                        int x = vertex.XCoordinate.Fraction;
-                        if (vertex.XCoordinate.Whole == byte.MaxValue)
-                        {
-                            x++;
-                        }
+                    Segment = e.NewSegment.FirstTextureIndex,
+                    Tile = e.OldTile.Index,
+                    X = e.OldBounds.X,
+                    Y = e.OldBounds.Y,
+                    Clip = new Rectangle(e.AdjustmentPoint.X - e.NewBounds.X, e.AdjustmentPoint.Y - e.NewBounds.Y, e.OldBounds.Width, e.OldBounds.Height)
+                });
+            };
+        }
 
-                        int y = vertex.YCoordinate.Fraction;
-                        if (vertex.YCoordinate.Whole == byte.MaxValue)
-                        {
-                            y++;
-                        }
-                        points[vertex] = new Point(x, y);
+        PreDefinitionCreation(level, entity);
+        D definition = CreateModelDefinition(level, entity);
+        ExportDependencies(definition);
+        ModelExportReady(definition);
+        StoreDefinition(definition);
+
+        if (ExportIndividualSegments)
+        {
+            _textureHandler.SegmentExported -= segmentDelegate;
+            _textureHandler.SegmentRemapped -= segmentRemapped;
+
+            File.WriteAllText(Path.Combine(segmentDir, "DuplicateClips.json"), JsonConvert.SerializeObject(duplicateClips, Formatting.Indented));
+        }
+
+        return definition;
+    }
+
+    protected virtual void PreDefinitionCreation(L level, E modelEntity) { }
+    protected abstract D CreateModelDefinition(L level, E modelEntity);
+    protected virtual void ModelExportReady(D definition) { }
+
+    private void ExportDependencies(D definition)
+    {
+        List<E> dependencies = new List<E>(Data.GetModelDependencies(definition.Alias));
+        definition.Dependencies = dependencies.ToArray();
+    }
+
+    protected void AmendDXtre3DTextures(D definition)
+    {
+        // Dxtre3D can produce faulty UV mapping which can cause casting issues
+        // when used in model IO, so fix coordinates at this stage.
+        foreach (List<IndexedTRObjectTexture> textureList in definition.ObjectTextures.Values)
+        {
+            foreach (IndexedTRObjectTexture texture in textureList)
+            {
+                Dictionary<TRObjectTextureVert, Point> points = new Dictionary<TRObjectTextureVert, Point>();
+                foreach (TRObjectTextureVert vertex in texture.Texture.Vertices)
+                {
+                    int x = vertex.XCoordinate.Fraction;
+                    if (vertex.XCoordinate.Whole == byte.MaxValue)
+                    {
+                        x++;
                     }
 
-                    int maxX = points.Values.Max(p => p.X);
-                    int maxY = points.Values.Max(p => p.Y);
-                    foreach (TRObjectTextureVert vertex in texture.Texture.Vertices)
+                    int y = vertex.YCoordinate.Fraction;
+                    if (vertex.YCoordinate.Whole == byte.MaxValue)
                     {
-                        Point p = points[vertex];
-                        if (p.X == maxX && maxX != byte.MaxValue)
-                        {
-                            vertex.XCoordinate.Fraction--;
-                            vertex.XCoordinate.Whole = byte.MaxValue;
-                        }
-                        if (p.Y == maxY && maxY != byte.MaxValue)
-                        {
-                            vertex.YCoordinate.Fraction--;
-                            vertex.YCoordinate.Whole = byte.MaxValue;
-                        }
+                        y++;
+                    }
+                    points[vertex] = new Point(x, y);
+                }
+
+                int maxX = points.Values.Max(p => p.X);
+                int maxY = points.Values.Max(p => p.Y);
+                foreach (TRObjectTextureVert vertex in texture.Texture.Vertices)
+                {
+                    Point p = points[vertex];
+                    if (p.X == maxX && maxX != byte.MaxValue)
+                    {
+                        vertex.XCoordinate.Fraction--;
+                        vertex.XCoordinate.Whole = byte.MaxValue;
+                    }
+                    if (p.Y == maxY && maxY != byte.MaxValue)
+                    {
+                        vertex.YCoordinate.Fraction--;
+                        vertex.YCoordinate.Whole = byte.MaxValue;
                     }
                 }
             }

--- a/TRModelTransporter/Transport/AbstractTRModelImporter.cs
+++ b/TRModelTransporter/Transport/AbstractTRModelImporter.cs
@@ -45,8 +45,8 @@ public abstract class AbstractTRModelImporter<E, L, D> : AbstractTRModelTranspor
 
         CleanAliases();
 
-        List<D> standardModelDefinitions = new List<D>();
-        List<D> soundModelDefinitions = new List<D>();
+        List<D> standardModelDefinitions = new();
+        List<D> soundModelDefinitions = new();
         foreach (E entity in EntitiesToImport)
         {
             BuildDefinitionList(standardModelDefinitions, soundModelDefinitions, existingEntities, entity, false);
@@ -86,7 +86,7 @@ public abstract class AbstractTRModelImporter<E, L, D> : AbstractTRModelTranspor
     {
         // If an entity is marked to be removed but is also in the list
         // to import, don't remove it in the first place.
-        List<E> cleanedEntities = new List<E>();
+        List<E> cleanedEntities = new();
         foreach (E entity in EntitiesToRemove)
         {
             bool entityClean = false;
@@ -136,7 +136,7 @@ public abstract class AbstractTRModelImporter<E, L, D> : AbstractTRModelTranspor
 
     private void CleanAliases()
     {
-        List<E> cleanedEntities = new List<E>();
+        List<E> cleanedEntities = new();
         // Do we have any aliases?
         foreach (E importEntity in EntitiesToImport)
         {
@@ -175,7 +175,7 @@ public abstract class AbstractTRModelImporter<E, L, D> : AbstractTRModelTranspor
 
     private void ValidateDefinitionList(List<E> modelEntities, List<D> importDefinitions)
     {
-        Dictionary<E, List<E>> detectedAliases = new Dictionary<E, List<E>>();
+        Dictionary<E, List<E>> detectedAliases = new();
         foreach (E entity in modelEntities)
         {
             if (Data.IsAlias(entity))

--- a/TRModelTransporter/Transport/AbstractTRModelImporter.cs
+++ b/TRModelTransporter/Transport/AbstractTRModelImporter.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using TRModelTransporter.Handlers;
+﻿using TRModelTransporter.Handlers;
 using TRModelTransporter.Model;
 using TRModelTransporter.Model.Textures;
 

--- a/TRModelTransporter/Transport/AbstractTRModelImporter.cs
+++ b/TRModelTransporter/Transport/AbstractTRModelImporter.cs
@@ -5,297 +5,296 @@ using TRModelTransporter.Handlers;
 using TRModelTransporter.Model;
 using TRModelTransporter.Model.Textures;
 
-namespace TRModelTransporter.Transport
+namespace TRModelTransporter.Transport;
+
+public abstract class AbstractTRModelImporter<E, L, D> : AbstractTRModelTransport<E, L, D> 
+    where E : Enum
+    where L : class
+    where D : AbstractTRModelDefinition<E>
 {
-    public abstract class AbstractTRModelImporter<E, L, D> : AbstractTRModelTransport<E, L, D> 
-        where E : Enum
-        where L : class
-        where D : AbstractTRModelDefinition<E>
+    public IEnumerable<E> EntitiesToImport { get; set; }
+    public IEnumerable<E> EntitiesToRemove { get; set; }
+    public bool ClearUnusedSprites { get; set; }
+    public string TextureRemapPath { get; set; }
+    public ITexturePositionMonitor<E> TexturePositionMonitor { get; set; }
+    public bool SortModels { get; set; }
+    public bool IgnoreGraphics { get; set; }
+
+    protected AbstractTextureImportHandler<E, L, D> _textureHandler;
+
+    public AbstractTRModelImporter()
     {
-        public IEnumerable<E> EntitiesToImport { get; set; }
-        public IEnumerable<E> EntitiesToRemove { get; set; }
-        public bool ClearUnusedSprites { get; set; }
-        public string TextureRemapPath { get; set; }
-        public ITexturePositionMonitor<E> TexturePositionMonitor { get; set; }
-        public bool SortModels { get; set; }
-        public bool IgnoreGraphics { get; set; }
+        EntitiesToImport = new List<E>();
+        EntitiesToRemove = new List<E>();
+        ClearUnusedSprites = false;
+    }
 
-        protected AbstractTextureImportHandler<E, L, D> _textureHandler;
+    protected abstract AbstractTextureImportHandler<E, L, D> CreateTextureHandler();
 
-        public AbstractTRModelImporter()
+    public void Import()
+    {
+        if (_textureHandler == null)
         {
-            EntitiesToImport = new List<E>();
-            EntitiesToRemove = new List<E>();
-            ClearUnusedSprites = false;
+            _textureHandler = CreateTextureHandler();
+            _textureHandler.Data = Data;
         }
 
-        protected abstract AbstractTextureImportHandler<E, L, D> CreateTextureHandler();
+        List<E> existingEntities = GetExistingModelTypes();
 
-        public void Import()
+        if (EntitiesToRemove != null)
         {
-            if (_textureHandler == null)
-            {
-                _textureHandler = CreateTextureHandler();
-                _textureHandler.Data = Data;
-            }
-
-            List<E> existingEntities = GetExistingModelTypes();
-
-            if (EntitiesToRemove != null)
-            {
-                AdjustEntities();
-            }
-
-            CleanAliases();
-
-            List<D> standardModelDefinitions = new List<D>();
-            List<D> soundModelDefinitions = new List<D>();
-            foreach (E entity in EntitiesToImport)
-            {
-                BuildDefinitionList(standardModelDefinitions, soundModelDefinitions, existingEntities, entity, false);
-            }
-
-            // Check for alias duplication
-            ValidateDefinitionList(existingEntities, standardModelDefinitions);
-
-            if (SortModels)
-            {
-                standardModelDefinitions.Sort(delegate (D d1, D d2)
-                {
-                    return d1.Entity.CompareTo(d2.Entity);
-                });
-                soundModelDefinitions.Sort(delegate (D d1, D d2)
-                {
-                    return d1.Entity.CompareTo(d2.Entity);
-                });
-            }
-
-            try
-            {
-                if (standardModelDefinitions.Count + soundModelDefinitions.Count > 0)
-                {
-                    Import(standardModelDefinitions, soundModelDefinitions);
-                }
-            }
-            finally
-            {
-                // Bitmap cleanup
-                standardModelDefinitions.ForEach(d => d.Dispose());
-                soundModelDefinitions.ForEach(d => d.Dispose());
-            }
+            AdjustEntities();
         }
 
-        private void AdjustEntities()
-        {
-            // If an entity is marked to be removed but is also in the list
-            // to import, don't remove it in the first place.
-            List<E> cleanedEntities = new List<E>();
-            foreach (E entity in EntitiesToRemove)
-            {
-                bool entityClean = false;
-                if (Data.HasAliases(entity))
-                {
-                    // Check if we have another alias in the import list different from any
-                    // in the current level
-                    E alias = Data.GetLevelAlias(LevelName, entity);
-                    E importAlias = default;
-                    foreach (E a in Data.GetAliases(entity))
-                    {
-                        if (EntitiesToImport.Contains(a))
-                        {
-                            importAlias = a;
-                            break;
-                        }
-                    }
+        CleanAliases();
 
-                    if (!Equals(alias, importAlias))
+        List<D> standardModelDefinitions = new List<D>();
+        List<D> soundModelDefinitions = new List<D>();
+        foreach (E entity in EntitiesToImport)
+        {
+            BuildDefinitionList(standardModelDefinitions, soundModelDefinitions, existingEntities, entity, false);
+        }
+
+        // Check for alias duplication
+        ValidateDefinitionList(existingEntities, standardModelDefinitions);
+
+        if (SortModels)
+        {
+            standardModelDefinitions.Sort(delegate (D d1, D d2)
+            {
+                return d1.Entity.CompareTo(d2.Entity);
+            });
+            soundModelDefinitions.Sort(delegate (D d1, D d2)
+            {
+                return d1.Entity.CompareTo(d2.Entity);
+            });
+        }
+
+        try
+        {
+            if (standardModelDefinitions.Count + soundModelDefinitions.Count > 0)
+            {
+                Import(standardModelDefinitions, soundModelDefinitions);
+            }
+        }
+        finally
+        {
+            // Bitmap cleanup
+            standardModelDefinitions.ForEach(d => d.Dispose());
+            soundModelDefinitions.ForEach(d => d.Dispose());
+        }
+    }
+
+    private void AdjustEntities()
+    {
+        // If an entity is marked to be removed but is also in the list
+        // to import, don't remove it in the first place.
+        List<E> cleanedEntities = new List<E>();
+        foreach (E entity in EntitiesToRemove)
+        {
+            bool entityClean = false;
+            if (Data.HasAliases(entity))
+            {
+                // Check if we have another alias in the import list different from any
+                // in the current level
+                E alias = Data.GetLevelAlias(LevelName, entity);
+                E importAlias = default;
+                foreach (E a in Data.GetAliases(entity))
+                {
+                    if (EntitiesToImport.Contains(a))
                     {
-                        entityClean = true;
+                        importAlias = a;
+                        break;
                     }
                 }
-                else if (!EntitiesToImport.Contains(entity))
+
+                if (!Equals(alias, importAlias))
                 {
                     entityClean = true;
                 }
+            }
+            else if (!EntitiesToImport.Contains(entity))
+            {
+                entityClean = true;
+            }
 
-                if (entityClean)
+            if (entityClean)
+            {
+                // There may be null meshes dependent on this removal, so we can only remove it if they're
+                // being removed as well.
+                IEnumerable<E> exclusions = Data.GetRemovalExclusions(entity);
+                if (exclusions.Count() > 0 && exclusions.All(EntitiesToRemove.Contains))
                 {
-                    // There may be null meshes dependent on this removal, so we can only remove it if they're
-                    // being removed as well.
-                    IEnumerable<E> exclusions = Data.GetRemovalExclusions(entity);
-                    if (exclusions.Count() > 0 && exclusions.All(EntitiesToRemove.Contains))
-                    {
-                        entityClean = false;
-                    }
-                }
-
-                if (entityClean)
-                {
-                    cleanedEntities.Add(entity);
+                    entityClean = false;
                 }
             }
-            EntitiesToRemove = cleanedEntities;
+
+            if (entityClean)
+            {
+                cleanedEntities.Add(entity);
+            }
+        }
+        EntitiesToRemove = cleanedEntities;
+    }
+
+    private void CleanAliases()
+    {
+        List<E> cleanedEntities = new List<E>();
+        // Do we have any aliases?
+        foreach (E importEntity in EntitiesToImport)
+        {
+            if (Data.HasAliases(importEntity))
+            {
+                throw new TransportException(string.Format
+                (
+                    "Cannot import ambiguous entity {0} - choose an alias from [{1}].",
+                    importEntity.ToString(),
+                    string.Join(", ", Data.GetAliases(importEntity))
+                ));
+            }
+
+            bool entityIsValid = true;
+            if (Data.IsAlias(importEntity))
+            {
+                E existingEntity = Data.GetLevelAlias(LevelName, Data.TranslateAlias(importEntity));
+                // This entity is only valid if the alias it's for is not already there
+                entityIsValid = !Equals(importEntity, existingEntity);
+            }
+
+            if (entityIsValid)
+            {
+                cleanedEntities.Add(importEntity);
+            }
         }
 
-        private void CleanAliases()
+        // #139 Ensure that aliases are added last so to avoid dependency issues
+        cleanedEntities.Sort(delegate (E e1, E e2)
         {
-            List<E> cleanedEntities = new List<E>();
-            // Do we have any aliases?
-            foreach (E importEntity in EntitiesToImport)
+            return Data.TranslateAlias(e1).CompareTo(Data.TranslateAlias(e2));
+        });
+
+        EntitiesToImport = cleanedEntities;
+    }
+
+    private void ValidateDefinitionList(List<E> modelEntities, List<D> importDefinitions)
+    {
+        Dictionary<E, List<E>> detectedAliases = new Dictionary<E, List<E>>();
+        foreach (E entity in modelEntities)
+        {
+            if (Data.IsAlias(entity))
             {
-                if (Data.HasAliases(importEntity))
+                E masterEntity = Data.TranslateAlias(entity);
+                if (!detectedAliases.ContainsKey(masterEntity))
+                {
+                    detectedAliases[masterEntity] = new List<E>();
+                }
+                detectedAliases[masterEntity].Add(entity);
+            }
+        }
+
+        foreach (E masterEntity in detectedAliases.Keys)
+        {
+            if (detectedAliases[masterEntity].Count > 1)
+            {
+                if (!Data.IsAliasDuplicatePermitted(masterEntity))
                 {
                     throw new TransportException(string.Format
                     (
-                        "Cannot import ambiguous entity {0} - choose an alias from [{1}].",
-                        importEntity.ToString(),
-                        string.Join(", ", Data.GetAliases(importEntity))
+                        "Only one alias per entity can exist in the same level. [{0}] were found as aliases for {1}.",
+                        string.Join(", ", detectedAliases[masterEntity]),
+                        masterEntity.ToString()
                     ));
                 }
-
-                bool entityIsValid = true;
-                if (Data.IsAlias(importEntity))
+                else if (Data.AliasPriority.ContainsKey(masterEntity))
                 {
-                    E existingEntity = Data.GetLevelAlias(LevelName, Data.TranslateAlias(importEntity));
-                    // This entity is only valid if the alias it's for is not already there
-                    entityIsValid = !Equals(importEntity, existingEntity);
-                }
-
-                if (entityIsValid)
-                {
-                    cleanedEntities.Add(importEntity);
-                }
-            }
-
-            // #139 Ensure that aliases are added last so to avoid dependency issues
-            cleanedEntities.Sort(delegate (E e1, E e2)
-            {
-                return Data.TranslateAlias(e1).CompareTo(Data.TranslateAlias(e2));
-            });
-
-            EntitiesToImport = cleanedEntities;
-        }
-
-        private void ValidateDefinitionList(List<E> modelEntities, List<D> importDefinitions)
-        {
-            Dictionary<E, List<E>> detectedAliases = new Dictionary<E, List<E>>();
-            foreach (E entity in modelEntities)
-            {
-                if (Data.IsAlias(entity))
-                {
-                    E masterEntity = Data.TranslateAlias(entity);
-                    if (!detectedAliases.ContainsKey(masterEntity))
-                    {
-                        detectedAliases[masterEntity] = new List<E>();
-                    }
-                    detectedAliases[masterEntity].Add(entity);
-                }
-            }
-
-            foreach (E masterEntity in detectedAliases.Keys)
-            {
-                if (detectedAliases[masterEntity].Count > 1)
-                {
-                    if (!Data.IsAliasDuplicatePermitted(masterEntity))
-                    {
-                        throw new TransportException(string.Format
-                        (
-                            "Only one alias per entity can exist in the same level. [{0}] were found as aliases for {1}.",
-                            string.Join(", ", detectedAliases[masterEntity]),
-                            masterEntity.ToString()
-                        ));
-                    }
-                    else if (Data.AliasPriority.ContainsKey(masterEntity))
-                    {
-                        // If we are importing two aliases such as LaraMiscAnim_Unwater and LaraMiscAnim_Xian,
-                        // allow the priority list to define exactly what imports. Otherwise while the prioritised
-                        // model will be imported, other aspects such as texture import will try to import both.
-                        E prioritisedType = Data.AliasPriority[masterEntity];
-                        importDefinitions.RemoveAll(d => detectedAliases[masterEntity].Contains(d.Alias) && !Equals(d.Alias, prioritisedType));
-                    }
+                    // If we are importing two aliases such as LaraMiscAnim_Unwater and LaraMiscAnim_Xian,
+                    // allow the priority list to define exactly what imports. Otherwise while the prioritised
+                    // model will be imported, other aspects such as texture import will try to import both.
+                    E prioritisedType = Data.AliasPriority[masterEntity];
+                    importDefinitions.RemoveAll(d => detectedAliases[masterEntity].Contains(d.Alias) && !Equals(d.Alias, prioritisedType));
                 }
             }
         }
-
-        private void BuildDefinitionList(List<D> standardModelDefinitions, List<D> soundModelDefinitions, List<E> modelEntities, E nextEntity, bool isDependency)
-        {
-            if (modelEntities.Contains(nextEntity))
-            {
-                // Are we allowed to replace it?
-                if (!Data.IsOverridePermitted(nextEntity))
-                {
-                    // If the model already in the list is a dependency only, but the new one to add isn't, switch it
-                    D definition = standardModelDefinitions.Find(m => Equals(m.Alias, nextEntity));
-                    if (definition != null && definition.IsDependencyOnly && !isDependency)
-                    {
-                        definition.IsDependencyOnly = false;
-                    }
-                    else if (EntitiesToRemove.Contains(nextEntity))
-                    {
-                        EntitiesToRemove = new List<E>(EntitiesToRemove).Except(new List<E> { nextEntity });
-                    }
-
-                    // Avoid issues with cyclic dependencies by adding separately. The caveat here is
-                    // cyclic dependencies can't have further sub-dependencies.
-                    IEnumerable<E> cyclicDependencies = Data.GetCyclicDependencies(nextEntity);
-                    foreach (E cyclicDependency in cyclicDependencies)
-                    {
-                        if (!modelEntities.Contains(cyclicDependency) || Data.IsOverridePermitted(cyclicDependency))
-                        {
-                            modelEntities.Add(cyclicDependency);
-                            standardModelDefinitions.Add(LoadDefinition(cyclicDependency));
-                        }
-                    }
-
-                    return;
-                }
-            }
-
-            D nextDefinition = LoadDefinition(nextEntity);
-            nextDefinition.IsDependencyOnly = isDependency;
-            modelEntities.Add(nextEntity);
-
-            // Add dependencies first
-            foreach (E dependency in nextDefinition.Dependencies)
-            {
-                // If it's a non-graphics dependency, but we are importing another alias
-                // for it, or the level already contains the dependency, we don't need it.
-                bool nonGraphics = Data.IsNonGraphicsDependency(dependency);
-                E aliasFor = Data.TranslateAlias(dependency);
-                if (!Equals(aliasFor, dependency) && nonGraphics)
-                {
-                    bool required = true;
-                    // #139 check entire model list for instances where alias and dependencies cause clashes
-                    foreach (E entity in modelEntities)
-                    {
-                        // If this entity and the dependency are in the same family
-                        if (Equals(aliasFor, Data.TranslateAlias(entity)))
-                        {
-                            // Skip it
-                            required = false;
-                            break;
-                        }
-                    }
-
-                    if (!required)
-                    {
-                        // We don't need the graphics, but do we need hardcoded sound?
-                        if (Data.IsSoundOnlyDependency(dependency) && standardModelDefinitions.Find(m => Equals(m.Alias, dependency)) == null)
-                        {
-                            soundModelDefinitions.Add(LoadDefinition(dependency));
-                        }
-
-                        continue;
-                    }
-                }
-
-                BuildDefinitionList(standardModelDefinitions, soundModelDefinitions, modelEntities, dependency, nonGraphics);
-            }
-
-            standardModelDefinitions.Add(nextDefinition);
-        }
-
-        protected abstract List<E> GetExistingModelTypes();
-        protected abstract void Import(IEnumerable<D> standardDefinitions, IEnumerable<D> soundOnlyDefinitions);
     }
+
+    private void BuildDefinitionList(List<D> standardModelDefinitions, List<D> soundModelDefinitions, List<E> modelEntities, E nextEntity, bool isDependency)
+    {
+        if (modelEntities.Contains(nextEntity))
+        {
+            // Are we allowed to replace it?
+            if (!Data.IsOverridePermitted(nextEntity))
+            {
+                // If the model already in the list is a dependency only, but the new one to add isn't, switch it
+                D definition = standardModelDefinitions.Find(m => Equals(m.Alias, nextEntity));
+                if (definition != null && definition.IsDependencyOnly && !isDependency)
+                {
+                    definition.IsDependencyOnly = false;
+                }
+                else if (EntitiesToRemove.Contains(nextEntity))
+                {
+                    EntitiesToRemove = new List<E>(EntitiesToRemove).Except(new List<E> { nextEntity });
+                }
+
+                // Avoid issues with cyclic dependencies by adding separately. The caveat here is
+                // cyclic dependencies can't have further sub-dependencies.
+                IEnumerable<E> cyclicDependencies = Data.GetCyclicDependencies(nextEntity);
+                foreach (E cyclicDependency in cyclicDependencies)
+                {
+                    if (!modelEntities.Contains(cyclicDependency) || Data.IsOverridePermitted(cyclicDependency))
+                    {
+                        modelEntities.Add(cyclicDependency);
+                        standardModelDefinitions.Add(LoadDefinition(cyclicDependency));
+                    }
+                }
+
+                return;
+            }
+        }
+
+        D nextDefinition = LoadDefinition(nextEntity);
+        nextDefinition.IsDependencyOnly = isDependency;
+        modelEntities.Add(nextEntity);
+
+        // Add dependencies first
+        foreach (E dependency in nextDefinition.Dependencies)
+        {
+            // If it's a non-graphics dependency, but we are importing another alias
+            // for it, or the level already contains the dependency, we don't need it.
+            bool nonGraphics = Data.IsNonGraphicsDependency(dependency);
+            E aliasFor = Data.TranslateAlias(dependency);
+            if (!Equals(aliasFor, dependency) && nonGraphics)
+            {
+                bool required = true;
+                // #139 check entire model list for instances where alias and dependencies cause clashes
+                foreach (E entity in modelEntities)
+                {
+                    // If this entity and the dependency are in the same family
+                    if (Equals(aliasFor, Data.TranslateAlias(entity)))
+                    {
+                        // Skip it
+                        required = false;
+                        break;
+                    }
+                }
+
+                if (!required)
+                {
+                    // We don't need the graphics, but do we need hardcoded sound?
+                    if (Data.IsSoundOnlyDependency(dependency) && standardModelDefinitions.Find(m => Equals(m.Alias, dependency)) == null)
+                    {
+                        soundModelDefinitions.Add(LoadDefinition(dependency));
+                    }
+
+                    continue;
+                }
+            }
+
+            BuildDefinitionList(standardModelDefinitions, soundModelDefinitions, modelEntities, dependency, nonGraphics);
+        }
+
+        standardModelDefinitions.Add(nextDefinition);
+    }
+
+    protected abstract List<E> GetExistingModelTypes();
+    protected abstract void Import(IEnumerable<D> standardDefinitions, IEnumerable<D> soundOnlyDefinitions);
 }

--- a/TRModelTransporter/Transport/AbstractTRModelImporter.cs
+++ b/TRModelTransporter/Transport/AbstractTRModelImporter.cs
@@ -120,7 +120,7 @@ public abstract class AbstractTRModelImporter<E, L, D> : AbstractTRModelTranspor
                 // There may be null meshes dependent on this removal, so we can only remove it if they're
                 // being removed as well.
                 IEnumerable<E> exclusions = Data.GetRemovalExclusions(entity);
-                if (exclusions.Count() > 0 && exclusions.All(EntitiesToRemove.Contains))
+                if (exclusions.Any() && exclusions.All(EntitiesToRemove.Contains))
                 {
                     entityClean = false;
                 }

--- a/TRModelTransporter/Transport/AbstractTRModelTransport.cs
+++ b/TRModelTransporter/Transport/AbstractTRModelTransport.cs
@@ -1,9 +1,6 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
-using System.IO;
 using TRModelTransporter.Data;
 using TRModelTransporter.Handlers;
 using TRModelTransporter.Model;

--- a/TRModelTransporter/Transport/AbstractTRModelTransport.cs
+++ b/TRModelTransporter/Transport/AbstractTRModelTransport.cs
@@ -8,86 +8,85 @@ using TRModelTransporter.Data;
 using TRModelTransporter.Handlers;
 using TRModelTransporter.Model;
 
-namespace TRModelTransporter.Transport
+namespace TRModelTransporter.Transport;
+
+public abstract class AbstractTRModelTransport<E, L, D> 
+    where E : Enum
+    where L : class
+    where D : AbstractTRModelDefinition<E>
 {
-    public abstract class AbstractTRModelTransport<E, L, D> 
-        where E : Enum
-        where L : class
-        where D : AbstractTRModelDefinition<E>
+    protected static readonly string _defaultDataFolder = @"Resources\Models";
+    protected static readonly string _dataFileName = "Data.json";
+    protected static readonly string _imageFileName = "Segments.png";
+
+    public ITransportDataProvider<E> Data { get; set; }
+    public L Level { get; set; }
+
+    public string LevelName { get; set; }
+
+    public string DataFolder { get; set; }
+
+    protected readonly AnimationTransportHandler _animationHandler;
+    protected readonly CinematicTransportHandler _cinematicHandler;
+    protected readonly MeshTransportHandler _meshHandler;
+    protected readonly ModelTransportHandler _modelHandler;
+    protected readonly ColourTransportHandler _colourHandler;
+    protected readonly SoundTransportHandler _soundHandler;
+
+    public AbstractTRModelTransport()
     {
-        protected static readonly string _defaultDataFolder = @"Resources\Models";
-        protected static readonly string _dataFileName = "Data.json";
-        protected static readonly string _imageFileName = "Segments.png";
+        DataFolder = _defaultDataFolder;
 
-        public ITransportDataProvider<E> Data { get; set; }
-        public L Level { get; set; }
+        _animationHandler = new AnimationTransportHandler();
+        _cinematicHandler = new CinematicTransportHandler();
+        _meshHandler = new MeshTransportHandler();
+        _modelHandler = new ModelTransportHandler();
+        _colourHandler = new ColourTransportHandler();
+        _soundHandler = new SoundTransportHandler();
+    }
 
-        public string LevelName { get; set; }
-
-        public string DataFolder { get; set; }
-
-        protected readonly AnimationTransportHandler _animationHandler;
-        protected readonly CinematicTransportHandler _cinematicHandler;
-        protected readonly MeshTransportHandler _meshHandler;
-        protected readonly ModelTransportHandler _modelHandler;
-        protected readonly ColourTransportHandler _colourHandler;
-        protected readonly SoundTransportHandler _soundHandler;
-
-        public AbstractTRModelTransport()
+    protected void StoreDefinition(D definition)
+    {
+        string directory = Path.Combine(DataFolder, definition.Alias.ToString());
+        if (!Directory.Exists(directory))
         {
-            DataFolder = _defaultDataFolder;
-
-            _animationHandler = new AnimationTransportHandler();
-            _cinematicHandler = new CinematicTransportHandler();
-            _meshHandler = new MeshTransportHandler();
-            _modelHandler = new ModelTransportHandler();
-            _colourHandler = new ColourTransportHandler();
-            _soundHandler = new SoundTransportHandler();
+            Directory.CreateDirectory(directory);
         }
 
-        protected void StoreDefinition(D definition)
+        if (definition.HasGraphics)
         {
-            string directory = Path.Combine(DataFolder, definition.Alias.ToString());
-            if (!Directory.Exists(directory))
-            {
-                Directory.CreateDirectory(directory);
-            }
+            definition.Bitmap.Save(Path.Combine(directory, _imageFileName), ImageFormat.Png);
+        }
+        File.WriteAllText(Path.Combine(directory, _dataFileName), JsonConvert.SerializeObject(definition, Formatting.None));
+    }
 
-            if (definition.HasGraphics)
-            {
-                definition.Bitmap.Save(Path.Combine(directory, _imageFileName), ImageFormat.Png);
-            }
-            File.WriteAllText(Path.Combine(directory, _dataFileName), JsonConvert.SerializeObject(definition, Formatting.None));
+    public D LoadDefinition(E modelEntity)
+    {
+        string directory = Path.Combine(DataFolder, modelEntity.ToString());
+        string dataFilePath = Path.Combine(directory, _dataFileName);
+        string imageFilePath = Path.Combine(directory, _imageFileName);
+
+        if (!File.Exists(dataFilePath))
+        {
+            throw new IOException(string.Format("Missing model data JSON file ({0})", dataFilePath));
         }
 
-        public D LoadDefinition(E modelEntity)
+        D definition = JsonConvert.DeserializeObject<D>(File.ReadAllText(dataFilePath));
+        definition.Alias = modelEntity;
+
+        if (definition.HasGraphics)
         {
-            string directory = Path.Combine(DataFolder, modelEntity.ToString());
-            string dataFilePath = Path.Combine(directory, _dataFileName);
-            string imageFilePath = Path.Combine(directory, _imageFileName);
-
-            if (!File.Exists(dataFilePath))
+            if (!File.Exists(imageFilePath))
             {
-                throw new IOException(string.Format("Missing model data JSON file ({0})", dataFilePath));
+                throw new IOException(string.Format("Missing model data image file ({0})", imageFilePath));
             }
-
-            D definition = JsonConvert.DeserializeObject<D>(File.ReadAllText(dataFilePath));
-            definition.Alias = modelEntity;
-
-            if (definition.HasGraphics)
-            {
-                if (!File.Exists(imageFilePath))
-                {
-                    throw new IOException(string.Format("Missing model data image file ({0})", imageFilePath));
-                }
-                definition.Bitmap = new Bitmap(imageFilePath);
-            }
-            return definition;
+            definition.Bitmap = new Bitmap(imageFilePath);
         }
+        return definition;
+    }
 
-        protected bool Equals(E e1, E e2)
-        {
-            return EqualityComparer<E>.Default.Equals(e1, e2);
-        }
+    protected bool Equals(E e1, E e2)
+    {
+        return EqualityComparer<E>.Default.Equals(e1, e2);
     }
 }

--- a/TRModelTransporter/Transport/TR1/TR1ModelExporter.cs
+++ b/TRModelTransporter/Transport/TR1/TR1ModelExporter.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using TRLevelControl;
+﻿using TRLevelControl;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;

--- a/TRModelTransporter/Transport/TR1/TR1ModelExporter.cs
+++ b/TRModelTransporter/Transport/TR1/TR1ModelExporter.cs
@@ -33,13 +33,13 @@ public class TR1ModelExporter : AbstractTRModelExporter<TREntities, TR1Level, TR
             modelEntity = Data.TranslateAlias(modelEntity);
         }
 
-        _modelHandler.Export(level, definition, modelEntity);
-        _meshHandler.Export(level, definition);
-        _colourHandler.Export(level, definition);
+        ModelTransportHandler.Export(level, definition, modelEntity);
+        MeshTransportHandler.Export(level, definition);
+        ColourTransportHandler.Export(level, definition);
         _textureHandler.Export(level, definition, TextureClassifier, Data.GetSpriteDependencies(modelEntity), Data.GetIgnorableTextureIndices(modelEntity, LevelName));
-        _animationHandler.Export(level, definition);
-        _cinematicHandler.Export(level, definition, Data.GetCinematicEntities());
-        _soundHandler.Export(level, definition, Data.GetHardcodedSounds(definition.Alias));
+        AnimationTransportHandler.Export(level, definition);
+        CinematicTransportHandler.Export(level, definition, Data.GetCinematicEntities());
+        SoundTransportHandler.Export(level, definition, Data.GetHardcodedSounds(definition.Alias));
 
         return definition;
     }

--- a/TRModelTransporter/Transport/TR1/TR1ModelExporter.cs
+++ b/TRModelTransporter/Transport/TR1/TR1ModelExporter.cs
@@ -23,7 +23,7 @@ public class TR1ModelExporter : AbstractTRModelExporter<TREntities, TR1Level, TR
 
     protected override TR1ModelDefinition CreateModelDefinition(TR1Level level, TREntities modelEntity)
     {
-        TR1ModelDefinition definition = new TR1ModelDefinition
+        TR1ModelDefinition definition = new()
         {
             Alias = modelEntity
         };

--- a/TRModelTransporter/Transport/TR1/TR1ModelExporter.cs
+++ b/TRModelTransporter/Transport/TR1/TR1ModelExporter.cs
@@ -10,212 +10,211 @@ using TRModelTransporter.Handlers;
 using TRModelTransporter.Handlers.Textures;
 using TRModelTransporter.Model.Definitions;
 
-namespace TRModelTransporter.Transport
+namespace TRModelTransporter.Transport;
+
+public class TR1ModelExporter : AbstractTRModelExporter<TREntities, TR1Level, TR1ModelDefinition>
 {
-    public class TR1ModelExporter : AbstractTRModelExporter<TREntities, TR1Level, TR1ModelDefinition>
+    public TR1ModelExporter()
     {
-        public TR1ModelExporter()
+        Data = new TR1DefaultDataProvider();
+    }
+
+    protected override AbstractTextureExportHandler<TREntities, TR1Level, TR1ModelDefinition> CreateTextureHandler()
+    {
+        return new TR1TextureExportHandler();
+    }
+
+    protected override TR1ModelDefinition CreateModelDefinition(TR1Level level, TREntities modelEntity)
+    {
+        TR1ModelDefinition definition = new TR1ModelDefinition
         {
-            Data = new TR1DefaultDataProvider();
+            Alias = modelEntity
+        };
+
+        if (Data.IsAlias(modelEntity))
+        {
+            modelEntity = Data.TranslateAlias(modelEntity);
         }
 
-        protected override AbstractTextureExportHandler<TREntities, TR1Level, TR1ModelDefinition> CreateTextureHandler()
+        _modelHandler.Export(level, definition, modelEntity);
+        _meshHandler.Export(level, definition);
+        _colourHandler.Export(level, definition);
+        _textureHandler.Export(level, definition, TextureClassifier, Data.GetSpriteDependencies(modelEntity), Data.GetIgnorableTextureIndices(modelEntity, LevelName));
+        _animationHandler.Export(level, definition);
+        _cinematicHandler.Export(level, definition, Data.GetCinematicEntities());
+        _soundHandler.Export(level, definition, Data.GetHardcodedSounds(definition.Alias));
+
+        return definition;
+    }
+
+    protected override void PreDefinitionCreation(TR1Level level, TREntities modelEntity)
+    {
+        switch (modelEntity)
         {
-            return new TR1TextureExportHandler();
+            case TREntities.Pierre:
+                AmendPierreGunshot(level);
+                AmendPierreDeath(level);
+                break;
+            case TREntities.Larson:
+                AmendLarsonDeath(level);
+                break;
+            case TREntities.SkateboardKid:
+                AmendSkaterBoyDeath(level);
+                break;
+            case TREntities.Natla:
+                AmendNatlaDeath(level);
+                break;
+            case TREntities.MovingBlock:
+                AddMovingBlockSFX(level);
+                break;
+        }
+    }
+
+    protected override void ModelExportReady(TR1ModelDefinition definition)
+    {
+        switch (definition.Alias)
+        {
+            case TREntities.Kold:
+                if (definition.Colours.ContainsKey(123))
+                {
+                    // Incorrect orange colouring on head and hands
+                    definition.Colours[123].Red = 28;
+                    definition.Colours[123].Green = 18;
+                    definition.Colours[123].Blue = 4;
+                }
+                break;
+            case TREntities.SkateboardKid:
+                if (definition.Colours.ContainsKey(182))
+                {
+                    // Incorrect yellow colouring on his arm
+                    definition.Colours[182].Red = 51;
+                    definition.Colours[182].Green = 33;
+                    definition.Colours[182].Blue = 22;
+                }
+                break;
+            case TREntities.CowboyHeadless:
+                AmendDXtre3DTextures(definition);
+                break;
+            default:
+                break;
+        }
+    }
+
+    public static void AmendPierreGunshot(TR1Level level)
+    {
+        TRModel model = Array.Find(level.Models, m => m.ID == (uint)TREntities.Pierre);
+        // Get his shooting animation
+        TRAnimation anim = level.Animations[model.Animation + 10];
+        List<TRAnimCommand> cmds = level.AnimCommands.ToList();
+        anim.AnimCommand = (ushort)cmds.Count;
+        anim.NumAnimCommands = 1;
+
+        // On the 2nd frame, play SFX 44 (magnums)
+        cmds.Add(new TRAnimCommand { Value = 5 });
+        cmds.Add(new TRAnimCommand { Value = (short)(anim.FrameStart + 1) });
+        cmds.Add(new TRAnimCommand { Value = 44 });
+
+        level.AnimCommands = cmds.ToArray();
+        level.NumAnimCommands = (uint)cmds.Count;
+    }
+
+    public static void AmendPierreDeath(TR1Level level)
+    {
+        TRModel model = Array.Find(level.Models, m => m.ID == (uint)TREntities.Pierre);
+        // Get his death animation
+        TRAnimation anim = level.Animations[model.Animation + 12];
+        anim.NumAnimCommands++;
+
+        List<TRAnimCommand> cmds = level.AnimCommands.ToList();
+        anim.AnimCommand = (ushort)cmds.Count;
+        cmds.Add(new TRAnimCommand { Value = 4 }); // Death
+
+        // On the 61st frame, play SFX 159 (death)
+        cmds.Add(new TRAnimCommand { Value = 5 });
+        cmds.Add(new TRAnimCommand { Value = (short)(anim.FrameStart + 60) });
+        cmds.Add(new TRAnimCommand { Value = 159 });
+
+        level.AnimCommands = cmds.ToArray();
+        level.NumAnimCommands = (uint)cmds.Count;
+    }
+
+    public static void AmendLarsonDeath(TR1Level level)
+    {
+        TRModel model = Array.Find(level.Models, m => m.ID == (uint)TREntities.Larson);
+        // Get his death animation
+        TRAnimation anim = level.Animations[model.Animation + 15];
+        anim.NumAnimCommands++;
+
+        List<TRAnimCommand> cmds = level.AnimCommands.ToList();
+        anim.AnimCommand = (ushort)cmds.Count;
+        cmds.Add(new TRAnimCommand { Value = 4 }); // Death
+
+        // On the 2nd frame, play SFX 158 (death)
+        cmds.Add(new TRAnimCommand { Value = 5 });
+        cmds.Add(new TRAnimCommand { Value = (short)(anim.FrameStart + 1) });
+        cmds.Add(new TRAnimCommand { Value = 158 });
+
+        level.AnimCommands = cmds.ToArray();
+        level.NumAnimCommands = (uint)cmds.Count;
+    }
+
+    public static void AmendSkaterBoyDeath(TR1Level level)
+    {
+        TRModel model = Array.Find(level.Models, m => m.ID == (uint)TREntities.SkateboardKid);
+        // Get his death animation
+        TRAnimation anim = level.Animations[model.Animation + 13];
+        // Play the death sound on the 2nd frame (doesn't work on the 1st, which is OG).
+        level.AnimCommands[anim.AnimCommand + 2].Value++;
+    }
+
+    public static void AmendNatlaDeath(TR1Level level)
+    {
+        TRModel model = Array.Find(level.Models, m => m.ID == (uint)TREntities.Natla);
+        // Get her death animation
+        TRAnimation anim = level.Animations[model.Animation + 13];
+        anim.NumAnimCommands++;
+
+        List<TRAnimCommand> cmds = level.AnimCommands.ToList();
+        anim.AnimCommand = (ushort)cmds.Count;
+        cmds.Add(new TRAnimCommand { Value = 4 }); // Death
+
+        // On the 5th frame, play SFX 160 (death)
+        cmds.Add(new TRAnimCommand { Value = 5 });
+        cmds.Add(new TRAnimCommand { Value = (short)(anim.FrameStart + 4) });
+        cmds.Add(new TRAnimCommand { Value = 160 });
+
+        level.AnimCommands = cmds.ToArray();
+        level.NumAnimCommands = (uint)cmds.Count;
+    }
+
+    public static void AddMovingBlockSFX(TR1Level level)
+    {
+        // ToQ moving blocks are silent but we want them to scrape along the floor when they move.
+        // Import the trapdoor closing SFX from Vilcabamba and adjust the animations accordingly.
+
+        if (level.SoundMap[162] == -1)
+        {
+            TR1Level vilcabamba = new TR1LevelControl().Read(TR1LevelNames.VILCABAMBA);
+            SoundUtilities.ImportLevelSound(level, vilcabamba, new short[] { 162 });
         }
 
-        protected override TR1ModelDefinition CreateModelDefinition(TR1Level level, TREntities modelEntity)
+        TRModel model = Array.Find(level.Models, m => m.ID == (uint)TREntities.MovingBlock);
+        List<TRAnimCommand> cmds = level.AnimCommands.ToList();
+        for (int i = 2; i < 4; i++)
         {
-            TR1ModelDefinition definition = new TR1ModelDefinition
-            {
-                Alias = modelEntity
-            };
-
-            if (Data.IsAlias(modelEntity))
-            {
-                modelEntity = Data.TranslateAlias(modelEntity);
-            }
-
-            _modelHandler.Export(level, definition, modelEntity);
-            _meshHandler.Export(level, definition);
-            _colourHandler.Export(level, definition);
-            _textureHandler.Export(level, definition, TextureClassifier, Data.GetSpriteDependencies(modelEntity), Data.GetIgnorableTextureIndices(modelEntity, LevelName));
-            _animationHandler.Export(level, definition);
-            _cinematicHandler.Export(level, definition, Data.GetCinematicEntities());
-            _soundHandler.Export(level, definition, Data.GetHardcodedSounds(definition.Alias));
-
-            return definition;
-        }
-
-        protected override void PreDefinitionCreation(TR1Level level, TREntities modelEntity)
-        {
-            switch (modelEntity)
-            {
-                case TREntities.Pierre:
-                    AmendPierreGunshot(level);
-                    AmendPierreDeath(level);
-                    break;
-                case TREntities.Larson:
-                    AmendLarsonDeath(level);
-                    break;
-                case TREntities.SkateboardKid:
-                    AmendSkaterBoyDeath(level);
-                    break;
-                case TREntities.Natla:
-                    AmendNatlaDeath(level);
-                    break;
-                case TREntities.MovingBlock:
-                    AddMovingBlockSFX(level);
-                    break;
-            }
-        }
-
-        protected override void ModelExportReady(TR1ModelDefinition definition)
-        {
-            switch (definition.Alias)
-            {
-                case TREntities.Kold:
-                    if (definition.Colours.ContainsKey(123))
-                    {
-                        // Incorrect orange colouring on head and hands
-                        definition.Colours[123].Red = 28;
-                        definition.Colours[123].Green = 18;
-                        definition.Colours[123].Blue = 4;
-                    }
-                    break;
-                case TREntities.SkateboardKid:
-                    if (definition.Colours.ContainsKey(182))
-                    {
-                        // Incorrect yellow colouring on his arm
-                        definition.Colours[182].Red = 51;
-                        definition.Colours[182].Green = 33;
-                        definition.Colours[182].Blue = 22;
-                    }
-                    break;
-                case TREntities.CowboyHeadless:
-                    AmendDXtre3DTextures(definition);
-                    break;
-                default:
-                    break;
-            }
-        }
-
-        public static void AmendPierreGunshot(TR1Level level)
-        {
-            TRModel model = Array.Find(level.Models, m => m.ID == (uint)TREntities.Pierre);
-            // Get his shooting animation
-            TRAnimation anim = level.Animations[model.Animation + 10];
-            List<TRAnimCommand> cmds = level.AnimCommands.ToList();
-            anim.AnimCommand = (ushort)cmds.Count;
-            anim.NumAnimCommands = 1;
-
-            // On the 2nd frame, play SFX 44 (magnums)
-            cmds.Add(new TRAnimCommand { Value = 5 });
-            cmds.Add(new TRAnimCommand { Value = (short)(anim.FrameStart + 1) });
-            cmds.Add(new TRAnimCommand { Value = 44 });
-
-            level.AnimCommands = cmds.ToArray();
-            level.NumAnimCommands = (uint)cmds.Count;
-        }
-
-        public static void AmendPierreDeath(TR1Level level)
-        {
-            TRModel model = Array.Find(level.Models, m => m.ID == (uint)TREntities.Pierre);
-            // Get his death animation
-            TRAnimation anim = level.Animations[model.Animation + 12];
+            TRAnimation anim = level.Animations[model.Animation + i];
             anim.NumAnimCommands++;
 
-            List<TRAnimCommand> cmds = level.AnimCommands.ToList();
             anim.AnimCommand = (ushort)cmds.Count;
-            cmds.Add(new TRAnimCommand { Value = 4 }); // Death
+            cmds.Add(new TRAnimCommand { Value = 4 }); // KillItem
 
-            // On the 61st frame, play SFX 159 (death)
+            // On the 1st frame, play SFX 162
             cmds.Add(new TRAnimCommand { Value = 5 });
-            cmds.Add(new TRAnimCommand { Value = (short)(anim.FrameStart + 60) });
-            cmds.Add(new TRAnimCommand { Value = 159 });
+            cmds.Add(new TRAnimCommand { Value = (short)(anim.FrameStart) });
+            cmds.Add(new TRAnimCommand { Value = 162 });
+        }            
 
-            level.AnimCommands = cmds.ToArray();
-            level.NumAnimCommands = (uint)cmds.Count;
-        }
-
-        public static void AmendLarsonDeath(TR1Level level)
-        {
-            TRModel model = Array.Find(level.Models, m => m.ID == (uint)TREntities.Larson);
-            // Get his death animation
-            TRAnimation anim = level.Animations[model.Animation + 15];
-            anim.NumAnimCommands++;
-
-            List<TRAnimCommand> cmds = level.AnimCommands.ToList();
-            anim.AnimCommand = (ushort)cmds.Count;
-            cmds.Add(new TRAnimCommand { Value = 4 }); // Death
-
-            // On the 2nd frame, play SFX 158 (death)
-            cmds.Add(new TRAnimCommand { Value = 5 });
-            cmds.Add(new TRAnimCommand { Value = (short)(anim.FrameStart + 1) });
-            cmds.Add(new TRAnimCommand { Value = 158 });
-
-            level.AnimCommands = cmds.ToArray();
-            level.NumAnimCommands = (uint)cmds.Count;
-        }
-
-        public static void AmendSkaterBoyDeath(TR1Level level)
-        {
-            TRModel model = Array.Find(level.Models, m => m.ID == (uint)TREntities.SkateboardKid);
-            // Get his death animation
-            TRAnimation anim = level.Animations[model.Animation + 13];
-            // Play the death sound on the 2nd frame (doesn't work on the 1st, which is OG).
-            level.AnimCommands[anim.AnimCommand + 2].Value++;
-        }
-
-        public static void AmendNatlaDeath(TR1Level level)
-        {
-            TRModel model = Array.Find(level.Models, m => m.ID == (uint)TREntities.Natla);
-            // Get her death animation
-            TRAnimation anim = level.Animations[model.Animation + 13];
-            anim.NumAnimCommands++;
-
-            List<TRAnimCommand> cmds = level.AnimCommands.ToList();
-            anim.AnimCommand = (ushort)cmds.Count;
-            cmds.Add(new TRAnimCommand { Value = 4 }); // Death
-
-            // On the 5th frame, play SFX 160 (death)
-            cmds.Add(new TRAnimCommand { Value = 5 });
-            cmds.Add(new TRAnimCommand { Value = (short)(anim.FrameStart + 4) });
-            cmds.Add(new TRAnimCommand { Value = 160 });
-
-            level.AnimCommands = cmds.ToArray();
-            level.NumAnimCommands = (uint)cmds.Count;
-        }
-
-        public static void AddMovingBlockSFX(TR1Level level)
-        {
-            // ToQ moving blocks are silent but we want them to scrape along the floor when they move.
-            // Import the trapdoor closing SFX from Vilcabamba and adjust the animations accordingly.
-
-            if (level.SoundMap[162] == -1)
-            {
-                TR1Level vilcabamba = new TR1LevelControl().Read(TR1LevelNames.VILCABAMBA);
-                SoundUtilities.ImportLevelSound(level, vilcabamba, new short[] { 162 });
-            }
-
-            TRModel model = Array.Find(level.Models, m => m.ID == (uint)TREntities.MovingBlock);
-            List<TRAnimCommand> cmds = level.AnimCommands.ToList();
-            for (int i = 2; i < 4; i++)
-            {
-                TRAnimation anim = level.Animations[model.Animation + i];
-                anim.NumAnimCommands++;
-
-                anim.AnimCommand = (ushort)cmds.Count;
-                cmds.Add(new TRAnimCommand { Value = 4 }); // KillItem
-
-                // On the 1st frame, play SFX 162
-                cmds.Add(new TRAnimCommand { Value = 5 });
-                cmds.Add(new TRAnimCommand { Value = (short)(anim.FrameStart) });
-                cmds.Add(new TRAnimCommand { Value = 162 });
-            }            
-
-            level.AnimCommands = cmds.ToArray();
-            level.NumAnimCommands = (uint)cmds.Count;
-        }
+        level.AnimCommands = cmds.ToArray();
+        level.NumAnimCommands = (uint)cmds.Count;
     }
 }

--- a/TRModelTransporter/Transport/TR1/TR1ModelImporter.cs
+++ b/TRModelTransporter/Transport/TR1/TR1ModelImporter.cs
@@ -34,7 +34,7 @@ public class TR1ModelImporter : AbstractTRModelImporter<TREntities, TR1Level, TR
 
     protected override List<TREntities> GetExistingModelTypes()
     {
-        List<TREntities> existingEntities = new List<TREntities>();
+        List<TREntities> existingEntities = new();
         Level.Models.ToList().ForEach(m => existingEntities.Add((TREntities)m.ID));
         return existingEntities;
     }

--- a/TRModelTransporter/Transport/TR1/TR1ModelImporter.cs
+++ b/TRModelTransporter/Transport/TR1/TR1ModelImporter.cs
@@ -1,7 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;
 using TRModelTransporter.Data;

--- a/TRModelTransporter/Transport/TR1/TR1ModelImporter.cs
+++ b/TRModelTransporter/Transport/TR1/TR1ModelImporter.cs
@@ -56,7 +56,7 @@ public class TR1ModelImporter : AbstractTRModelImporter<TREntities, TR1Level, TR
             _textureHandler.Import(Level, standardDefinitions, EntitiesToRemove, remap, ClearUnusedSprites, TexturePositionMonitor);
         }
 
-        _soundHandler.Import(Level, standardDefinitions.Concat(soundOnlyDefinitions));
+        SoundTransportHandler.Import(Level, standardDefinitions.Concat(soundOnlyDefinitions));
 
         Dictionary<TREntities, TREntities> aliasPriority = Data.AliasPriority ?? new Dictionary<TREntities, TREntities>();
 
@@ -64,12 +64,12 @@ public class TR1ModelImporter : AbstractTRModelImporter<TREntities, TR1Level, TR
         {
             if (!IgnoreGraphics)
             {
-                _colourHandler.Import(Level, definition, PaletteManager);
+                ColourTransportHandler.Import(Level, definition, PaletteManager);
             }
-            _meshHandler.Import(Level, definition);
-            _animationHandler.Import(Level, definition);
-            _cinematicHandler.Import(Level, definition);
-            _modelHandler.Import(Level, definition, aliasPriority, Data.GetLaraDependants());
+            MeshTransportHandler.Import(Level, definition);
+            AnimationTransportHandler.Import(Level, definition);
+            CinematicTransportHandler.Import(Level, definition);
+            ModelTransportHandler.Import(Level, definition, aliasPriority, Data.GetLaraDependants());
         }
 
         if (!IgnoreGraphics)

--- a/TRModelTransporter/Transport/TR1/TR1ModelImporter.cs
+++ b/TRModelTransporter/Transport/TR1/TR1ModelImporter.cs
@@ -11,75 +11,74 @@ using TRModelTransporter.Model.Definitions;
 using TRModelTransporter.Model.Textures;
 using TRTexture16Importer.Helpers;
 
-namespace TRModelTransporter.Transport
+namespace TRModelTransporter.Transport;
+
+public class TR1ModelImporter : AbstractTRModelImporter<TREntities, TR1Level, TR1ModelDefinition>
 {
-    public class TR1ModelImporter : AbstractTRModelImporter<TREntities, TR1Level, TR1ModelDefinition>
+    public TR1PaletteManager PaletteManager { get; set; }
+
+    public TR1ModelImporter(bool isCommunityPatch = false)
     {
-        public TR1PaletteManager PaletteManager { get; set; }
+        Data = new TR1DefaultDataProvider();
+        SortModels = true;
+        PaletteManager = new TR1PaletteManager();
 
-        public TR1ModelImporter(bool isCommunityPatch = false)
+        if (isCommunityPatch)
         {
-            Data = new TR1DefaultDataProvider();
-            SortModels = true;
-            PaletteManager = new TR1PaletteManager();
+            Data.TextureTileLimit = 128;
+            Data.TextureObjectLimit = 8192;
+        }
+    }
 
-            if (isCommunityPatch)
-            {
-                Data.TextureTileLimit = 128;
-                Data.TextureObjectLimit = 8192;
-            }
+    protected override AbstractTextureImportHandler<TREntities, TR1Level, TR1ModelDefinition> CreateTextureHandler()
+    {
+        return new TR1TextureImportHandler();
+    }
+
+    protected override List<TREntities> GetExistingModelTypes()
+    {
+        List<TREntities> existingEntities = new List<TREntities>();
+        Level.Models.ToList().ForEach(m => existingEntities.Add((TREntities)m.ID));
+        return existingEntities;
+    }
+
+    protected override void Import(IEnumerable<TR1ModelDefinition> standardDefinitions, IEnumerable<TR1ModelDefinition> soundOnlyDefinitions)
+    {
+        TR1TextureRemapGroup remap = null;
+        if (TextureRemapPath != null)
+        {
+            remap = JsonConvert.DeserializeObject<TR1TextureRemapGroup>(File.ReadAllText(TextureRemapPath));
         }
 
-        protected override AbstractTextureImportHandler<TREntities, TR1Level, TR1ModelDefinition> CreateTextureHandler()
+        if (!IgnoreGraphics)
         {
-            return new TR1TextureImportHandler();
+            PaletteManager.Level = Level;
+            PaletteManager.ObsoleteModels = EntitiesToRemove.Select(e => Data.TranslateAlias(e)).ToList();
+
+            (_textureHandler as TR1TextureImportHandler).PaletteManager = PaletteManager;
+            _textureHandler.Import(Level, standardDefinitions, EntitiesToRemove, remap, ClearUnusedSprites, TexturePositionMonitor);
         }
 
-        protected override List<TREntities> GetExistingModelTypes()
-        {
-            List<TREntities> existingEntities = new List<TREntities>();
-            Level.Models.ToList().ForEach(m => existingEntities.Add((TREntities)m.ID));
-            return existingEntities;
-        }
+        _soundHandler.Import(Level, standardDefinitions.Concat(soundOnlyDefinitions));
 
-        protected override void Import(IEnumerable<TR1ModelDefinition> standardDefinitions, IEnumerable<TR1ModelDefinition> soundOnlyDefinitions)
-        {
-            TR1TextureRemapGroup remap = null;
-            if (TextureRemapPath != null)
-            {
-                remap = JsonConvert.DeserializeObject<TR1TextureRemapGroup>(File.ReadAllText(TextureRemapPath));
-            }
+        Dictionary<TREntities, TREntities> aliasPriority = Data.AliasPriority ?? new Dictionary<TREntities, TREntities>();
 
+        foreach (TR1ModelDefinition definition in standardDefinitions)
+        {
             if (!IgnoreGraphics)
             {
-                PaletteManager.Level = Level;
-                PaletteManager.ObsoleteModels = EntitiesToRemove.Select(e => Data.TranslateAlias(e)).ToList();
-
-                (_textureHandler as TR1TextureImportHandler).PaletteManager = PaletteManager;
-                _textureHandler.Import(Level, standardDefinitions, EntitiesToRemove, remap, ClearUnusedSprites, TexturePositionMonitor);
+                _colourHandler.Import(Level, definition, PaletteManager);
             }
+            _meshHandler.Import(Level, definition);
+            _animationHandler.Import(Level, definition);
+            _cinematicHandler.Import(Level, definition);
+            _modelHandler.Import(Level, definition, aliasPriority, Data.GetLaraDependants());
+        }
 
-            _soundHandler.Import(Level, standardDefinitions.Concat(soundOnlyDefinitions));
-
-            Dictionary<TREntities, TREntities> aliasPriority = Data.AliasPriority ?? new Dictionary<TREntities, TREntities>();
-
-            foreach (TR1ModelDefinition definition in standardDefinitions)
-            {
-                if (!IgnoreGraphics)
-                {
-                    _colourHandler.Import(Level, definition, PaletteManager);
-                }
-                _meshHandler.Import(Level, definition);
-                _animationHandler.Import(Level, definition);
-                _cinematicHandler.Import(Level, definition);
-                _modelHandler.Import(Level, definition, aliasPriority, Data.GetLaraDependants());
-            }
-
-            if (!IgnoreGraphics)
-            {
-                _textureHandler.ResetUnusedTextures();
-                PaletteManager.Dispose();
-            }
+        if (!IgnoreGraphics)
+        {
+            _textureHandler.ResetUnusedTextures();
+            PaletteManager.Dispose();
         }
     }
 }

--- a/TRModelTransporter/Transport/TR1/TR1ModelImporter.cs
+++ b/TRModelTransporter/Transport/TR1/TR1ModelImporter.cs
@@ -64,7 +64,7 @@ public class TR1ModelImporter : AbstractTRModelImporter<TREntities, TR1Level, TR
         {
             if (!IgnoreGraphics)
             {
-                ColourTransportHandler.Import(Level, definition, PaletteManager);
+                ColourTransportHandler.Import(definition, PaletteManager);
             }
             MeshTransportHandler.Import(Level, definition);
             AnimationTransportHandler.Import(Level, definition);

--- a/TRModelTransporter/Transport/TR2/TR2ModelExporter.cs
+++ b/TRModelTransporter/Transport/TR2/TR2ModelExporter.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using TRLevelControl.Model;
+﻿using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;
 using TRModelTransporter.Data;
 using TRModelTransporter.Handlers;

--- a/TRModelTransporter/Transport/TR2/TR2ModelExporter.cs
+++ b/TRModelTransporter/Transport/TR2/TR2ModelExporter.cs
@@ -31,13 +31,13 @@ public class TR2ModelExporter : AbstractTRModelExporter<TR2Entities, TR2Level, T
             modelEntity = Data.TranslateAlias(modelEntity);
         }
 
-        _modelHandler.Export(level, definition, modelEntity);
-        _meshHandler.Export(level, definition);
-        _colourHandler.Export(level, definition);
+        ModelTransportHandler.Export(level, definition, modelEntity);
+        MeshTransportHandler.Export(level, definition);
+        ColourTransportHandler.Export(level, definition);
         _textureHandler.Export(level, definition, TextureClassifier, Data.GetSpriteDependencies(modelEntity), Data.GetIgnorableTextureIndices(modelEntity, LevelName));
-        _animationHandler.Export(level, definition);
-        _cinematicHandler.Export(level, definition, Data.GetCinematicEntities());
-        _soundHandler.Export(level, definition, Data.GetHardcodedSounds(definition.Alias));
+        AnimationTransportHandler.Export(level, definition);
+        CinematicTransportHandler.Export(level, definition, Data.GetCinematicEntities());
+        SoundTransportHandler.Export(level, definition, Data.GetHardcodedSounds(definition.Alias));
 
         return definition;
     }
@@ -59,7 +59,7 @@ public class TR2ModelExporter : AbstractTRModelExporter<TR2Entities, TR2Level, T
         }
     }
 
-    private void AmendDXtre3DFlameTextures(TR2ModelDefinition definition)
+    private static void AmendDXtre3DFlameTextures(TR2ModelDefinition definition)
     {
         if (!definition.SpriteSequences.ContainsKey(TR2Entities.Flame_S_H))
         {

--- a/TRModelTransporter/Transport/TR2/TR2ModelExporter.cs
+++ b/TRModelTransporter/Transport/TR2/TR2ModelExporter.cs
@@ -21,7 +21,7 @@ public class TR2ModelExporter : AbstractTRModelExporter<TR2Entities, TR2Level, T
 
     protected override TR2ModelDefinition CreateModelDefinition(TR2Level level, TR2Entities modelEntity)
     {
-        TR2ModelDefinition definition = new TR2ModelDefinition
+        TR2ModelDefinition definition = new()
         {
             Alias = modelEntity
         };

--- a/TRModelTransporter/Transport/TR2/TR2ModelExporter.cs
+++ b/TRModelTransporter/Transport/TR2/TR2ModelExporter.cs
@@ -6,78 +6,77 @@ using TRModelTransporter.Handlers;
 using TRModelTransporter.Model.Definitions;
 using TRModelTransporter.Model.Textures;
 
-namespace TRModelTransporter.Transport
+namespace TRModelTransporter.Transport;
+
+public class TR2ModelExporter : AbstractTRModelExporter<TR2Entities, TR2Level, TR2ModelDefinition>
 {
-    public class TR2ModelExporter : AbstractTRModelExporter<TR2Entities, TR2Level, TR2ModelDefinition>
+    public TR2ModelExporter()
     {
-        public TR2ModelExporter()
+        Data = new TR2DefaultDataProvider();
+    }
+
+    protected override AbstractTextureExportHandler<TR2Entities, TR2Level, TR2ModelDefinition> CreateTextureHandler()
+    {
+        return new TR2TextureExportHandler();
+    }
+
+    protected override TR2ModelDefinition CreateModelDefinition(TR2Level level, TR2Entities modelEntity)
+    {
+        TR2ModelDefinition definition = new TR2ModelDefinition
         {
-            Data = new TR2DefaultDataProvider();
+            Alias = modelEntity
+        };
+
+        if (Data.IsAlias(modelEntity))
+        {
+            modelEntity = Data.TranslateAlias(modelEntity);
         }
 
-        protected override AbstractTextureExportHandler<TR2Entities, TR2Level, TR2ModelDefinition> CreateTextureHandler()
+        _modelHandler.Export(level, definition, modelEntity);
+        _meshHandler.Export(level, definition);
+        _colourHandler.Export(level, definition);
+        _textureHandler.Export(level, definition, TextureClassifier, Data.GetSpriteDependencies(modelEntity), Data.GetIgnorableTextureIndices(modelEntity, LevelName));
+        _animationHandler.Export(level, definition);
+        _cinematicHandler.Export(level, definition, Data.GetCinematicEntities());
+        _soundHandler.Export(level, definition, Data.GetHardcodedSounds(definition.Alias));
+
+        return definition;
+    }
+
+    protected override void ModelExportReady(TR2ModelDefinition definition)
+    {
+        switch (definition.Alias)
         {
-            return new TR2TextureExportHandler();
+            case TR2Entities.FlamethrowerGoonTopixtor:
+                AmendDXtre3DTextures(definition);
+                AmendDXtre3DFlameTextures(definition);
+                break;
+            case TR2Entities.Gunman1TopixtorORC:
+            case TR2Entities.Gunman1TopixtorCAC:
+                AmendDXtre3DTextures(definition);
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void AmendDXtre3DFlameTextures(TR2ModelDefinition definition)
+    {
+        if (!definition.SpriteSequences.ContainsKey(TR2Entities.Flame_S_H))
+        {
+            return;
         }
 
-        protected override TR2ModelDefinition CreateModelDefinition(TR2Level level, TR2Entities modelEntity)
+        // Ensures the flame sprite is aligned to OG - required for texture monitoring
+        TRSpriteSequence seq = definition.SpriteSequences[TR2Entities.Flame_S_H];
+        seq.Offset += 22;
+
+        Dictionary<int, List<IndexedTRSpriteTexture>> defaultSprites = definition.SpriteTextures[TR2Entities.Flame_S_H];
+        foreach (int id in defaultSprites.Keys)
         {
-            TR2ModelDefinition definition = new TR2ModelDefinition
+            foreach (IndexedTRSpriteTexture sprite in defaultSprites[id])
             {
-                Alias = modelEntity
-            };
-
-            if (Data.IsAlias(modelEntity))
-            {
-                modelEntity = Data.TranslateAlias(modelEntity);
-            }
-
-            _modelHandler.Export(level, definition, modelEntity);
-            _meshHandler.Export(level, definition);
-            _colourHandler.Export(level, definition);
-            _textureHandler.Export(level, definition, TextureClassifier, Data.GetSpriteDependencies(modelEntity), Data.GetIgnorableTextureIndices(modelEntity, LevelName));
-            _animationHandler.Export(level, definition);
-            _cinematicHandler.Export(level, definition, Data.GetCinematicEntities());
-            _soundHandler.Export(level, definition, Data.GetHardcodedSounds(definition.Alias));
-
-            return definition;
-        }
-
-        protected override void ModelExportReady(TR2ModelDefinition definition)
-        {
-            switch (definition.Alias)
-            {
-                case TR2Entities.FlamethrowerGoonTopixtor:
-                    AmendDXtre3DTextures(definition);
-                    AmendDXtre3DFlameTextures(definition);
-                    break;
-                case TR2Entities.Gunman1TopixtorORC:
-                case TR2Entities.Gunman1TopixtorCAC:
-                    AmendDXtre3DTextures(definition);
-                    break;
-                default:
-                    break;
-            }
-        }
-
-        private void AmendDXtre3DFlameTextures(TR2ModelDefinition definition)
-        {
-            if (!definition.SpriteSequences.ContainsKey(TR2Entities.Flame_S_H))
-            {
-                return;
-            }
-
-            // Ensures the flame sprite is aligned to OG - required for texture monitoring
-            TRSpriteSequence seq = definition.SpriteSequences[TR2Entities.Flame_S_H];
-            seq.Offset += 22;
-
-            Dictionary<int, List<IndexedTRSpriteTexture>> defaultSprites = definition.SpriteTextures[TR2Entities.Flame_S_H];
-            foreach (int id in defaultSprites.Keys)
-            {
-                foreach (IndexedTRSpriteTexture sprite in defaultSprites[id])
-                {
-                    sprite.Index += 22;
-                }
+                sprite.Index += 22;
             }
         }
     }

--- a/TRModelTransporter/Transport/TR2/TR2ModelImporter.cs
+++ b/TRModelTransporter/Transport/TR2/TR2ModelImporter.cs
@@ -45,7 +45,7 @@ public class TR2ModelImporter : AbstractTRModelImporter<TR2Entities, TR2Level, T
 
         // Hardcoded sounds are also imported en-masse to ensure the correct SoundMap indices are assigned
         // before any animation sounds are dealt with.
-        _soundHandler.Import(Level, standardDefinitions.Concat(soundOnlyDefinitions));
+        SoundTransportHandler.Import(Level, standardDefinitions.Concat(soundOnlyDefinitions));
 
         // Allow external alias model priorities to be defined
         Dictionary<TR2Entities, TR2Entities> aliasPriority = Data.AliasPriority ?? new Dictionary<TR2Entities, TR2Entities>();
@@ -55,20 +55,20 @@ public class TR2ModelImporter : AbstractTRModelImporter<TR2Entities, TR2Level, T
             if (!IgnoreGraphics)
             {
                 // Colours next, again to remap Mesh rectangles/triangles to any new palette indices
-                _colourHandler.Import(Level, definition);
+                ColourTransportHandler.Import(Level, definition);
             }
 
             // Meshes and trees should now be remapped, so import into the level
-            _meshHandler.Import(Level, definition);
+            MeshTransportHandler.Import(Level, definition);
 
             // Animations, AnimCommands, AnimDispatches, Sounds, StateChanges and Frames
-            _animationHandler.Import(Level, definition);
+            AnimationTransportHandler.Import(Level, definition);
 
             // Cinematic frames
-            _cinematicHandler.Import(Level, definition);
+            CinematicTransportHandler.Import(Level, definition);
 
             // Add the model, which will have the correct StartingMesh, MeshTree, Frame and Animation offset.
-            _modelHandler.Import(Level, definition, aliasPriority, Data.GetLaraDependants());
+            ModelTransportHandler.Import(Level, definition, aliasPriority, Data.GetLaraDependants());
         }
 
         if (!IgnoreGraphics)

--- a/TRModelTransporter/Transport/TR2/TR2ModelImporter.cs
+++ b/TRModelTransporter/Transport/TR2/TR2ModelImporter.cs
@@ -1,7 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;
 using TRModelTransporter.Data;

--- a/TRModelTransporter/Transport/TR2/TR2ModelImporter.cs
+++ b/TRModelTransporter/Transport/TR2/TR2ModelImporter.cs
@@ -9,75 +9,74 @@ using TRModelTransporter.Handlers;
 using TRModelTransporter.Model.Definitions;
 using TRModelTransporter.Model.Textures;
 
-namespace TRModelTransporter.Transport
+namespace TRModelTransporter.Transport;
+
+public class TR2ModelImporter : AbstractTRModelImporter<TR2Entities, TR2Level, TR2ModelDefinition>
 {
-    public class TR2ModelImporter : AbstractTRModelImporter<TR2Entities, TR2Level, TR2ModelDefinition>
+    public TR2ModelImporter()
     {
-        public TR2ModelImporter()
+        Data = new TR2DefaultDataProvider();
+    }
+
+    protected override AbstractTextureImportHandler<TR2Entities, TR2Level, TR2ModelDefinition> CreateTextureHandler()
+    {
+        return new TR2TextureImportHandler();
+    }
+
+    protected override List<TR2Entities> GetExistingModelTypes()
+    {
+        List<TR2Entities> existingEntities = new List<TR2Entities>();
+        Level.Models.ToList().ForEach(m => existingEntities.Add((TR2Entities)m.ID));
+        return existingEntities;
+    }
+
+    protected override void Import(IEnumerable<TR2ModelDefinition> standardDefinitions, IEnumerable<TR2ModelDefinition> soundOnlyDefinitions)
+    {
+        // Textures first, which will remap Mesh rectangles/triangles to the new texture indices.
+        // This is called using the entire entity list to import so that RectanglePacker packer has
+        // the best chance to organise the tiles.
+        TR2TextureRemapGroup remap = null;
+        if (TextureRemapPath != null)
         {
-            Data = new TR2DefaultDataProvider();
+            remap = JsonConvert.DeserializeObject<TR2TextureRemapGroup>(File.ReadAllText(TextureRemapPath));
         }
 
-        protected override AbstractTextureImportHandler<TR2Entities, TR2Level, TR2ModelDefinition> CreateTextureHandler()
+        if (!IgnoreGraphics)
         {
-            return new TR2TextureImportHandler();
+            _textureHandler.Import(Level, standardDefinitions, EntitiesToRemove, remap, ClearUnusedSprites, TexturePositionMonitor);
         }
 
-        protected override List<TR2Entities> GetExistingModelTypes()
-        {
-            List<TR2Entities> existingEntities = new List<TR2Entities>();
-            Level.Models.ToList().ForEach(m => existingEntities.Add((TR2Entities)m.ID));
-            return existingEntities;
-        }
+        // Hardcoded sounds are also imported en-masse to ensure the correct SoundMap indices are assigned
+        // before any animation sounds are dealt with.
+        _soundHandler.Import(Level, standardDefinitions.Concat(soundOnlyDefinitions));
 
-        protected override void Import(IEnumerable<TR2ModelDefinition> standardDefinitions, IEnumerable<TR2ModelDefinition> soundOnlyDefinitions)
-        {
-            // Textures first, which will remap Mesh rectangles/triangles to the new texture indices.
-            // This is called using the entire entity list to import so that RectanglePacker packer has
-            // the best chance to organise the tiles.
-            TR2TextureRemapGroup remap = null;
-            if (TextureRemapPath != null)
-            {
-                remap = JsonConvert.DeserializeObject<TR2TextureRemapGroup>(File.ReadAllText(TextureRemapPath));
-            }
+        // Allow external alias model priorities to be defined
+        Dictionary<TR2Entities, TR2Entities> aliasPriority = Data.AliasPriority ?? new Dictionary<TR2Entities, TR2Entities>();
 
+        foreach (TR2ModelDefinition definition in standardDefinitions)
+        {
             if (!IgnoreGraphics)
             {
-                _textureHandler.Import(Level, standardDefinitions, EntitiesToRemove, remap, ClearUnusedSprites, TexturePositionMonitor);
+                // Colours next, again to remap Mesh rectangles/triangles to any new palette indices
+                _colourHandler.Import(Level, definition);
             }
 
-            // Hardcoded sounds are also imported en-masse to ensure the correct SoundMap indices are assigned
-            // before any animation sounds are dealt with.
-            _soundHandler.Import(Level, standardDefinitions.Concat(soundOnlyDefinitions));
+            // Meshes and trees should now be remapped, so import into the level
+            _meshHandler.Import(Level, definition);
 
-            // Allow external alias model priorities to be defined
-            Dictionary<TR2Entities, TR2Entities> aliasPriority = Data.AliasPriority ?? new Dictionary<TR2Entities, TR2Entities>();
+            // Animations, AnimCommands, AnimDispatches, Sounds, StateChanges and Frames
+            _animationHandler.Import(Level, definition);
 
-            foreach (TR2ModelDefinition definition in standardDefinitions)
-            {
-                if (!IgnoreGraphics)
-                {
-                    // Colours next, again to remap Mesh rectangles/triangles to any new palette indices
-                    _colourHandler.Import(Level, definition);
-                }
+            // Cinematic frames
+            _cinematicHandler.Import(Level, definition);
 
-                // Meshes and trees should now be remapped, so import into the level
-                _meshHandler.Import(Level, definition);
+            // Add the model, which will have the correct StartingMesh, MeshTree, Frame and Animation offset.
+            _modelHandler.Import(Level, definition, aliasPriority, Data.GetLaraDependants());
+        }
 
-                // Animations, AnimCommands, AnimDispatches, Sounds, StateChanges and Frames
-                _animationHandler.Import(Level, definition);
-
-                // Cinematic frames
-                _cinematicHandler.Import(Level, definition);
-
-                // Add the model, which will have the correct StartingMesh, MeshTree, Frame and Animation offset.
-                _modelHandler.Import(Level, definition, aliasPriority, Data.GetLaraDependants());
-            }
-
-            if (!IgnoreGraphics)
-            {
-                _textureHandler.ResetUnusedTextures();
-            }
+        if (!IgnoreGraphics)
+        {
+            _textureHandler.ResetUnusedTextures();
         }
     }
 }

--- a/TRModelTransporter/Transport/TR2/TR2ModelImporter.cs
+++ b/TRModelTransporter/Transport/TR2/TR2ModelImporter.cs
@@ -22,7 +22,7 @@ public class TR2ModelImporter : AbstractTRModelImporter<TR2Entities, TR2Level, T
 
     protected override List<TR2Entities> GetExistingModelTypes()
     {
-        List<TR2Entities> existingEntities = new List<TR2Entities>();
+        List<TR2Entities> existingEntities = new();
         Level.Models.ToList().ForEach(m => existingEntities.Add((TR2Entities)m.ID));
         return existingEntities;
     }

--- a/TRModelTransporter/Transport/TR3/TR3ModelExporter.cs
+++ b/TRModelTransporter/Transport/TR3/TR3ModelExporter.cs
@@ -30,13 +30,13 @@ public class TR3ModelExporter : AbstractTRModelExporter<TR3Entities, TR3Level, T
             modelEntity = Data.TranslateAlias(modelEntity);
         }
 
-        _modelHandler.Export(level, definition, modelEntity);
-        _meshHandler.Export(level, definition);
-        _colourHandler.Export(level, definition);
+        ModelTransportHandler.Export(level, definition, modelEntity);
+        MeshTransportHandler.Export(level, definition);
+        ColourTransportHandler.Export(level, definition);
         _textureHandler.Export(level, definition, TextureClassifier, Data.GetSpriteDependencies(modelEntity), Data.GetIgnorableTextureIndices(modelEntity, LevelName));
-        _animationHandler.Export(level, definition);
-        _cinematicHandler.Export(level, definition, Data.GetCinematicEntities());
-        _soundHandler.Export(level, definition, Data.GetHardcodedSounds(definition.Alias));
+        AnimationTransportHandler.Export(level, definition);
+        CinematicTransportHandler.Export(level, definition, Data.GetCinematicEntities());
+        SoundTransportHandler.Export(level, definition, Data.GetHardcodedSounds(definition.Alias));
 
         return definition;
     }

--- a/TRModelTransporter/Transport/TR3/TR3ModelExporter.cs
+++ b/TRModelTransporter/Transport/TR3/TR3ModelExporter.cs
@@ -20,7 +20,7 @@ public class TR3ModelExporter : AbstractTRModelExporter<TR3Entities, TR3Level, T
 
     protected override TR3ModelDefinition CreateModelDefinition(TR3Level level, TR3Entities modelEntity)
     {
-        TR3ModelDefinition definition = new TR3ModelDefinition
+        TR3ModelDefinition definition = new()
         {
             Alias = modelEntity
         };

--- a/TRModelTransporter/Transport/TR3/TR3ModelExporter.cs
+++ b/TRModelTransporter/Transport/TR3/TR3ModelExporter.cs
@@ -4,41 +4,40 @@ using TRModelTransporter.Data;
 using TRModelTransporter.Handlers;
 using TRModelTransporter.Model.Definitions;
 
-namespace TRModelTransporter.Transport
+namespace TRModelTransporter.Transport;
+
+public class TR3ModelExporter : AbstractTRModelExporter<TR3Entities, TR3Level, TR3ModelDefinition>
 {
-    public class TR3ModelExporter : AbstractTRModelExporter<TR3Entities, TR3Level, TR3ModelDefinition>
+    public TR3ModelExporter()
     {
-        public TR3ModelExporter()
+        Data = new TR3DefaultDataProvider();
+    }
+
+    protected override AbstractTextureExportHandler<TR3Entities, TR3Level, TR3ModelDefinition> CreateTextureHandler()
+    {
+        return new TR3TextureExportHandler();
+    }
+
+    protected override TR3ModelDefinition CreateModelDefinition(TR3Level level, TR3Entities modelEntity)
+    {
+        TR3ModelDefinition definition = new TR3ModelDefinition
         {
-            Data = new TR3DefaultDataProvider();
+            Alias = modelEntity
+        };
+
+        if (Data.IsAlias(modelEntity))
+        {
+            modelEntity = Data.TranslateAlias(modelEntity);
         }
 
-        protected override AbstractTextureExportHandler<TR3Entities, TR3Level, TR3ModelDefinition> CreateTextureHandler()
-        {
-            return new TR3TextureExportHandler();
-        }
+        _modelHandler.Export(level, definition, modelEntity);
+        _meshHandler.Export(level, definition);
+        _colourHandler.Export(level, definition);
+        _textureHandler.Export(level, definition, TextureClassifier, Data.GetSpriteDependencies(modelEntity), Data.GetIgnorableTextureIndices(modelEntity, LevelName));
+        _animationHandler.Export(level, definition);
+        _cinematicHandler.Export(level, definition, Data.GetCinematicEntities());
+        _soundHandler.Export(level, definition, Data.GetHardcodedSounds(definition.Alias));
 
-        protected override TR3ModelDefinition CreateModelDefinition(TR3Level level, TR3Entities modelEntity)
-        {
-            TR3ModelDefinition definition = new TR3ModelDefinition
-            {
-                Alias = modelEntity
-            };
-
-            if (Data.IsAlias(modelEntity))
-            {
-                modelEntity = Data.TranslateAlias(modelEntity);
-            }
-
-            _modelHandler.Export(level, definition, modelEntity);
-            _meshHandler.Export(level, definition);
-            _colourHandler.Export(level, definition);
-            _textureHandler.Export(level, definition, TextureClassifier, Data.GetSpriteDependencies(modelEntity), Data.GetIgnorableTextureIndices(modelEntity, LevelName));
-            _animationHandler.Export(level, definition);
-            _cinematicHandler.Export(level, definition, Data.GetCinematicEntities());
-            _soundHandler.Export(level, definition, Data.GetHardcodedSounds(definition.Alias));
-
-            return definition;
-        }
+        return definition;
     }
 }

--- a/TRModelTransporter/Transport/TR3/TR3ModelImporter.cs
+++ b/TRModelTransporter/Transport/TR3/TR3ModelImporter.cs
@@ -41,7 +41,7 @@ public class TR3ModelImporter : AbstractTRModelImporter<TR3Entities, TR3Level, T
             _textureHandler.Import(Level, standardDefinitions, EntitiesToRemove, remap, ClearUnusedSprites, TexturePositionMonitor);
         }
 
-        _soundHandler.Import(Level, standardDefinitions.Concat(soundOnlyDefinitions));
+        SoundTransportHandler.Import(Level, standardDefinitions.Concat(soundOnlyDefinitions));
 
         Dictionary<TR3Entities, TR3Entities> aliasPriority = Data.AliasPriority ?? new Dictionary<TR3Entities, TR3Entities>();
 
@@ -49,12 +49,12 @@ public class TR3ModelImporter : AbstractTRModelImporter<TR3Entities, TR3Level, T
         {
             if (!IgnoreGraphics)
             {
-                _colourHandler.Import(Level, definition);
+                ColourTransportHandler.Import(Level, definition);
             }
-            _meshHandler.Import(Level, definition);
-            _animationHandler.Import(Level, definition);
-            _cinematicHandler.Import(Level, definition);
-            _modelHandler.Import(Level, definition, aliasPriority, Data.GetLaraDependants(), Data.GetUnsafeModelReplacements());
+            MeshTransportHandler.Import(Level, definition);
+            AnimationTransportHandler.Import(Level, definition);
+            CinematicTransportHandler.Import(Level, definition);
+            ModelTransportHandler.Import(Level, definition, aliasPriority, Data.GetLaraDependants(), Data.GetUnsafeModelReplacements());
         }
 
         if (!IgnoreGraphics)

--- a/TRModelTransporter/Transport/TR3/TR3ModelImporter.cs
+++ b/TRModelTransporter/Transport/TR3/TR3ModelImporter.cs
@@ -1,7 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;
 using TRModelTransporter.Data;

--- a/TRModelTransporter/Transport/TR3/TR3ModelImporter.cs
+++ b/TRModelTransporter/Transport/TR3/TR3ModelImporter.cs
@@ -23,7 +23,7 @@ public class TR3ModelImporter : AbstractTRModelImporter<TR3Entities, TR3Level, T
 
     protected override List<TR3Entities> GetExistingModelTypes()
     {
-        List<TR3Entities> existingEntities = new List<TR3Entities>();
+        List<TR3Entities> existingEntities = new();
         Level.Models.ToList().ForEach(m => existingEntities.Add((TR3Entities)m.ID));
         return existingEntities;
     }

--- a/TRModelTransporter/Transport/TransportException.cs
+++ b/TRModelTransporter/Transport/TransportException.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace TRModelTransporter.Transport;
+﻿namespace TRModelTransporter.Transport;
 
 public class TransportException : Exception
 {

--- a/TRModelTransporter/Transport/TransportException.cs
+++ b/TRModelTransporter/Transport/TransportException.cs
@@ -1,16 +1,15 @@
 ﻿using System;
 
-namespace TRModelTransporter.Transport
+namespace TRModelTransporter.Transport;
+
+public class TransportException : Exception
 {
-    public class TransportException : Exception
-    {
-        public TransportException()
-            : base() { }
+    public TransportException()
+        : base() { }
 
-        public TransportException(string message)
-            : base(message) { }
+    public TransportException(string message)
+        : base(message) { }
 
-        public TransportException(string message, Exception innerException)
-            : base(message, innerException) { }
-    }
+    public TransportException(string message, Exception innerException)
+        : base(message, innerException) { }
 }

--- a/TRModelTransporter/Utilities/AbstractMassTRModelExporter.cs
+++ b/TRModelTransporter/Utilities/AbstractMassTRModelExporter.cs
@@ -4,60 +4,59 @@ using System.IO;
 using TRModelTransporter.Model;
 using TRModelTransporter.Transport;
 
-namespace TRModelTransporter.Utilities
+namespace TRModelTransporter.Utilities;
+
+public abstract class AbstractMassTRModelExporter<E, L, D>
+    where E : Enum
+    where L : class
+    where D : AbstractTRModelDefinition<E>
 {
-    public abstract class AbstractMassTRModelExporter<E, L, D>
-        where E : Enum
-        where L : class
-        where D : AbstractTRModelDefinition<E>
+    public abstract List<string> LevelNames { get; }
+    public abstract Dictionary<string, List<E>> ExportTypes { get; }
+
+    private AbstractTRModelExporter<E, L, D> _exporter;
+    private List<E> _processedEntities;
+
+    public void Export(string levelFileDirectory, string exportDirectory, string segmentsDirectory = null)
     {
-        public abstract List<string> LevelNames { get; }
-        public abstract Dictionary<string, List<E>> ExportTypes { get; }
+        _exporter = CreateExporter();
+        _exporter.ExportIndividualSegments = segmentsDirectory != null;
+        _exporter.SegmentsDataFolder = segmentsDirectory;
+        _exporter.DataFolder = exportDirectory;
+        _processedEntities = new List<E>();
 
-        private AbstractTRModelExporter<E, L, D> _exporter;
-        private List<E> _processedEntities;
-
-        public void Export(string levelFileDirectory, string exportDirectory, string segmentsDirectory = null)
+        foreach (string lvlName in LevelNames)
         {
-            _exporter = CreateExporter();
-            _exporter.ExportIndividualSegments = segmentsDirectory != null;
-            _exporter.SegmentsDataFolder = segmentsDirectory;
-            _exporter.DataFolder = exportDirectory;
-            _processedEntities = new List<E>();
-
-            foreach (string lvlName in LevelNames)
+            _exporter.LevelName = lvlName;
+            if (ExportTypes.ContainsKey(lvlName))
             {
-                _exporter.LevelName = lvlName;
-                if (ExportTypes.ContainsKey(lvlName))
+                string levelPath = Path.Combine(levelFileDirectory, lvlName);
+                foreach (E entity in ExportTypes[lvlName])
                 {
-                    string levelPath = Path.Combine(levelFileDirectory, lvlName);
-                    foreach (E entity in ExportTypes[lvlName])
-                    {
-                        Export(levelPath, entity);
-                    }
+                    Export(levelPath, entity);
                 }
             }
         }
-
-        private void Export(string levelPath, E entity)
-        {
-            if (!_processedEntities.Contains(entity))
-            {
-                // The level has to be re-read per entity because TextureTransportHandler can modify ObjectTextures
-                // which when shared between entities is difficult to undo.
-                _exporter.TextureClassifier = new TRTextureClassifier(levelPath);
-                L level = ReadLevel(levelPath);
-                D definition = _exporter.Export(level, entity);
-                _processedEntities.Add(entity);
-
-                foreach (E dependency in definition.Dependencies)
-                {
-                    Export(levelPath, dependency);
-                }
-            }
-        }
-
-        protected abstract AbstractTRModelExporter<E, L, D> CreateExporter();
-        protected abstract L ReadLevel(string path);
     }
+
+    private void Export(string levelPath, E entity)
+    {
+        if (!_processedEntities.Contains(entity))
+        {
+            // The level has to be re-read per entity because TextureTransportHandler can modify ObjectTextures
+            // which when shared between entities is difficult to undo.
+            _exporter.TextureClassifier = new TRTextureClassifier(levelPath);
+            L level = ReadLevel(levelPath);
+            D definition = _exporter.Export(level, entity);
+            _processedEntities.Add(entity);
+
+            foreach (E dependency in definition.Dependencies)
+            {
+                Export(levelPath, dependency);
+            }
+        }
+    }
+
+    protected abstract AbstractTRModelExporter<E, L, D> CreateExporter();
+    protected abstract L ReadLevel(string path);
 }

--- a/TRModelTransporter/Utilities/AbstractMassTRModelExporter.cs
+++ b/TRModelTransporter/Utilities/AbstractMassTRModelExporter.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using TRModelTransporter.Model;
+﻿using TRModelTransporter.Model;
 using TRModelTransporter.Transport;
 
 namespace TRModelTransporter.Utilities;

--- a/TRModelTransporter/Utilities/AbstractMassTRTextureDeduplicator.cs
+++ b/TRModelTransporter/Utilities/AbstractMassTRTextureDeduplicator.cs
@@ -1,9 +1,6 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing.Imaging;
-using System.IO;
 using TRModelTransporter.Model.Textures;
 using TRModelTransporter.Packing;
 

--- a/TRModelTransporter/Utilities/AbstractMassTRTextureDeduplicator.cs
+++ b/TRModelTransporter/Utilities/AbstractMassTRTextureDeduplicator.cs
@@ -7,144 +7,143 @@ using System.IO;
 using TRModelTransporter.Model.Textures;
 using TRModelTransporter.Packing;
 
-namespace TRModelTransporter.Utilities
+namespace TRModelTransporter.Utilities;
+
+public abstract class AbstractMassTRTextureDeduplicator<E, L>
+    where E : Enum
+    where L : class
 {
-    public abstract class AbstractMassTRTextureDeduplicator<E, L>
-        where E : Enum
-        where L : class
+    public abstract List<string> LevelNames { get; }
+
+    public string LevelFileDirectory { get; set; }
+    public string OutputDirectory { get; set; }
+    public bool OutputTileImages { get; set; }
+
+    private readonly TRTextureDeduplicator<E> _deduplicator;
+    private readonly Dictionary<string, AbstractTextureRemapGroup<E, L>> _levelRemap;
+    private string _currentLevel;
+    private int _currentSave;
+
+    public AbstractMassTRTextureDeduplicator()
     {
-        public abstract List<string> LevelNames { get; }
-
-        public string LevelFileDirectory { get; set; }
-        public string OutputDirectory { get; set; }
-        public bool OutputTileImages { get; set; }
-
-        private readonly TRTextureDeduplicator<E> _deduplicator;
-        private readonly Dictionary<string, AbstractTextureRemapGroup<E, L>> _levelRemap;
-        private string _currentLevel;
-        private int _currentSave;
-
-        public AbstractMassTRTextureDeduplicator()
+        _deduplicator = new TRTextureDeduplicator<E>
         {
-            _deduplicator = new TRTextureDeduplicator<E>
-            {
-                UpdateGraphics = true
-            };
+            UpdateGraphics = true
+        };
 
-            _levelRemap = new Dictionary<string, AbstractTextureRemapGroup<E, L>>();
-        }
+        _levelRemap = new Dictionary<string, AbstractTextureRemapGroup<E, L>>();
+    }
 
 
-        public void Export()
-        {
-            Directory.CreateDirectory(OutputDirectory);
-            _deduplicator.SegmentRemapped += SegmentRepositioned;
+    public void Export()
+    {
+        Directory.CreateDirectory(OutputDirectory);
+        _deduplicator.SegmentRemapped += SegmentRepositioned;
 
-            try
-            {
-                foreach (string lvlName in LevelNames)
-                {
-                    _currentLevel = lvlName;
-                    _currentSave = 0;
-                    string lvlPath = Path.Combine(LevelFileDirectory, lvlName);
-                    if (File.Exists(lvlPath))
-                    {
-                        ExportDuplicateLevelTextures(lvlPath);
-                    }
-                }
-
-                if (_levelRemap.Count > 0)
-                {
-                    File.WriteAllText(Path.Combine(OutputDirectory, "Full-TextureRemap.json"), JsonConvert.SerializeObject(_levelRemap, Formatting.Indented));
-                }
-            }
-            finally
-            {
-                _deduplicator.SegmentRemapped -= SegmentRepositioned;
-            }
-        }
-
-        private void ExportDuplicateLevelTextures(string lvlPath)
-        {
-            using (AbstractTexturePacker<E, L> levelPacker = CreatePacker(ReadLevel(lvlPath)))
-            {
-                Dictionary<TexturedTile, List<TexturedTileSegment>> allTextures = new Dictionary<TexturedTile, List<TexturedTileSegment>>();
-                foreach (TexturedTile tile in levelPacker.Tiles)
-                {
-                    allTextures[tile] = new List<TexturedTileSegment>(tile.Rectangles);
-                }
-
-                _deduplicator.SegmentMap = allTextures;
-                _deduplicator.Deduplicate();
-
-                if (_levelRemap.ContainsKey(_currentLevel))
-                {
-                    if (OutputTileImages)
-                    {
-                        string dir = Path.Combine(OutputDirectory, _currentLevel);
-                        Directory.CreateDirectory(dir);
-                        foreach (TexturedTile tile in allTextures.Keys)
-                        {
-                            tile.BitmapGraphics.Bitmap.Save(Path.Combine(dir, tile.Index.ToString() + ".png"), ImageFormat.Png);
-                        }
-                    }
-
-                    File.WriteAllText(Path.Combine(OutputDirectory, _currentLevel + "-TextureRemap.json"), JsonConvert.SerializeObject(_levelRemap[_currentLevel], Formatting.Indented));
-                }
-            }
-        }
-
-        public void Import()
+        try
         {
             foreach (string lvlName in LevelNames)
             {
+                _currentLevel = lvlName;
+                _currentSave = 0;
                 string lvlPath = Path.Combine(LevelFileDirectory, lvlName);
-                string mapPath = Path.Combine(OutputDirectory, lvlName + "-TextureRemap.json");
-                if (File.Exists(lvlPath) && File.Exists(mapPath))
+                if (File.Exists(lvlPath))
                 {
-                    _currentLevel = lvlName;
-                    ImportDeduplication(lvlPath, mapPath);
+                    ExportDuplicateLevelTextures(lvlPath);
                 }
             }
-        }
 
-        private void ImportDeduplication(string lvlPath, string mapPath)
-        {
-            L level = ReadLevel(lvlPath);
-            AbstractTRLevelTextureDeduplicator<E, L> deduplicator = CreateDeduplicator();
-            deduplicator.Level = level;
-            deduplicator.Deduplicate(mapPath);
-
-            WriteLevel(level, Path.Combine(OutputDirectory, _currentLevel, _currentLevel));
-        }
-
-        private void SegmentRepositioned(object sender, TRTextureRemapEventArgs e)
-        {
-            if (!_levelRemap.ContainsKey(_currentLevel))
+            if (_levelRemap.Count > 0)
             {
-                _levelRemap[_currentLevel] = CreateRemapGroup();
+                File.WriteAllText(Path.Combine(OutputDirectory, "Full-TextureRemap.json"), JsonConvert.SerializeObject(_levelRemap, Formatting.Indented));
+            }
+        }
+        finally
+        {
+            _deduplicator.SegmentRemapped -= SegmentRepositioned;
+        }
+    }
+
+    private void ExportDuplicateLevelTextures(string lvlPath)
+    {
+        using (AbstractTexturePacker<E, L> levelPacker = CreatePacker(ReadLevel(lvlPath)))
+        {
+            Dictionary<TexturedTile, List<TexturedTileSegment>> allTextures = new Dictionary<TexturedTile, List<TexturedTileSegment>>();
+            foreach (TexturedTile tile in levelPacker.Tiles)
+            {
+                allTextures[tile] = new List<TexturedTileSegment>(tile.Rectangles);
             }
 
-            _levelRemap[_currentLevel].Remapping.Add(new TextureRemap
+            _deduplicator.SegmentMap = allTextures;
+            _deduplicator.Deduplicate();
+
+            if (_levelRemap.ContainsKey(_currentLevel))
             {
-                OriginalTile = e.OldTile.Index,
-                OriginalIndex = e.OldFirstTextureIndex,
-                OriginalBounds = e.OldBounds,
-                NewBounds = e.NewBounds,
-                NewTile = e.NewTile.Index,
-                NewIndex = e.NewSegment.FirstTextureIndex,
-                AdjustmentPoint = e.AdjustmentPoint
-            });
+                if (OutputTileImages)
+                {
+                    string dir = Path.Combine(OutputDirectory, _currentLevel);
+                    Directory.CreateDirectory(dir);
+                    foreach (TexturedTile tile in allTextures.Keys)
+                    {
+                        tile.BitmapGraphics.Bitmap.Save(Path.Combine(dir, tile.Index.ToString() + ".png"), ImageFormat.Png);
+                    }
+                }
 
-            _currentSave += e.OldArea;
+                File.WriteAllText(Path.Combine(OutputDirectory, _currentLevel + "-TextureRemap.json"), JsonConvert.SerializeObject(_levelRemap[_currentLevel], Formatting.Indented));
+            }
+        }
+    }
 
-            Debug.WriteLine(_currentLevel + ": " + _currentSave);
+    public void Import()
+    {
+        foreach (string lvlName in LevelNames)
+        {
+            string lvlPath = Path.Combine(LevelFileDirectory, lvlName);
+            string mapPath = Path.Combine(OutputDirectory, lvlName + "-TextureRemap.json");
+            if (File.Exists(lvlPath) && File.Exists(mapPath))
+            {
+                _currentLevel = lvlName;
+                ImportDeduplication(lvlPath, mapPath);
+            }
+        }
+    }
+
+    private void ImportDeduplication(string lvlPath, string mapPath)
+    {
+        L level = ReadLevel(lvlPath);
+        AbstractTRLevelTextureDeduplicator<E, L> deduplicator = CreateDeduplicator();
+        deduplicator.Level = level;
+        deduplicator.Deduplicate(mapPath);
+
+        WriteLevel(level, Path.Combine(OutputDirectory, _currentLevel, _currentLevel));
+    }
+
+    private void SegmentRepositioned(object sender, TRTextureRemapEventArgs e)
+    {
+        if (!_levelRemap.ContainsKey(_currentLevel))
+        {
+            _levelRemap[_currentLevel] = CreateRemapGroup();
         }
 
-        protected abstract AbstractTextureRemapGroup<E, L> CreateRemapGroup();
-        protected abstract AbstractTexturePacker<E, L> CreatePacker(L level);
-        protected abstract AbstractTRLevelTextureDeduplicator<E, L> CreateDeduplicator();
-        protected abstract L ReadLevel(string path);
-        protected abstract void WriteLevel(L level, string path);
+        _levelRemap[_currentLevel].Remapping.Add(new TextureRemap
+        {
+            OriginalTile = e.OldTile.Index,
+            OriginalIndex = e.OldFirstTextureIndex,
+            OriginalBounds = e.OldBounds,
+            NewBounds = e.NewBounds,
+            NewTile = e.NewTile.Index,
+            NewIndex = e.NewSegment.FirstTextureIndex,
+            AdjustmentPoint = e.AdjustmentPoint
+        });
+
+        _currentSave += e.OldArea;
+
+        Debug.WriteLine(_currentLevel + ": " + _currentSave);
     }
+
+    protected abstract AbstractTextureRemapGroup<E, L> CreateRemapGroup();
+    protected abstract AbstractTexturePacker<E, L> CreatePacker(L level);
+    protected abstract AbstractTRLevelTextureDeduplicator<E, L> CreateDeduplicator();
+    protected abstract L ReadLevel(string path);
+    protected abstract void WriteLevel(L level, string path);
 }

--- a/TRModelTransporter/Utilities/AbstractMassTRTextureDeduplicator.cs
+++ b/TRModelTransporter/Utilities/AbstractMassTRTextureDeduplicator.cs
@@ -65,7 +65,7 @@ public abstract class AbstractMassTRTextureDeduplicator<E, L>
     {
         using (AbstractTexturePacker<E, L> levelPacker = CreatePacker(ReadLevel(lvlPath)))
         {
-            Dictionary<TexturedTile, List<TexturedTileSegment>> allTextures = new Dictionary<TexturedTile, List<TexturedTileSegment>>();
+            Dictionary<TexturedTile, List<TexturedTileSegment>> allTextures = new();
             foreach (TexturedTile tile in levelPacker.Tiles)
             {
                 allTextures[tile] = new List<TexturedTileSegment>(tile.Rectangles);

--- a/TRModelTransporter/Utilities/AbstractTRLevelTextureDeduplicator.cs
+++ b/TRModelTransporter/Utilities/AbstractTRLevelTextureDeduplicator.cs
@@ -21,37 +21,35 @@ public abstract class AbstractTRLevelTextureDeduplicator<E, L>
 
     public void Deduplicate(string remappingPath)
     {
-        using (AbstractTexturePacker<E, L> levelPacker = CreatePacker(Level))
+        using AbstractTexturePacker<E, L> levelPacker = CreatePacker(Level);
+        Dictionary<TexturedTile, List<TexturedTileSegment>> allTextures = new();
+        foreach (TexturedTile tile in levelPacker.Tiles)
         {
-            Dictionary<TexturedTile, List<TexturedTileSegment>> allTextures = new();
-            foreach (TexturedTile tile in levelPacker.Tiles)
-            {
-                allTextures[tile] = new List<TexturedTileSegment>(tile.Rectangles);
-            }
-
-            AbstractTextureRemapGroup<E, L> remapGroup = GetRemapGroup(remappingPath);
-
-            _deduplicator.SegmentMap = allTextures;
-            _deduplicator.PrecompiledRemapping = remapGroup.Remapping;
-            _deduplicator.Deduplicate();
-
-            levelPacker.AllowEmptyPacking = true;
-            levelPacker.Pack(true);
-
-            // Now we want to go through every IndexedTexture and see if it's
-            // pointing to the same thing - so tile, position, and point direction
-            // have to be equal. See IndexedTRObjectTexture
-            Dictionary<int, int> indexMap = new();
-            foreach (TexturedTile tile in allTextures.Keys)
-            {
-                foreach (TexturedTileSegment segment in allTextures[tile])
-                {
-                    TidySegment(segment, indexMap);
-                }
-            }
-
-            ReindexTextures(indexMap);
+            allTextures[tile] = new List<TexturedTileSegment>(tile.Rectangles);
         }
+
+        AbstractTextureRemapGroup<E, L> remapGroup = GetRemapGroup(remappingPath);
+
+        _deduplicator.SegmentMap = allTextures;
+        _deduplicator.PrecompiledRemapping = remapGroup.Remapping;
+        _deduplicator.Deduplicate();
+
+        levelPacker.AllowEmptyPacking = true;
+        levelPacker.Pack(true);
+
+        // Now we want to go through every IndexedTexture and see if it's
+        // pointing to the same thing - so tile, position, and point direction
+        // have to be equal. See IndexedTRObjectTexture
+        Dictionary<int, int> indexMap = new();
+        foreach (TexturedTile tile in allTextures.Keys)
+        {
+            foreach (TexturedTileSegment segment in allTextures[tile])
+            {
+                TidySegment(segment, indexMap);
+            }
+        }
+
+        ReindexTextures(indexMap);
     }
 
     protected abstract AbstractTexturePacker<E, L> CreatePacker(L level);

--- a/TRModelTransporter/Utilities/AbstractTRLevelTextureDeduplicator.cs
+++ b/TRModelTransporter/Utilities/AbstractTRLevelTextureDeduplicator.cs
@@ -3,90 +3,89 @@ using System.Collections.Generic;
 using TRModelTransporter.Model.Textures;
 using TRModelTransporter.Packing;
 
-namespace TRModelTransporter.Utilities
+namespace TRModelTransporter.Utilities;
+
+public abstract class AbstractTRLevelTextureDeduplicator<E, L>
+    where E : Enum
+    where L : class
 {
-    public abstract class AbstractTRLevelTextureDeduplicator<E, L>
-        where E : Enum
-        where L : class
+    public L Level { get; set; }
+
+    private readonly TRTextureDeduplicator<E> _deduplicator;
+
+    public AbstractTRLevelTextureDeduplicator()
     {
-        public L Level { get; set; }
-
-        private readonly TRTextureDeduplicator<E> _deduplicator;
-
-        public AbstractTRLevelTextureDeduplicator()
+        _deduplicator = new TRTextureDeduplicator<E>
         {
-            _deduplicator = new TRTextureDeduplicator<E>
-            {
-                UpdateGraphics = true
-            };
-        }
+            UpdateGraphics = true
+        };
+    }
 
-        public void Deduplicate(string remappingPath)
+    public void Deduplicate(string remappingPath)
+    {
+        using (AbstractTexturePacker<E, L> levelPacker = CreatePacker(Level))
         {
-            using (AbstractTexturePacker<E, L> levelPacker = CreatePacker(Level))
+            Dictionary<TexturedTile, List<TexturedTileSegment>> allTextures = new Dictionary<TexturedTile, List<TexturedTileSegment>>();
+            foreach (TexturedTile tile in levelPacker.Tiles)
             {
-                Dictionary<TexturedTile, List<TexturedTileSegment>> allTextures = new Dictionary<TexturedTile, List<TexturedTileSegment>>();
-                foreach (TexturedTile tile in levelPacker.Tiles)
-                {
-                    allTextures[tile] = new List<TexturedTileSegment>(tile.Rectangles);
-                }
-
-                AbstractTextureRemapGroup<E, L> remapGroup = GetRemapGroup(remappingPath);
-
-                _deduplicator.SegmentMap = allTextures;
-                _deduplicator.PrecompiledRemapping = remapGroup.Remapping;
-                _deduplicator.Deduplicate();
-
-                levelPacker.AllowEmptyPacking = true;
-                levelPacker.Pack(true);
-
-                // Now we want to go through every IndexedTexture and see if it's
-                // pointing to the same thing - so tile, position, and point direction
-                // have to be equal. See IndexedTRObjectTexture
-                Dictionary<int, int> indexMap = new Dictionary<int, int>();
-                foreach (TexturedTile tile in allTextures.Keys)
-                {
-                    foreach (TexturedTileSegment segment in allTextures[tile])
-                    {
-                        TidySegment(segment, indexMap);
-                    }
-                }
-
-                ReindexTextures(indexMap);
+                allTextures[tile] = new List<TexturedTileSegment>(tile.Rectangles);
             }
-        }
 
-        protected abstract AbstractTexturePacker<E, L> CreatePacker(L level);
-        protected abstract AbstractTextureRemapGroup<E, L> GetRemapGroup(string path);
-        protected abstract void ReindexTextures(Dictionary<int, int> indexMap);
+            AbstractTextureRemapGroup<E, L> remapGroup = GetRemapGroup(remappingPath);
 
-        private void TidySegment(TexturedTileSegment segment, Dictionary<int, int> reindexMap)
-        {
-            for (int i = segment.Textures.Count - 1; i > 0; i--) //ignore the first = the largest
+            _deduplicator.SegmentMap = allTextures;
+            _deduplicator.PrecompiledRemapping = remapGroup.Remapping;
+            _deduplicator.Deduplicate();
+
+            levelPacker.AllowEmptyPacking = true;
+            levelPacker.Pack(true);
+
+            // Now we want to go through every IndexedTexture and see if it's
+            // pointing to the same thing - so tile, position, and point direction
+            // have to be equal. See IndexedTRObjectTexture
+            Dictionary<int, int> indexMap = new Dictionary<int, int>();
+            foreach (TexturedTile tile in allTextures.Keys)
             {
-                AbstractIndexedTRTexture texture = segment.Textures[i];
-                AbstractIndexedTRTexture candidateTexture = null;
-                for (int j = 0; j < segment.Textures.Count; j++)
+                foreach (TexturedTileSegment segment in allTextures[tile])
                 {
-                    if (i == j)
-                    {
-                        continue;
-                    }
+                    TidySegment(segment, indexMap);
+                }
+            }
 
-                    AbstractIndexedTRTexture texture2 = segment.Textures[j];
-                    if (texture.Equals(texture2))
-                    {
-                        candidateTexture = texture2;
-                        break;
-                    }
+            ReindexTextures(indexMap);
+        }
+    }
+
+    protected abstract AbstractTexturePacker<E, L> CreatePacker(L level);
+    protected abstract AbstractTextureRemapGroup<E, L> GetRemapGroup(string path);
+    protected abstract void ReindexTextures(Dictionary<int, int> indexMap);
+
+    private void TidySegment(TexturedTileSegment segment, Dictionary<int, int> reindexMap)
+    {
+        for (int i = segment.Textures.Count - 1; i > 0; i--) //ignore the first = the largest
+        {
+            AbstractIndexedTRTexture texture = segment.Textures[i];
+            AbstractIndexedTRTexture candidateTexture = null;
+            for (int j = 0; j < segment.Textures.Count; j++)
+            {
+                if (i == j)
+                {
+                    continue;
                 }
 
-                if (candidateTexture != null)
+                AbstractIndexedTRTexture texture2 = segment.Textures[j];
+                if (texture.Equals(texture2))
                 {
-                    reindexMap[texture.Index] = candidateTexture.Index;
-                    texture.Invalidate();
-                    segment.Textures.RemoveAt(i);
+                    candidateTexture = texture2;
+                    break;
                 }
+            }
+
+            if (candidateTexture != null)
+            {
+                reindexMap[texture.Index] = candidateTexture.Index;
+                texture.Invalidate();
+                segment.Textures.RemoveAt(i);
             }
         }
     }

--- a/TRModelTransporter/Utilities/AbstractTRLevelTextureDeduplicator.cs
+++ b/TRModelTransporter/Utilities/AbstractTRLevelTextureDeduplicator.cs
@@ -23,7 +23,7 @@ public abstract class AbstractTRLevelTextureDeduplicator<E, L>
     {
         using (AbstractTexturePacker<E, L> levelPacker = CreatePacker(Level))
         {
-            Dictionary<TexturedTile, List<TexturedTileSegment>> allTextures = new Dictionary<TexturedTile, List<TexturedTileSegment>>();
+            Dictionary<TexturedTile, List<TexturedTileSegment>> allTextures = new();
             foreach (TexturedTile tile in levelPacker.Tiles)
             {
                 allTextures[tile] = new List<TexturedTileSegment>(tile.Rectangles);
@@ -41,7 +41,7 @@ public abstract class AbstractTRLevelTextureDeduplicator<E, L>
             // Now we want to go through every IndexedTexture and see if it's
             // pointing to the same thing - so tile, position, and point direction
             // have to be equal. See IndexedTRObjectTexture
-            Dictionary<int, int> indexMap = new Dictionary<int, int>();
+            Dictionary<int, int> indexMap = new();
             foreach (TexturedTile tile in allTextures.Keys)
             {
                 foreach (TexturedTileSegment segment in allTextures[tile])

--- a/TRModelTransporter/Utilities/AbstractTRLevelTextureDeduplicator.cs
+++ b/TRModelTransporter/Utilities/AbstractTRLevelTextureDeduplicator.cs
@@ -56,7 +56,7 @@ public abstract class AbstractTRLevelTextureDeduplicator<E, L>
     protected abstract AbstractTextureRemapGroup<E, L> GetRemapGroup(string path);
     protected abstract void ReindexTextures(Dictionary<int, int> indexMap);
 
-    private void TidySegment(TexturedTileSegment segment, Dictionary<int, int> reindexMap)
+    private static void TidySegment(TexturedTileSegment segment, Dictionary<int, int> reindexMap)
     {
         for (int i = segment.Textures.Count - 1; i > 0; i--) //ignore the first = the largest
         {

--- a/TRModelTransporter/Utilities/AbstractTRLevelTextureDeduplicator.cs
+++ b/TRModelTransporter/Utilities/AbstractTRLevelTextureDeduplicator.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using TRModelTransporter.Model.Textures;
+﻿using TRModelTransporter.Model.Textures;
 using TRModelTransporter.Packing;
 
 namespace TRModelTransporter.Utilities;

--- a/TRModelTransporter/Utilities/Deduplication/MassTR2TextureDeduplicator.cs
+++ b/TRModelTransporter/Utilities/Deduplication/MassTR2TextureDeduplicator.cs
@@ -6,42 +6,41 @@ using TRLevelControl.Model.Enums;
 using TRModelTransporter.Model.Textures;
 using TRModelTransporter.Packing;
 
-namespace TRModelTransporter.Utilities
+namespace TRModelTransporter.Utilities;
+
+public class MassTR2TextureDeduplicator : AbstractMassTRTextureDeduplicator<TR2Entities, TR2Level>
 {
-    public class MassTR2TextureDeduplicator : AbstractMassTRTextureDeduplicator<TR2Entities, TR2Level>
+    public override List<string> LevelNames => TR2LevelNames.AsList;
+
+    private readonly TR2LevelControl _control;
+
+    public MassTR2TextureDeduplicator()
     {
-        public override List<string> LevelNames => TR2LevelNames.AsList;
+        _control = new();
+    }
 
-        private readonly TR2LevelControl _control;
+    protected override AbstractTexturePacker<TR2Entities, TR2Level> CreatePacker(TR2Level level)
+    {
+        return new TR2TexturePacker(level);
+    }
 
-        public MassTR2TextureDeduplicator()
-        {
-            _control = new();
-        }
+    protected override AbstractTextureRemapGroup<TR2Entities, TR2Level> CreateRemapGroup()
+    {
+        return new TR2TextureRemapGroup();
+    }
 
-        protected override AbstractTexturePacker<TR2Entities, TR2Level> CreatePacker(TR2Level level)
-        {
-            return new TR2TexturePacker(level);
-        }
+    protected override AbstractTRLevelTextureDeduplicator<TR2Entities, TR2Level> CreateDeduplicator()
+    {
+        return new TR2LevelTextureDeduplicator();
+    }
 
-        protected override AbstractTextureRemapGroup<TR2Entities, TR2Level> CreateRemapGroup()
-        {
-            return new TR2TextureRemapGroup();
-        }
+    protected override TR2Level ReadLevel(string path)
+    {
+        return _control.Read(path);
+    }
 
-        protected override AbstractTRLevelTextureDeduplicator<TR2Entities, TR2Level> CreateDeduplicator()
-        {
-            return new TR2LevelTextureDeduplicator();
-        }
-
-        protected override TR2Level ReadLevel(string path)
-        {
-            return _control.Read(path);
-        }
-
-        protected override void WriteLevel(TR2Level level, string path)
-        {
-            _control.Write(level, path);
-        }
+    protected override void WriteLevel(TR2Level level, string path)
+    {
+        _control.Write(level, path);
     }
 }

--- a/TRModelTransporter/Utilities/Deduplication/MassTR2TextureDeduplicator.cs
+++ b/TRModelTransporter/Utilities/Deduplication/MassTR2TextureDeduplicator.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using TRLevelControl;
+﻿using TRLevelControl;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;

--- a/TRModelTransporter/Utilities/Deduplication/TR2LevelTextureDeduplicator.cs
+++ b/TRModelTransporter/Utilities/Deduplication/TR2LevelTextureDeduplicator.cs
@@ -1,6 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System.Collections.Generic;
-using System.IO;
 using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;
 using TRModelTransporter.Helpers;

--- a/TRModelTransporter/Utilities/Deduplication/TR2LevelTextureDeduplicator.cs
+++ b/TRModelTransporter/Utilities/Deduplication/TR2LevelTextureDeduplicator.cs
@@ -7,24 +7,23 @@ using TRModelTransporter.Helpers;
 using TRModelTransporter.Model.Textures;
 using TRModelTransporter.Packing;
 
-namespace TRModelTransporter.Utilities
+namespace TRModelTransporter.Utilities;
+
+public class TR2LevelTextureDeduplicator : AbstractTRLevelTextureDeduplicator<TR2Entities, TR2Level>
 {
-    public class TR2LevelTextureDeduplicator : AbstractTRLevelTextureDeduplicator<TR2Entities, TR2Level>
+    protected override AbstractTexturePacker<TR2Entities, TR2Level> CreatePacker(TR2Level level)
     {
-        protected override AbstractTexturePacker<TR2Entities, TR2Level> CreatePacker(TR2Level level)
-        {
-            return new TR2TexturePacker(level);
-        }
+        return new TR2TexturePacker(level);
+    }
 
-        protected override AbstractTextureRemapGroup<TR2Entities, TR2Level> GetRemapGroup(string path)
-        {
-            return JsonConvert.DeserializeObject<TR2TextureRemapGroup>(File.ReadAllText(path));
-        }
+    protected override AbstractTextureRemapGroup<TR2Entities, TR2Level> GetRemapGroup(string path)
+    {
+        return JsonConvert.DeserializeObject<TR2TextureRemapGroup>(File.ReadAllText(path));
+    }
 
-        protected override void ReindexTextures(Dictionary<int, int> indexMap)
-        {
-            Level.ReindexTextures(indexMap);
-            Level.ResetUnusedTextures();
-        }
+    protected override void ReindexTextures(Dictionary<int, int> indexMap)
+    {
+        Level.ReindexTextures(indexMap);
+        Level.ResetUnusedTextures();
     }
 }

--- a/TRModelTransporter/Utilities/Export/MassTR1ModelExporter.cs
+++ b/TRModelTransporter/Utilities/Export/MassTR1ModelExporter.cs
@@ -7,107 +7,106 @@ using TRLevelControl.Model.Enums;
 using TRModelTransporter.Model.Definitions;
 using TRModelTransporter.Transport;
 
-namespace TRModelTransporter.Utilities
+namespace TRModelTransporter.Utilities;
+
+public class MassTR1ModelExporter : AbstractMassTRModelExporter<TREntities, TR1Level, TR1ModelDefinition>
 {
-    public class MassTR1ModelExporter : AbstractMassTRModelExporter<TREntities, TR1Level, TR1ModelDefinition>
+    private static readonly List<string> _sourceLevels = TR1LevelNames.AsListWithAssault.Concat(new List<string>
     {
-        private static readonly List<string> _sourceLevels = TR1LevelNames.AsListWithAssault.Concat(new List<string>
-        {
-            // https://trcustoms.org/users/854 by Leoc1995
-            "LEOC.TR2"
-        }).ToList();
+        // https://trcustoms.org/users/854 by Leoc1995
+        "LEOC.TR2"
+    }).ToList();
 
-        public override List<string> LevelNames => _sourceLevels;
+    public override List<string> LevelNames => _sourceLevels;
 
-        public override Dictionary<string, List<TREntities>> ExportTypes => _exportModelTypes;
+    public override Dictionary<string, List<TREntities>> ExportTypes => _exportModelTypes;
 
-        private readonly TR1LevelControl _reader;
+    private readonly TR1LevelControl _reader;
 
-        public MassTR1ModelExporter()
-        {
-            _reader = new();
-        }
-
-        protected override AbstractTRModelExporter<TREntities, TR1Level, TR1ModelDefinition> CreateExporter()
-        {
-            return new TR1ModelExporter();
-        }
-
-        protected override TR1Level ReadLevel(string path)
-        {
-            return _reader.Read(path);
-        }
-
-        private static readonly Dictionary<string, List<TREntities>> _exportModelTypes = new Dictionary<string, List<TREntities>>
-        {
-            [TR1LevelNames.CAVES] = new List<TREntities>
-            {
-                TREntities.Pistols_M_H, TREntities.Shotgun_M_H, TREntities.Magnums_M_H, TREntities.Uzis_M_H,
-                TREntities.Lara, TREntities.Bat, TREntities.Bear, TREntities.Wolf,
-                TREntities.FallingBlock, TREntities.DartEmitter, TREntities.WallSwitch, TREntities.LaraMiscAnim_H_General
-            },
-            [TR1LevelNames.VILCABAMBA] = new List<TREntities>
-            {
-                TREntities.PushBlock1, TREntities.SwingingBlade, TREntities.Trapdoor1, TREntities.UnderwaterSwitch
-            },
-            [TR1LevelNames.VALLEY] = new List<TREntities>
-            {
-                TREntities.TRex, TREntities.Raptor, TREntities.LaraPonytail_H_U
-            },
-            [TR1LevelNames.QUALOPEC] = new List<TREntities>
-            {
-                TREntities.Mummy, TREntities.RollingBall, TREntities.FallingCeiling1, TREntities.MovingBlock, TREntities.TeethSpikes
-            },
-            [TR1LevelNames.FOLLY] = new List<TREntities>
-            {
-                TREntities.CrocodileLand, TREntities.CrocodileWater, TREntities.Gorilla, TREntities.Lion, TREntities.Lioness,
-                TREntities.ThorHammerHandle, TREntities.ThorLightning, TREntities.DamoclesSword
-            },
-            [TR1LevelNames.COLOSSEUM] = new List<TREntities>
-            {
-                
-            },
-            [TR1LevelNames.MIDAS] = new List<TREntities>
-            {
-                TREntities.PushBlock2
-            },
-            [TR1LevelNames.CISTERN] = new List<TREntities>
-            {
-                TREntities.RatLand, TREntities.RatWater
-            },
-            [TR1LevelNames.TIHOCAN] = new List<TREntities>
-            {
-                TREntities.CentaurStatue, TREntities.Centaur, TREntities.Pierre, TREntities.ScionPiece_M_H,
-                TREntities.SlammingDoor
-            },
-            [TR1LevelNames.KHAMOON] = new List<TREntities>
-            {
-                TREntities.Panther
-            },
-            [TR1LevelNames.OBELISK] = new List<TREntities>
-            {
-                TREntities.BandagedAtlantean
-            },
-            [TR1LevelNames.SANCTUARY] = new List<TREntities>
-            {
-                TREntities.MeatyFlyer, TREntities.MeatyAtlantean, TREntities.ShootingAtlantean_N, TREntities.Larson
-            },
-            [TR1LevelNames.MINES] = new List<TREntities>
-            {
-                TREntities.CowboyOG, TREntities.Kold, TREntities.SkateboardKid
-            },
-            [TR1LevelNames.ATLANTIS] = new List<TREntities>
-            {
-                TREntities.Doppelganger, TREntities.AtlanteanEgg
-            },
-            [TR1LevelNames.PYRAMID] = new List<TREntities>
-            {
-                TREntities.Adam, TREntities.AdamEgg, TREntities.Natla
-            },
-            ["LEOC.PHD"] = new List<TREntities>
-            {
-                TREntities.CowboyHeadless
-            }
-        };
+    public MassTR1ModelExporter()
+    {
+        _reader = new();
     }
+
+    protected override AbstractTRModelExporter<TREntities, TR1Level, TR1ModelDefinition> CreateExporter()
+    {
+        return new TR1ModelExporter();
+    }
+
+    protected override TR1Level ReadLevel(string path)
+    {
+        return _reader.Read(path);
+    }
+
+    private static readonly Dictionary<string, List<TREntities>> _exportModelTypes = new Dictionary<string, List<TREntities>>
+    {
+        [TR1LevelNames.CAVES] = new List<TREntities>
+        {
+            TREntities.Pistols_M_H, TREntities.Shotgun_M_H, TREntities.Magnums_M_H, TREntities.Uzis_M_H,
+            TREntities.Lara, TREntities.Bat, TREntities.Bear, TREntities.Wolf,
+            TREntities.FallingBlock, TREntities.DartEmitter, TREntities.WallSwitch, TREntities.LaraMiscAnim_H_General
+        },
+        [TR1LevelNames.VILCABAMBA] = new List<TREntities>
+        {
+            TREntities.PushBlock1, TREntities.SwingingBlade, TREntities.Trapdoor1, TREntities.UnderwaterSwitch
+        },
+        [TR1LevelNames.VALLEY] = new List<TREntities>
+        {
+            TREntities.TRex, TREntities.Raptor, TREntities.LaraPonytail_H_U
+        },
+        [TR1LevelNames.QUALOPEC] = new List<TREntities>
+        {
+            TREntities.Mummy, TREntities.RollingBall, TREntities.FallingCeiling1, TREntities.MovingBlock, TREntities.TeethSpikes
+        },
+        [TR1LevelNames.FOLLY] = new List<TREntities>
+        {
+            TREntities.CrocodileLand, TREntities.CrocodileWater, TREntities.Gorilla, TREntities.Lion, TREntities.Lioness,
+            TREntities.ThorHammerHandle, TREntities.ThorLightning, TREntities.DamoclesSword
+        },
+        [TR1LevelNames.COLOSSEUM] = new List<TREntities>
+        {
+            
+        },
+        [TR1LevelNames.MIDAS] = new List<TREntities>
+        {
+            TREntities.PushBlock2
+        },
+        [TR1LevelNames.CISTERN] = new List<TREntities>
+        {
+            TREntities.RatLand, TREntities.RatWater
+        },
+        [TR1LevelNames.TIHOCAN] = new List<TREntities>
+        {
+            TREntities.CentaurStatue, TREntities.Centaur, TREntities.Pierre, TREntities.ScionPiece_M_H,
+            TREntities.SlammingDoor
+        },
+        [TR1LevelNames.KHAMOON] = new List<TREntities>
+        {
+            TREntities.Panther
+        },
+        [TR1LevelNames.OBELISK] = new List<TREntities>
+        {
+            TREntities.BandagedAtlantean
+        },
+        [TR1LevelNames.SANCTUARY] = new List<TREntities>
+        {
+            TREntities.MeatyFlyer, TREntities.MeatyAtlantean, TREntities.ShootingAtlantean_N, TREntities.Larson
+        },
+        [TR1LevelNames.MINES] = new List<TREntities>
+        {
+            TREntities.CowboyOG, TREntities.Kold, TREntities.SkateboardKid
+        },
+        [TR1LevelNames.ATLANTIS] = new List<TREntities>
+        {
+            TREntities.Doppelganger, TREntities.AtlanteanEgg
+        },
+        [TR1LevelNames.PYRAMID] = new List<TREntities>
+        {
+            TREntities.Adam, TREntities.AdamEgg, TREntities.Natla
+        },
+        ["LEOC.PHD"] = new List<TREntities>
+        {
+            TREntities.CowboyHeadless
+        }
+    };
 }

--- a/TRModelTransporter/Utilities/Export/MassTR1ModelExporter.cs
+++ b/TRModelTransporter/Utilities/Export/MassTR1ModelExporter.cs
@@ -36,7 +36,7 @@ public class MassTR1ModelExporter : AbstractMassTRModelExporter<TREntities, TR1L
         return _reader.Read(path);
     }
 
-    private static readonly Dictionary<string, List<TREntities>> _exportModelTypes = new Dictionary<string, List<TREntities>>
+    private static readonly Dictionary<string, List<TREntities>> _exportModelTypes = new()
     {
         [TR1LevelNames.CAVES] = new List<TREntities>
         {

--- a/TRModelTransporter/Utilities/Export/MassTR1ModelExporter.cs
+++ b/TRModelTransporter/Utilities/Export/MassTR1ModelExporter.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using TRLevelControl;
+﻿using TRLevelControl;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;

--- a/TRModelTransporter/Utilities/Export/MassTR2ModelExporter.cs
+++ b/TRModelTransporter/Utilities/Export/MassTR2ModelExporter.cs
@@ -37,7 +37,7 @@ public class MassTR2ModelExporter : AbstractMassTRModelExporter<TR2Entities, TR2
         return _reader.Read(path);
     }
 
-    private static readonly Dictionary<string, List<TR2Entities>> _exportModelTypes = new Dictionary<string, List<TR2Entities>>
+    private static readonly Dictionary<string, List<TR2Entities>> _exportModelTypes = new()
     {
         [TR2LevelNames.GW] = new List<TR2Entities>
         {

--- a/TRModelTransporter/Utilities/Export/MassTR2ModelExporter.cs
+++ b/TRModelTransporter/Utilities/Export/MassTR2ModelExporter.cs
@@ -7,121 +7,120 @@ using TRLevelControl.Model.Enums;
 using TRModelTransporter.Model.Definitions;
 using TRModelTransporter.Transport;
 
-namespace TRModelTransporter.Utilities
+namespace TRModelTransporter.Utilities;
+
+public class MassTR2ModelExporter : AbstractMassTRModelExporter<TR2Entities, TR2Level, TR2ModelDefinition>
 {
-    public class MassTR2ModelExporter : AbstractMassTRModelExporter<TR2Entities, TR2Level, TR2ModelDefinition>
+    private static readonly List<string> _sourceLevels = TR2LevelNames.AsListWithAssault.Concat(new List<string>
     {
-        private static readonly List<string> _sourceLevels = TR2LevelNames.AsListWithAssault.Concat(new List<string>
-        {
-            // https://trcustoms.org/levels/3013 by Topixtor
-            "TOPIORC.TR2",
-            "TOPICAC.TR2",
-        }).ToList();
+        // https://trcustoms.org/levels/3013 by Topixtor
+        "TOPIORC.TR2",
+        "TOPICAC.TR2",
+    }).ToList();
 
-        public override List<string> LevelNames => _sourceLevels;
+    public override List<string> LevelNames => _sourceLevels;
 
-        public override Dictionary<string, List<TR2Entities>> ExportTypes => _exportModelTypes;
+    public override Dictionary<string, List<TR2Entities>> ExportTypes => _exportModelTypes;
 
-        private readonly TR2LevelControl _reader;
+    private readonly TR2LevelControl _reader;
 
-        public MassTR2ModelExporter()
-        {
-            _reader = new();
-        }
-
-        protected override AbstractTRModelExporter<TR2Entities, TR2Level, TR2ModelDefinition> CreateExporter()
-        {
-            return new TR2ModelExporter();
-        }
-
-        protected override TR2Level ReadLevel(string path)
-        {
-            return _reader.Read(path);
-        }
-
-        private static readonly Dictionary<string, List<TR2Entities>> _exportModelTypes = new Dictionary<string, List<TR2Entities>>
-        {
-            [TR2LevelNames.GW] = new List<TR2Entities>
-            {
-                TR2Entities.Pistols_M_H, TR2Entities.Shotgun_M_H, TR2Entities.Uzi_M_H, TR2Entities.Autos_M_H, TR2Entities.Harpoon_M_H, TR2Entities.M16_M_H, TR2Entities.GrenadeLauncher_M_H,
-                TR2Entities.LaraSun, TR2Entities.Crow, TR2Entities.Spider, TR2Entities.BengalTiger, TR2Entities.TRex
-            },
-            [TR2LevelNames.VENICE] = new List<TR2Entities>
-            {
-                TR2Entities.Boat, TR2Entities.Doberman, TR2Entities.MaskedGoon1, TR2Entities.MaskedGoon2, TR2Entities.MaskedGoon3, TR2Entities.Rat, TR2Entities.StickWieldingGoon1BodyWarmer
-            },
-            [TR2LevelNames.BARTOLI] = new List<TR2Entities>
-            {
-                TR2Entities.StickWieldingGoon1WhiteVest
-            },
-            [TR2LevelNames.OPERA] = new List<TR2Entities>
-            {
-                TR2Entities.ShotgunGoon
-            },
-            [TR2LevelNames.RIG] = new List<TR2Entities>
-            {
-                TR2Entities.Gunman1OG, TR2Entities.Gunman2, TR2Entities.ScubaDiver, TR2Entities.StickWieldingGoon1Bandana
-            },
-            [TR2LevelNames.DA] = new List<TR2Entities>
-            {
-                TR2Entities.FlamethrowerGoonOG
-            },
-            [TR2LevelNames.FATHOMS] = new List<TR2Entities>
-            {
-                TR2Entities.LaraUnwater, TR2Entities.BarracudaUnwater, TR2Entities.Shark
-            },
-            [TR2LevelNames.DORIA] = new List<TR2Entities>
-            {
-                TR2Entities.StickWieldingGoon1GreenVest, TR2Entities.YellowMorayEel
-            },
-            [TR2LevelNames.LQ] = new List<TR2Entities>
-            {
-                TR2Entities.BlackMorayEel, TR2Entities.StickWieldingGoon2
-            },
-            [TR2LevelNames.TIBET] = new List<TR2Entities>
-            {
-                TR2Entities.LaraSnow, TR2Entities.Eagle, TR2Entities.Mercenary2, TR2Entities.Mercenary3, TR2Entities.MercSnowmobDriver, TR2Entities.SnowLeopard
-            },
-            [TR2LevelNames.MONASTERY] = new List<TR2Entities>
-            {
-                TR2Entities.Mercenary1, TR2Entities.MonkWithKnifeStick, TR2Entities.MonkWithLongStick
-            },
-            [TR2LevelNames.COT] = new List<TR2Entities>
-            {
-                TR2Entities.BarracudaIce, TR2Entities.Yeti
-            },
-            [TR2LevelNames.CHICKEN] = new List<TR2Entities>
-            {
-                TR2Entities.BirdMonster, TR2Entities.WhiteTiger
-            },
-            [TR2LevelNames.XIAN] = new List<TR2Entities>
-            {
-                TR2Entities.BarracudaXian, TR2Entities.GiantSpider
-            },
-            [TR2LevelNames.FLOATER] = new List<TR2Entities>
-            {
-                TR2Entities.Knifethrower, TR2Entities.XianGuardSword, TR2Entities.XianGuardSpear
-            },
-            [TR2LevelNames.LAIR] = new List<TR2Entities>
-            {
-                TR2Entities.MarcoBartoli
-            },
-            [TR2LevelNames.HOME] = new List<TR2Entities>
-            {
-                TR2Entities.LaraHome, TR2Entities.StickWieldingGoon1BlackJacket
-            },
-            [TR2LevelNames.ASSAULT] = new List<TR2Entities>
-            {
-                TR2Entities.Winston
-            },
-            ["TOPIORC.TR2"] = new List<TR2Entities>
-            {
-                TR2Entities.FlamethrowerGoonTopixtor, TR2Entities.Gunman1TopixtorORC
-            },
-            ["TOPICAC.TR2"] = new List<TR2Entities>
-            {
-                TR2Entities.Gunman1TopixtorCAC
-            }
-        };
+    public MassTR2ModelExporter()
+    {
+        _reader = new();
     }
+
+    protected override AbstractTRModelExporter<TR2Entities, TR2Level, TR2ModelDefinition> CreateExporter()
+    {
+        return new TR2ModelExporter();
+    }
+
+    protected override TR2Level ReadLevel(string path)
+    {
+        return _reader.Read(path);
+    }
+
+    private static readonly Dictionary<string, List<TR2Entities>> _exportModelTypes = new Dictionary<string, List<TR2Entities>>
+    {
+        [TR2LevelNames.GW] = new List<TR2Entities>
+        {
+            TR2Entities.Pistols_M_H, TR2Entities.Shotgun_M_H, TR2Entities.Uzi_M_H, TR2Entities.Autos_M_H, TR2Entities.Harpoon_M_H, TR2Entities.M16_M_H, TR2Entities.GrenadeLauncher_M_H,
+            TR2Entities.LaraSun, TR2Entities.Crow, TR2Entities.Spider, TR2Entities.BengalTiger, TR2Entities.TRex
+        },
+        [TR2LevelNames.VENICE] = new List<TR2Entities>
+        {
+            TR2Entities.Boat, TR2Entities.Doberman, TR2Entities.MaskedGoon1, TR2Entities.MaskedGoon2, TR2Entities.MaskedGoon3, TR2Entities.Rat, TR2Entities.StickWieldingGoon1BodyWarmer
+        },
+        [TR2LevelNames.BARTOLI] = new List<TR2Entities>
+        {
+            TR2Entities.StickWieldingGoon1WhiteVest
+        },
+        [TR2LevelNames.OPERA] = new List<TR2Entities>
+        {
+            TR2Entities.ShotgunGoon
+        },
+        [TR2LevelNames.RIG] = new List<TR2Entities>
+        {
+            TR2Entities.Gunman1OG, TR2Entities.Gunman2, TR2Entities.ScubaDiver, TR2Entities.StickWieldingGoon1Bandana
+        },
+        [TR2LevelNames.DA] = new List<TR2Entities>
+        {
+            TR2Entities.FlamethrowerGoonOG
+        },
+        [TR2LevelNames.FATHOMS] = new List<TR2Entities>
+        {
+            TR2Entities.LaraUnwater, TR2Entities.BarracudaUnwater, TR2Entities.Shark
+        },
+        [TR2LevelNames.DORIA] = new List<TR2Entities>
+        {
+            TR2Entities.StickWieldingGoon1GreenVest, TR2Entities.YellowMorayEel
+        },
+        [TR2LevelNames.LQ] = new List<TR2Entities>
+        {
+            TR2Entities.BlackMorayEel, TR2Entities.StickWieldingGoon2
+        },
+        [TR2LevelNames.TIBET] = new List<TR2Entities>
+        {
+            TR2Entities.LaraSnow, TR2Entities.Eagle, TR2Entities.Mercenary2, TR2Entities.Mercenary3, TR2Entities.MercSnowmobDriver, TR2Entities.SnowLeopard
+        },
+        [TR2LevelNames.MONASTERY] = new List<TR2Entities>
+        {
+            TR2Entities.Mercenary1, TR2Entities.MonkWithKnifeStick, TR2Entities.MonkWithLongStick
+        },
+        [TR2LevelNames.COT] = new List<TR2Entities>
+        {
+            TR2Entities.BarracudaIce, TR2Entities.Yeti
+        },
+        [TR2LevelNames.CHICKEN] = new List<TR2Entities>
+        {
+            TR2Entities.BirdMonster, TR2Entities.WhiteTiger
+        },
+        [TR2LevelNames.XIAN] = new List<TR2Entities>
+        {
+            TR2Entities.BarracudaXian, TR2Entities.GiantSpider
+        },
+        [TR2LevelNames.FLOATER] = new List<TR2Entities>
+        {
+            TR2Entities.Knifethrower, TR2Entities.XianGuardSword, TR2Entities.XianGuardSpear
+        },
+        [TR2LevelNames.LAIR] = new List<TR2Entities>
+        {
+            TR2Entities.MarcoBartoli
+        },
+        [TR2LevelNames.HOME] = new List<TR2Entities>
+        {
+            TR2Entities.LaraHome, TR2Entities.StickWieldingGoon1BlackJacket
+        },
+        [TR2LevelNames.ASSAULT] = new List<TR2Entities>
+        {
+            TR2Entities.Winston
+        },
+        ["TOPIORC.TR2"] = new List<TR2Entities>
+        {
+            TR2Entities.FlamethrowerGoonTopixtor, TR2Entities.Gunman1TopixtorORC
+        },
+        ["TOPICAC.TR2"] = new List<TR2Entities>
+        {
+            TR2Entities.Gunman1TopixtorCAC
+        }
+    };
 }

--- a/TRModelTransporter/Utilities/Export/MassTR2ModelExporter.cs
+++ b/TRModelTransporter/Utilities/Export/MassTR2ModelExporter.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using TRLevelControl;
+﻿using TRLevelControl;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;

--- a/TRModelTransporter/Utilities/Export/MassTR3ModelExporter.cs
+++ b/TRModelTransporter/Utilities/Export/MassTR3ModelExporter.cs
@@ -6,118 +6,117 @@ using TRLevelControl.Model.Enums;
 using TRModelTransporter.Model.Definitions;
 using TRModelTransporter.Transport;
 
-namespace TRModelTransporter.Utilities
+namespace TRModelTransporter.Utilities;
+
+public class MassTR3ModelExporter : AbstractMassTRModelExporter<TR3Entities, TR3Level, TR3ModelDefinition>
 {
-    public class MassTR3ModelExporter : AbstractMassTRModelExporter<TR3Entities, TR3Level, TR3ModelDefinition>
+    public override List<string> LevelNames => TR3LevelNames.AsListWithAssault;
+
+    public override Dictionary<string, List<TR3Entities>> ExportTypes => _exportModelTypes;
+
+    private readonly TR3LevelControl _reader;
+
+    public MassTR3ModelExporter()
     {
-        public override List<string> LevelNames => TR3LevelNames.AsListWithAssault;
-
-        public override Dictionary<string, List<TR3Entities>> ExportTypes => _exportModelTypes;
-
-        private readonly TR3LevelControl _reader;
-
-        public MassTR3ModelExporter()
-        {
-            _reader = new();
-        }
-
-        protected override AbstractTRModelExporter<TR3Entities, TR3Level, TR3ModelDefinition> CreateExporter()
-        {
-            return new TR3ModelExporter();
-        }
-
-        protected override TR3Level ReadLevel(string path)
-        {
-            return _reader.Read(path);
-        }
-
-        private static readonly Dictionary<string, List<TR3Entities>> _exportModelTypes = new Dictionary<string, List<TR3Entities>>
-        {
-            [TR3LevelNames.JUNGLE] = new List<TR3Entities>
-            {
-                TR3Entities.LaraIndia, TR3Entities.Monkey, TR3Entities.Tiger, TR3Entities.Door1
-            },
-            [TR3LevelNames.RUINS] = new List<TR3Entities>
-            {
-                TR3Entities.Shiva, TR3Entities.CobraIndia
-            },
-            [TR3LevelNames.GANGES] = new List<TR3Entities>
-            {
-                TR3Entities.Quad, TR3Entities.Vulture
-            },
-            [TR3LevelNames.CAVES] = new List<TR3Entities>
-            {
-                TR3Entities.TonyFirehands, TR3Entities.Infada_P
-            },
-            [TR3LevelNames.COASTAL] = new List<TR3Entities>
-            {
-                TR3Entities.LaraCoastal, TR3Entities.Croc, TR3Entities.TribesmanAxe, TR3Entities.TribesmanDart
-            },
-            [TR3LevelNames.CRASH] = new List<TR3Entities>
-            {
-                TR3Entities.Compsognathus, TR3Entities.Mercenary, TR3Entities.Raptor, TR3Entities.Tyrannosaur
-            },
-            [TR3LevelNames.MADUBU] = new List<TR3Entities>
-            {
-                TR3Entities.Kayak, TR3Entities.LizardMan
-            },
-            [TR3LevelNames.PUNA] = new List<TR3Entities>
-            {
-                TR3Entities.Puna, TR3Entities.OraDagger_P
-            },
-            [TR3LevelNames.THAMES] = new List<TR3Entities>
-            {
-                TR3Entities.LaraLondon, TR3Entities.Crow, TR3Entities.LondonGuard, TR3Entities.LondonMerc, TR3Entities.Rat
-            },
-            [TR3LevelNames.ALDWYCH] = new List<TR3Entities>
-            {
-                TR3Entities.Punk, TR3Entities.DogLondon
-            },
-            [TR3LevelNames.LUDS] = new List<TR3Entities>
-            {
-                TR3Entities.ScubaSteve, TR3Entities.UPV
-            },
-            [TR3LevelNames.CITY] = new List<TR3Entities>
-            {
-                TR3Entities.SophiaLee, TR3Entities.EyeOfIsis_P
-            },
-            [TR3LevelNames.NEVADA] = new List<TR3Entities>
-            {
-                TR3Entities.LaraNevada, TR3Entities.DamGuard, TR3Entities.CobraNevada
-            },
-            [TR3LevelNames.HSC] = new List<TR3Entities>
-            {
-                TR3Entities.MPWithStick, TR3Entities.MPWithGun, TR3Entities.Prisoner, TR3Entities.DogNevada
-            },
-            [TR3LevelNames.AREA51] = new List<TR3Entities>
-            {
-                TR3Entities.KillerWhale, TR3Entities.MPWithMP5, TR3Entities.Element115_P
-            },
-            [TR3LevelNames.ANTARC] = new List<TR3Entities>
-            {
-                TR3Entities.LaraAntarc, TR3Entities.CrawlerMutantInCloset, TR3Entities.Boat, TR3Entities.RXRedBoi, TR3Entities.DogAntarc
-            }
-            ,
-            [TR3LevelNames.RXTECH] = new List<TR3Entities>
-            {
-                TR3Entities.Crawler, TR3Entities.RXTechFlameLad, TR3Entities.BruteMutant
-            },
-            [TR3LevelNames.TINNOS] = new List<TR3Entities>
-            {
-                TR3Entities.TinnosMonster, TR3Entities.TinnosWasp, TR3Entities.Door4
-            },
-            [TR3LevelNames.WILLIE] = new List<TR3Entities>
-            {
-                TR3Entities.Willie, TR3Entities.RXGunLad
-            },
-            [TR3LevelNames.HALLOWS] = new List<TR3Entities>
-            {
-                
-            },
-            [TR3LevelNames.ASSAULT] = new List<TR3Entities>
-            {
-                TR3Entities.LaraHome, TR3Entities.Winston, TR3Entities.WinstonInCamoSuit
-            }
-        };
+        _reader = new();
     }
+
+    protected override AbstractTRModelExporter<TR3Entities, TR3Level, TR3ModelDefinition> CreateExporter()
+    {
+        return new TR3ModelExporter();
+    }
+
+    protected override TR3Level ReadLevel(string path)
+    {
+        return _reader.Read(path);
+    }
+
+    private static readonly Dictionary<string, List<TR3Entities>> _exportModelTypes = new Dictionary<string, List<TR3Entities>>
+    {
+        [TR3LevelNames.JUNGLE] = new List<TR3Entities>
+        {
+            TR3Entities.LaraIndia, TR3Entities.Monkey, TR3Entities.Tiger, TR3Entities.Door1
+        },
+        [TR3LevelNames.RUINS] = new List<TR3Entities>
+        {
+            TR3Entities.Shiva, TR3Entities.CobraIndia
+        },
+        [TR3LevelNames.GANGES] = new List<TR3Entities>
+        {
+            TR3Entities.Quad, TR3Entities.Vulture
+        },
+        [TR3LevelNames.CAVES] = new List<TR3Entities>
+        {
+            TR3Entities.TonyFirehands, TR3Entities.Infada_P
+        },
+        [TR3LevelNames.COASTAL] = new List<TR3Entities>
+        {
+            TR3Entities.LaraCoastal, TR3Entities.Croc, TR3Entities.TribesmanAxe, TR3Entities.TribesmanDart
+        },
+        [TR3LevelNames.CRASH] = new List<TR3Entities>
+        {
+            TR3Entities.Compsognathus, TR3Entities.Mercenary, TR3Entities.Raptor, TR3Entities.Tyrannosaur
+        },
+        [TR3LevelNames.MADUBU] = new List<TR3Entities>
+        {
+            TR3Entities.Kayak, TR3Entities.LizardMan
+        },
+        [TR3LevelNames.PUNA] = new List<TR3Entities>
+        {
+            TR3Entities.Puna, TR3Entities.OraDagger_P
+        },
+        [TR3LevelNames.THAMES] = new List<TR3Entities>
+        {
+            TR3Entities.LaraLondon, TR3Entities.Crow, TR3Entities.LondonGuard, TR3Entities.LondonMerc, TR3Entities.Rat
+        },
+        [TR3LevelNames.ALDWYCH] = new List<TR3Entities>
+        {
+            TR3Entities.Punk, TR3Entities.DogLondon
+        },
+        [TR3LevelNames.LUDS] = new List<TR3Entities>
+        {
+            TR3Entities.ScubaSteve, TR3Entities.UPV
+        },
+        [TR3LevelNames.CITY] = new List<TR3Entities>
+        {
+            TR3Entities.SophiaLee, TR3Entities.EyeOfIsis_P
+        },
+        [TR3LevelNames.NEVADA] = new List<TR3Entities>
+        {
+            TR3Entities.LaraNevada, TR3Entities.DamGuard, TR3Entities.CobraNevada
+        },
+        [TR3LevelNames.HSC] = new List<TR3Entities>
+        {
+            TR3Entities.MPWithStick, TR3Entities.MPWithGun, TR3Entities.Prisoner, TR3Entities.DogNevada
+        },
+        [TR3LevelNames.AREA51] = new List<TR3Entities>
+        {
+            TR3Entities.KillerWhale, TR3Entities.MPWithMP5, TR3Entities.Element115_P
+        },
+        [TR3LevelNames.ANTARC] = new List<TR3Entities>
+        {
+            TR3Entities.LaraAntarc, TR3Entities.CrawlerMutantInCloset, TR3Entities.Boat, TR3Entities.RXRedBoi, TR3Entities.DogAntarc
+        }
+        ,
+        [TR3LevelNames.RXTECH] = new List<TR3Entities>
+        {
+            TR3Entities.Crawler, TR3Entities.RXTechFlameLad, TR3Entities.BruteMutant
+        },
+        [TR3LevelNames.TINNOS] = new List<TR3Entities>
+        {
+            TR3Entities.TinnosMonster, TR3Entities.TinnosWasp, TR3Entities.Door4
+        },
+        [TR3LevelNames.WILLIE] = new List<TR3Entities>
+        {
+            TR3Entities.Willie, TR3Entities.RXGunLad
+        },
+        [TR3LevelNames.HALLOWS] = new List<TR3Entities>
+        {
+            
+        },
+        [TR3LevelNames.ASSAULT] = new List<TR3Entities>
+        {
+            TR3Entities.LaraHome, TR3Entities.Winston, TR3Entities.WinstonInCamoSuit
+        }
+    };
 }

--- a/TRModelTransporter/Utilities/Export/MassTR3ModelExporter.cs
+++ b/TRModelTransporter/Utilities/Export/MassTR3ModelExporter.cs
@@ -30,7 +30,7 @@ public class MassTR3ModelExporter : AbstractMassTRModelExporter<TR3Entities, TR3
         return _reader.Read(path);
     }
 
-    private static readonly Dictionary<string, List<TR3Entities>> _exportModelTypes = new Dictionary<string, List<TR3Entities>>
+    private static readonly Dictionary<string, List<TR3Entities>> _exportModelTypes = new()
     {
         [TR3LevelNames.JUNGLE] = new List<TR3Entities>
         {

--- a/TRModelTransporter/Utilities/Export/MassTR3ModelExporter.cs
+++ b/TRModelTransporter/Utilities/Export/MassTR3ModelExporter.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using TRLevelControl;
+﻿using TRLevelControl;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRLevelControl.Model.Enums;

--- a/TRModelTransporter/Utilities/TRTextureClassifier.cs
+++ b/TRModelTransporter/Utilities/TRTextureClassifier.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using System.Security.Cryptography;
+﻿using System.Security.Cryptography;
 using System.Text;
 using TRModelTransporter.Model.Textures;
 

--- a/TRModelTransporter/Utilities/TRTextureClassifier.cs
+++ b/TRModelTransporter/Utilities/TRTextureClassifier.cs
@@ -10,16 +10,14 @@ public class TRTextureClassifier : ITextureClassifier
 
     public TRTextureClassifier(string levelPath)
     {
-        using (MD5 md5 = MD5.Create())
+        using MD5 md5 = MD5.Create();
+        byte[] hash = md5.ComputeHash(Encoding.Default.GetBytes(Path.GetFileNameWithoutExtension(levelPath).ToUpper()));
+        StringBuilder sb = new();
+        for (int i = 0; i < hash.Length; i++)
         {
-            byte[] hash = md5.ComputeHash(Encoding.Default.GetBytes(Path.GetFileNameWithoutExtension(levelPath).ToUpper()));
-            StringBuilder sb = new();
-            for (int i = 0; i < hash.Length; i++)
-            {
-                sb.Append(hash[i].ToString("x2"));
-            }
-            _levelClassification = sb.ToString();
+            sb.Append(hash[i].ToString("x2"));
         }
+        _levelClassification = sb.ToString();
     }
 
     public string GetClassification()

--- a/TRModelTransporter/Utilities/TRTextureClassifier.cs
+++ b/TRModelTransporter/Utilities/TRTextureClassifier.cs
@@ -13,7 +13,7 @@ public class TRTextureClassifier : ITextureClassifier
         using (MD5 md5 = MD5.Create())
         {
             byte[] hash = md5.ComputeHash(Encoding.Default.GetBytes(Path.GetFileNameWithoutExtension(levelPath).ToUpper()));
-            StringBuilder sb = new StringBuilder();
+            StringBuilder sb = new();
             for (int i = 0; i < hash.Length; i++)
             {
                 sb.Append(hash[i].ToString("x2"));

--- a/TRModelTransporter/Utilities/TRTextureClassifier.cs
+++ b/TRModelTransporter/Utilities/TRTextureClassifier.cs
@@ -3,29 +3,28 @@ using System.Security.Cryptography;
 using System.Text;
 using TRModelTransporter.Model.Textures;
 
-namespace TRModelTransporter.Utilities
+namespace TRModelTransporter.Utilities;
+
+public class TRTextureClassifier : ITextureClassifier
 {
-    public class TRTextureClassifier : ITextureClassifier
+    private readonly string _levelClassification;
+
+    public TRTextureClassifier(string levelPath)
     {
-        private readonly string _levelClassification;
-
-        public TRTextureClassifier(string levelPath)
+        using (MD5 md5 = MD5.Create())
         {
-            using (MD5 md5 = MD5.Create())
+            byte[] hash = md5.ComputeHash(Encoding.Default.GetBytes(Path.GetFileNameWithoutExtension(levelPath).ToUpper()));
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < hash.Length; i++)
             {
-                byte[] hash = md5.ComputeHash(Encoding.Default.GetBytes(Path.GetFileNameWithoutExtension(levelPath).ToUpper()));
-                StringBuilder sb = new StringBuilder();
-                for (int i = 0; i < hash.Length; i++)
-                {
-                    sb.Append(hash[i].ToString("x2"));
-                }
-                _levelClassification = sb.ToString();
+                sb.Append(hash[i].ToString("x2"));
             }
+            _levelClassification = sb.ToString();
         }
+    }
 
-        public string GetClassification()
-        {
-            return _levelClassification;
-        }
+    public string GetClassification()
+    {
+        return _levelClassification;
     }
 }

--- a/TRModelTransporter/Utilities/TRTextureDeduplicator.cs
+++ b/TRModelTransporter/Utilities/TRTextureDeduplicator.cs
@@ -177,7 +177,7 @@ public class TRTextureDeduplicator<E> where E : Enum
         });
     }
 
-    private Point? LocateSubSegment(MappedSegment segmentToLocate, MappedSegment containerSegment)
+    private static Point? LocateSubSegment(MappedSegment segmentToLocate, MappedSegment containerSegment)
     {
         int xEnd = containerSegment.Segment.Bounds.Width - segmentToLocate.Segment.Bounds.Width;
         int yEnd = containerSegment.Segment.Bounds.Height - segmentToLocate.Segment.Bounds.Height;
@@ -199,7 +199,7 @@ public class TRTextureDeduplicator<E> where E : Enum
         return null;
     }
 
-    private bool CompareBitmaps(Bitmap bmp1, Bitmap bmp2)
+    private static bool CompareBitmaps(Bitmap bmp1, Bitmap bmp2)
     {
         for (int x = 0; x < bmp1.Width; x++)
         {

--- a/TRModelTransporter/Utilities/TRTextureDeduplicator.cs
+++ b/TRModelTransporter/Utilities/TRTextureDeduplicator.cs
@@ -189,12 +189,10 @@ public class TRTextureDeduplicator<E> where E : Enum
             for (int y = 0; y <= yEnd; y++)
             {
                 rect.Y = y;
-                using (Bitmap bmp = containerSegment.Segment.Bitmap.Clone(rect, PixelFormat.Format32bppArgb))
+                using Bitmap bmp = containerSegment.Segment.Bitmap.Clone(rect, PixelFormat.Format32bppArgb);
+                if (CompareBitmaps(segmentToLocate.Segment.Bitmap, bmp))
                 {
-                    if (CompareBitmaps(segmentToLocate.Segment.Bitmap, bmp))
-                    {
-                        return new Point(x, y);
-                    }
+                    return new Point(x, y);
                 }
             }
         }

--- a/TRModelTransporter/Utilities/TRTextureDeduplicator.cs
+++ b/TRModelTransporter/Utilities/TRTextureDeduplicator.cs
@@ -240,7 +240,7 @@ public class TRTextureDeduplicator<E> where E : Enum
     {
         if (ignoredIndices != null)
         {
-            if (ignoredIndices.Count() == 0)
+            if (!ignoredIndices.Any())
             {
                 return true;
             }

--- a/TRModelTransporter/Utilities/TRTextureDeduplicator.cs
+++ b/TRModelTransporter/Utilities/TRTextureDeduplicator.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
+﻿using System.Drawing;
 using System.Drawing.Imaging;
-using System.Linq;
 using TRModelTransporter.Model.Textures;
 using TRModelTransporter.Packing;
 

--- a/TRModelTransporter/Utilities/TRTextureDeduplicator.cs
+++ b/TRModelTransporter/Utilities/TRTextureDeduplicator.cs
@@ -181,7 +181,7 @@ public class TRTextureDeduplicator<E> where E : Enum
     {
         int xEnd = containerSegment.Segment.Bounds.Width - segmentToLocate.Segment.Bounds.Width;
         int yEnd = containerSegment.Segment.Bounds.Height - segmentToLocate.Segment.Bounds.Height;
-        Rectangle rect = new Rectangle(0, 0, segmentToLocate.Segment.Bounds.Width, segmentToLocate.Segment.Bounds.Height);
+        Rectangle rect = new(0, 0, segmentToLocate.Segment.Bounds.Width, segmentToLocate.Segment.Bounds.Height);
 
         for (int x = 0; x <= xEnd; x++)
         {

--- a/TRModelTransporter/Utilities/TRTextureRemapEventArgs.cs
+++ b/TRModelTransporter/Utilities/TRTextureRemapEventArgs.cs
@@ -2,19 +2,18 @@
 using System.Drawing;
 using TRModelTransporter.Packing;
 
-namespace TRModelTransporter.Utilities
+namespace TRModelTransporter.Utilities;
+
+public class TRTextureRemapEventArgs : EventArgs
 {
-    public class TRTextureRemapEventArgs : EventArgs
-    {
-        public TexturedTile OldTile { get; set; }
-        public int OldFirstTextureIndex { get; set; }
-        public int OldArea { get; set; }
-        public Rectangle OldBounds { get; set; }
+    public TexturedTile OldTile { get; set; }
+    public int OldFirstTextureIndex { get; set; }
+    public int OldArea { get; set; }
+    public Rectangle OldBounds { get; set; }
 
-        public TexturedTile NewTile { get; set; }
-        public TexturedTileSegment NewSegment { get; set; }
-        public Rectangle NewBounds { get; set; }
+    public TexturedTile NewTile { get; set; }
+    public TexturedTileSegment NewSegment { get; set; }
+    public Rectangle NewBounds { get; set; }
 
-        public Point AdjustmentPoint { get; set; }
-    }
+    public Point AdjustmentPoint { get; set; }
 }

--- a/TRModelTransporter/Utilities/TRTextureRemapEventArgs.cs
+++ b/TRModelTransporter/Utilities/TRTextureRemapEventArgs.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Drawing;
+﻿using System.Drawing;
 using TRModelTransporter.Packing;
 
 namespace TRModelTransporter.Utilities;


### PR DESCRIPTION
Cleanup tasks for the `TRModelTransport` project. Similar tasks to the other projects, the only deviation here is swapping out  `Count()` for `Any()` on `IEnumerable`s - the IDE suggests a performance boost, although I imagine this is negligible for the cases here. It clears a message nonetheless.
Part of #425.