### PR TITLE
Move writing to control classes

### DIFF
--- a/TRLevelControl/Control/TR1LevelControl.cs
+++ b/TRLevelControl/Control/TR1LevelControl.cs
@@ -362,8 +362,6 @@ public class TR1LevelControl : TRLevelControlBase<TR1Level>
 
     protected override void Write(TRLevelWriter writer)
     {
-        writer.Write((uint)_level.Version.File);
-
         writer.Write(_level.NumImages);
         foreach (TRTexImage8 tex in _level.Images8) { writer.Write(tex.Serialize()); }
 

--- a/TRLevelControl/Control/TR1LevelControl.cs
+++ b/TRLevelControl/Control/TR1LevelControl.cs
@@ -362,7 +362,84 @@ public class TR1LevelControl : TRLevelControlBase<TR1Level>
 
     protected override void Write(TRLevelWriter writer)
     {
-        writer.Write(_level.Serialize());
+        writer.Write((uint)_level.Version.File);
+
+        writer.Write(_level.NumImages);
+        foreach (TRTexImage8 tex in _level.Images8) { writer.Write(tex.Serialize()); }
+
+        writer.Write(_level.Unused);
+
+        writer.Write(_level.NumRooms);
+        foreach (TRRoom room in _level.Rooms) { writer.Write(room.Serialize()); }
+
+        writer.Write(_level.NumFloorData);
+        foreach (ushort data in _level.FloorData) { writer.Write(data); }
+
+        writer.Write(_level.NumMeshData);
+        foreach (TRMesh mesh in _level.Meshes) { writer.Write(mesh.Serialize()); }
+        writer.Write(_level.NumMeshPointers);
+        foreach (uint ptr in _level.MeshPointers) { writer.Write(ptr); }
+
+        writer.Write(_level.NumAnimations);
+        foreach (TRAnimation anim in _level.Animations) { writer.Write(anim.Serialize()); }
+        writer.Write(_level.NumStateChanges);
+        foreach (TRStateChange statec in _level.StateChanges) { writer.Write(statec.Serialize()); }
+        writer.Write(_level.NumAnimDispatches);
+        foreach (TRAnimDispatch dispatch in _level.AnimDispatches) { writer.Write(dispatch.Serialize()); }
+        writer.Write(_level.NumAnimCommands);
+        foreach (TRAnimCommand cmd in _level.AnimCommands) { writer.Write(cmd.Serialize()); }
+        writer.Write(_level.NumMeshTrees * 4); //To get the correct number /= 4 is done during read, make sure to reverse it here.
+        foreach (TRMeshTreeNode node in _level.MeshTrees) { writer.Write(node.Serialize()); }
+        writer.Write(_level.NumFrames);
+        foreach (ushort frame in _level.Frames) { writer.Write(frame); }
+
+        writer.Write(_level.NumModels);
+        foreach (TRModel model in _level.Models) { writer.Write(model.Serialize()); }
+        writer.Write(_level.NumStaticMeshes);
+        foreach (TRStaticMesh mesh in _level.StaticMeshes) { writer.Write(mesh.Serialize()); }
+
+        writer.Write(_level.NumObjectTextures);
+        foreach (TRObjectTexture tex in _level.ObjectTextures) { writer.Write(tex.Serialize()); }
+        writer.Write(_level.NumSpriteTextures);
+        foreach (TRSpriteTexture tex in _level.SpriteTextures) { writer.Write(tex.Serialize()); }
+        writer.Write(_level.NumSpriteSequences);
+        foreach (TRSpriteSequence sequence in _level.SpriteSequences) { writer.Write(sequence.Serialize()); }
+
+        writer.Write(_level.NumCameras);
+        foreach (TRCamera cam in _level.Cameras) { writer.Write(cam.Serialize()); }
+
+        writer.Write(_level.NumSoundSources);
+        foreach (TRSoundSource src in _level.SoundSources) { writer.Write(src.Serialize()); }
+
+        writer.Write(_level.NumBoxes);
+        foreach (TRBox box in _level.Boxes) { writer.Write(box.Serialize()); }
+        writer.Write(_level.NumOverlaps);
+        foreach (ushort overlap in _level.Overlaps) { writer.Write(overlap); }
+        foreach (ushort zone in TR1BoxUtilities.FlattenZones(_level.Zones)) { writer.Write(zone); }
+
+        writer.Write(_level.NumAnimatedTextures);
+        writer.Write((ushort)_level.AnimatedTextures.Length);
+        foreach (TRAnimatedTexture texture in _level.AnimatedTextures) { writer.Write(texture.Serialize()); }
+
+        writer.Write(_level.NumEntities);
+        foreach (TREntity entity in _level.Entities) { writer.Write(entity.Serialize()); }
+
+        writer.Write(_level.LightMap);
+        foreach (TRColour col in _level.Palette) { writer.Write(col.Serialize()); }
+
+        writer.Write(_level.NumCinematicFrames);
+        foreach (TRCinematicFrame cineframe in _level.CinematicFrames) { writer.Write(cineframe.Serialize()); }
+
+        writer.Write(_level.NumDemoData);
+        writer.Write(_level.DemoData);
+
+        foreach (short sound in _level.SoundMap) { writer.Write(sound); }
+        writer.Write(_level.NumSoundDetails);
+        foreach (TRSoundDetails snddetail in _level.SoundDetails) { writer.Write(snddetail.Serialize()); }
+        writer.Write(_level.NumSamples);
+        foreach (byte sample in _level.Samples) { writer.Write(sample); }
+        writer.Write(_level.NumSampleIndices);
+        foreach (uint index in _level.SampleIndices) { writer.Write(index); }
     }
 
     private static TRColour[] PopulateColourPalette(byte[] palette)

--- a/TRLevelControl/Control/TR1LevelControl.cs
+++ b/TRLevelControl/Control/TR1LevelControl.cs
@@ -23,7 +23,7 @@ public class TR1LevelControl : TRLevelControlBase<TR1Level>
         return level;
     }
 
-    protected override void Read(BinaryReader reader)
+    protected override void Read(TRLevelReader reader)
     {
         _level.NumImages = reader.ReadUInt32();
         _level.Images8 = new TRTexImage8[_level.NumImages];
@@ -360,7 +360,7 @@ public class TR1LevelControl : TRLevelControlBase<TR1Level>
         }
     }
 
-    protected override void Write(BinaryWriter writer)
+    protected override void Write(TRLevelWriter writer)
     {
         writer.Write(_level.Serialize());
     }

--- a/TRLevelControl/Control/TR2LevelControl.cs
+++ b/TRLevelControl/Control/TR2LevelControl.cs
@@ -23,7 +23,7 @@ public class TR2LevelControl : TRLevelControlBase<TR2Level>
         return level;
     }
 
-    protected override void Read(BinaryReader reader)
+    protected override void Read(TRLevelReader reader)
     {
         //Colour palettes and textures
         _level.Palette = PopulateColourPalette(reader.ReadBytes((int)MAX_PALETTE_SIZE * 3));
@@ -375,7 +375,7 @@ public class TR2LevelControl : TRLevelControlBase<TR2Level>
         }
     }
 
-    protected override void Write(BinaryWriter writer)
+    protected override void Write(TRLevelWriter writer)
     {
         writer.Write(_level.Serialize());
     }

--- a/TRLevelControl/Control/TR2LevelControl.cs
+++ b/TRLevelControl/Control/TR2LevelControl.cs
@@ -377,8 +377,6 @@ public class TR2LevelControl : TRLevelControlBase<TR2Level>
 
     protected override void Write(TRLevelWriter writer)
     {
-        writer.Write((uint)_level.Version.File);
-
         foreach (TRColour col in _level.Palette) { writer.Write(col.Serialize()); }
         foreach (TRColour4 col in _level.Palette16) { writer.Write(col.Serialize()); }
 

--- a/TRLevelControl/Control/TR2LevelControl.cs
+++ b/TRLevelControl/Control/TR2LevelControl.cs
@@ -377,7 +377,83 @@ public class TR2LevelControl : TRLevelControlBase<TR2Level>
 
     protected override void Write(TRLevelWriter writer)
     {
-        writer.Write(_level.Serialize());
+        writer.Write((uint)_level.Version.File);
+
+        foreach (TRColour col in _level.Palette) { writer.Write(col.Serialize()); }
+        foreach (TRColour4 col in _level.Palette16) { writer.Write(col.Serialize()); }
+
+        writer.Write(_level.NumImages);
+        foreach (TRTexImage8 tex in _level.Images8) { writer.Write(tex.Serialize()); }
+        foreach (TRTexImage16 tex in _level.Images16) { writer.Write(tex.Serialize()); }
+
+        writer.Write(_level.Unused);
+
+        writer.Write(_level.NumRooms);
+        foreach (TR2Room room in _level.Rooms) { writer.Write(room.Serialize()); }
+        writer.Write(_level.NumFloorData);
+        foreach (ushort data in _level.FloorData) { writer.Write(data); }
+
+        writer.Write(_level.NumMeshData);
+        foreach (TRMesh mesh in _level.Meshes) { writer.Write(mesh.Serialize()); }
+        writer.Write(_level.NumMeshPointers);
+        foreach (uint ptr in _level.MeshPointers) { writer.Write(ptr); }
+
+        writer.Write(_level.NumAnimations);
+        foreach (TRAnimation anim in _level.Animations) { writer.Write(anim.Serialize()); }
+        writer.Write(_level.NumStateChanges);
+        foreach (TRStateChange statec in _level.StateChanges) { writer.Write(statec.Serialize()); }
+        writer.Write(_level.NumAnimDispatches);
+        foreach (TRAnimDispatch dispatch in _level.AnimDispatches) { writer.Write(dispatch.Serialize()); }
+        writer.Write(_level.NumAnimCommands);
+        foreach (TRAnimCommand cmd in _level.AnimCommands) { writer.Write(cmd.Serialize()); }
+        writer.Write(_level.NumMeshTrees * 4); //To get the correct number /= 4 is done during read, make sure to reverse it here.
+        foreach (TRMeshTreeNode node in _level.MeshTrees) { writer.Write(node.Serialize()); }
+        writer.Write(_level.NumFrames);
+        foreach (ushort frame in _level.Frames) { writer.Write(frame); }
+
+        writer.Write(_level.NumModels);
+        foreach (TRModel model in _level.Models) { writer.Write(model.Serialize()); }
+        writer.Write(_level.NumStaticMeshes);
+        foreach (TRStaticMesh mesh in _level.StaticMeshes) { writer.Write(mesh.Serialize()); }
+
+        writer.Write(_level.NumObjectTextures);
+        foreach (TRObjectTexture tex in _level.ObjectTextures) { writer.Write(tex.Serialize()); }
+        writer.Write(_level.NumSpriteTextures);
+        foreach (TRSpriteTexture tex in _level.SpriteTextures) { writer.Write(tex.Serialize()); }
+        writer.Write(_level.NumSpriteSequences);
+        foreach (TRSpriteSequence sequence in _level.SpriteSequences) { writer.Write(sequence.Serialize()); }
+
+        writer.Write(_level.NumCameras);
+        foreach (TRCamera cam in _level.Cameras) { writer.Write(cam.Serialize()); }
+
+        writer.Write(_level.NumSoundSources);
+        foreach (TRSoundSource src in _level.SoundSources) { writer.Write(src.Serialize()); }
+
+        writer.Write(_level.NumBoxes);
+        foreach (TR2Box box in _level.Boxes) { writer.Write(box.Serialize()); }
+        writer.Write(_level.NumOverlaps);
+        foreach (ushort overlap in _level.Overlaps) { writer.Write(overlap); }
+        foreach (ushort zone in TR2BoxUtilities.FlattenZones(_level.Zones)) { writer.Write(zone); }
+
+        writer.Write(_level.NumAnimatedTextures);
+        writer.Write((ushort)_level.AnimatedTextures.Length);
+        foreach (TRAnimatedTexture texture in _level.AnimatedTextures) { writer.Write(texture.Serialize()); }
+        writer.Write(_level.NumEntities);
+        foreach (TR2Entity entity in _level.Entities) { writer.Write(entity.Serialize()); }
+
+        writer.Write(_level.LightMap);
+
+        writer.Write(_level.NumCinematicFrames);
+        foreach (TRCinematicFrame cineframe in _level.CinematicFrames) { writer.Write(cineframe.Serialize()); }
+
+        writer.Write(_level.NumDemoData);
+        writer.Write(_level.DemoData);
+
+        foreach (short sound in _level.SoundMap) { writer.Write(sound); }
+        writer.Write(_level.NumSoundDetails);
+        foreach (TRSoundDetails snddetail in _level.SoundDetails) { writer.Write(snddetail.Serialize()); }
+        writer.Write(_level.NumSampleIndices);
+        foreach (uint index in _level.SampleIndices) { writer.Write(index); }
     }
 
     private static TRColour[] PopulateColourPalette(byte[] palette)

--- a/TRLevelControl/Control/TR3LevelControl.cs
+++ b/TRLevelControl/Control/TR3LevelControl.cs
@@ -379,7 +379,84 @@ public class TR3LevelControl : TRLevelControlBase<TR3Level>
 
     protected override void Write(TRLevelWriter writer)
     {
-        writer.Write(_level.Serialize());
+        writer.Write((uint)_level.Version.File);
+
+        foreach (TRColour col in _level.Palette) { writer.Write(col.Serialize()); }
+        foreach (TRColour4 col in _level.Palette16) { writer.Write(col.Serialize()); }
+
+        writer.Write(_level.NumImages);
+        foreach (TRTexImage8 tex in _level.Images8) { writer.Write(tex.Serialize()); }
+        foreach (TRTexImage16 tex in _level.Images16) { writer.Write(tex.Serialize()); }
+
+        writer.Write(_level.Unused);
+
+        writer.Write(_level.NumRooms);
+        foreach (TR3Room room in _level.Rooms) { writer.Write(room.Serialize()); }
+        writer.Write(_level.NumFloorData);
+        foreach (ushort data in _level.FloorData) { writer.Write(data); }
+
+        writer.Write(_level.NumMeshData);
+        foreach (TRMesh mesh in _level.Meshes) { writer.Write(mesh.Serialize()); }
+        writer.Write(_level.NumMeshPointers);
+        foreach (uint ptr in _level.MeshPointers) { writer.Write(ptr); }
+
+        writer.Write(_level.NumAnimations);
+        foreach (TRAnimation anim in _level.Animations) { writer.Write(anim.Serialize()); }
+        writer.Write(_level.NumStateChanges);
+        foreach (TRStateChange statec in _level.StateChanges) { writer.Write(statec.Serialize()); }
+        writer.Write(_level.NumAnimDispatches);
+        foreach (TRAnimDispatch dispatch in _level.AnimDispatches) { writer.Write(dispatch.Serialize()); }
+        writer.Write(_level.NumAnimCommands);
+        foreach (TRAnimCommand cmd in _level.AnimCommands) { writer.Write(cmd.Serialize()); }
+        writer.Write(_level.NumMeshTrees * 4); //To get the correct number /= 4 is done during read, make sure to reverse it here.
+        foreach (TRMeshTreeNode node in _level.MeshTrees) { writer.Write(node.Serialize()); }
+        writer.Write(_level.NumFrames);
+        foreach (ushort frame in _level.Frames) { writer.Write(frame); }
+
+        writer.Write(_level.NumModels);
+        foreach (TRModel model in _level.Models) { writer.Write(model.Serialize()); }
+        writer.Write(_level.NumStaticMeshes);
+        foreach (TRStaticMesh mesh in _level.StaticMeshes) { writer.Write(mesh.Serialize()); }
+
+        writer.Write(_level.NumSpriteTextures);
+        foreach (TRSpriteTexture tex in _level.SpriteTextures) { writer.Write(tex.Serialize()); }
+        writer.Write(_level.NumSpriteSequences);
+        foreach (TRSpriteSequence sequence in _level.SpriteSequences) { writer.Write(sequence.Serialize()); }
+        
+        writer.Write(_level.NumCameras);
+        foreach (TRCamera cam in _level.Cameras) { writer.Write(cam.Serialize()); }
+
+        writer.Write(_level.NumSoundSources);
+        foreach (TRSoundSource src in _level.SoundSources) { writer.Write(src.Serialize()); }
+        
+        writer.Write(_level.NumBoxes);
+        foreach (TR2Box box in _level.Boxes) { writer.Write(box.Serialize()); }
+        writer.Write(_level.NumOverlaps);
+        foreach (ushort overlap in _level.Overlaps) { writer.Write(overlap); }
+        foreach (ushort zone in TR2BoxUtilities.FlattenZones(_level.Zones)) { writer.Write(zone); }
+
+        writer.Write(_level.NumAnimatedTextures);
+        writer.Write((ushort)_level.AnimatedTextures.Length);
+        foreach (TRAnimatedTexture texture in _level.AnimatedTextures) { writer.Write(texture.Serialize()); }
+        writer.Write(_level.NumObjectTextures);
+        foreach (TRObjectTexture tex in _level.ObjectTextures) { writer.Write(tex.Serialize()); }
+
+        writer.Write(_level.NumEntities);
+        foreach (TR2Entity entity in _level.Entities) { writer.Write(entity.Serialize()); }
+
+        writer.Write(_level.LightMap);
+
+        writer.Write(_level.NumCinematicFrames);
+        foreach (TRCinematicFrame cineframe in _level.CinematicFrames) { writer.Write(cineframe.Serialize()); }
+
+        writer.Write(_level.NumDemoData);
+        writer.Write(_level.DemoData);
+
+        foreach (short sound in _level.SoundMap) { writer.Write(sound); }
+        writer.Write(_level.NumSoundDetails);
+        foreach (TR3SoundDetails snddetail in _level.SoundDetails) { writer.Write(snddetail.Serialize()); }
+        writer.Write(_level.NumSampleIndices);
+        foreach (uint index in _level.SampleIndices) { writer.Write(index); }
     }
 
     private static TRColour[] PopulateColourPalette(byte[] palette)

--- a/TRLevelControl/Control/TR3LevelControl.cs
+++ b/TRLevelControl/Control/TR3LevelControl.cs
@@ -23,7 +23,7 @@ public class TR3LevelControl : TRLevelControlBase<TR3Level>
         return level;
     }
 
-    protected override void Read(BinaryReader reader)
+    protected override void Read(TRLevelReader reader)
     {
         //Colour palettes and textures
         _level.Palette = PopulateColourPalette(reader.ReadBytes((int)MAX_PALETTE_SIZE * 3));
@@ -377,7 +377,7 @@ public class TR3LevelControl : TRLevelControlBase<TR3Level>
         }
     }
 
-    protected override void Write(BinaryWriter writer)
+    protected override void Write(TRLevelWriter writer)
     {
         writer.Write(_level.Serialize());
     }

--- a/TRLevelControl/Control/TR3LevelControl.cs
+++ b/TRLevelControl/Control/TR3LevelControl.cs
@@ -379,8 +379,6 @@ public class TR3LevelControl : TRLevelControlBase<TR3Level>
 
     protected override void Write(TRLevelWriter writer)
     {
-        writer.Write((uint)_level.Version.File);
-
         foreach (TRColour col in _level.Palette) { writer.Write(col.Serialize()); }
         foreach (TRColour4 col in _level.Palette16) { writer.Write(col.Serialize()); }
 

--- a/TRLevelControl/Control/TR4LevelControl.cs
+++ b/TRLevelControl/Control/TR4LevelControl.cs
@@ -97,7 +97,39 @@ public class TR4LevelControl : TRLevelControlBase<TR4Level>
 
     protected override void Write(TRLevelWriter writer)
     {
-        writer.Write(_level.Serialize());
+        writer.Write((uint)_level.Version.File);
+        writer.Write(_level.NumRoomTextiles);
+        writer.Write(_level.NumObjTextiles);
+        writer.Write(_level.NumBumpTextiles);
+
+        byte[] chunk = _level.Texture32Chunk.Serialize();
+        writer.Write(_level.Texture32Chunk.UncompressedSize);
+        writer.Write(_level.Texture32Chunk.CompressedSize);
+        writer.Write(chunk);
+
+        chunk = _level.Texture16Chunk.Serialize();
+        writer.Write(_level.Texture16Chunk.UncompressedSize);
+        writer.Write(_level.Texture16Chunk.CompressedSize);
+        writer.Write(chunk);
+
+        chunk = _level.SkyAndFont32Chunk.Serialize();
+        writer.Write(_level.SkyAndFont32Chunk.UncompressedSize);
+        writer.Write(_level.SkyAndFont32Chunk.CompressedSize);
+        writer.Write(chunk);
+
+        chunk = _level.LevelDataChunk.Serialize();
+        writer.Write(_level.LevelDataChunk.UncompressedSize);
+        writer.Write(_level.LevelDataChunk.CompressedSize);
+        writer.Write(chunk);
+
+        writer.Write(_level.NumSamples);
+
+        foreach (TR4Sample sample in _level.Samples)
+        {
+            writer.Write(sample.UncompSize);
+            writer.Write(sample.CompSize);
+            writer.Write(sample.CompressedChunk);
+        }
     }
 
     private static void DecompressTexture32Chunk(TR4Level lvl)

--- a/TRLevelControl/Control/TR4LevelControl.cs
+++ b/TRLevelControl/Control/TR4LevelControl.cs
@@ -21,7 +21,7 @@ public class TR4LevelControl : TRLevelControlBase<TR4Level>
         return level;
     }
 
-    protected override void Read(BinaryReader reader)
+    protected override void Read(TRLevelReader reader)
     {            
         //Texture Counts
         _level.NumRoomTextiles = reader.ReadUInt16();
@@ -95,7 +95,7 @@ public class TR4LevelControl : TRLevelControlBase<TR4Level>
         }
     }
 
-    protected override void Write(BinaryWriter writer)
+    protected override void Write(TRLevelWriter writer)
     {
         writer.Write(_level.Serialize());
     }

--- a/TRLevelControl/Control/TR4LevelControl.cs
+++ b/TRLevelControl/Control/TR4LevelControl.cs
@@ -97,7 +97,6 @@ public class TR4LevelControl : TRLevelControlBase<TR4Level>
 
     protected override void Write(TRLevelWriter writer)
     {
-        writer.Write((uint)_level.Version.File);
         writer.Write(_level.NumRoomTextiles);
         writer.Write(_level.NumObjTextiles);
         writer.Write(_level.NumBumpTextiles);

--- a/TRLevelControl/Control/TR5LevelControl.cs
+++ b/TRLevelControl/Control/TR5LevelControl.cs
@@ -21,7 +21,7 @@ public class TR5LevelControl : TRLevelControlBase<TR5Level>
         return level;
     }
 
-    protected override void Read(BinaryReader reader)
+    protected override void Read(TRLevelReader reader)
     {
         //Texture Counts
         _level.NumRoomTextiles = reader.ReadUInt16();
@@ -100,7 +100,7 @@ public class TR5LevelControl : TRLevelControlBase<TR5Level>
         }
     }
 
-    protected override void Write(BinaryWriter writer)
+    protected override void Write(TRLevelWriter writer)
     {
         writer.Write(_level.Serialize());
     }

--- a/TRLevelControl/Control/TR5LevelControl.cs
+++ b/TRLevelControl/Control/TR5LevelControl.cs
@@ -102,7 +102,6 @@ public class TR5LevelControl : TRLevelControlBase<TR5Level>
 
     protected override void Write(TRLevelWriter writer)
     {
-        writer.Write((uint)_level.Version.File);
         writer.Write(_level.NumRoomTextiles);
         writer.Write(_level.NumObjTextiles);
         writer.Write(_level.NumBumpTextiles);

--- a/TRLevelControl/Control/TR5LevelControl.cs
+++ b/TRLevelControl/Control/TR5LevelControl.cs
@@ -102,7 +102,44 @@ public class TR5LevelControl : TRLevelControlBase<TR5Level>
 
     protected override void Write(TRLevelWriter writer)
     {
-        writer.Write(_level.Serialize());
+        writer.Write((uint)_level.Version.File);
+        writer.Write(_level.NumRoomTextiles);
+        writer.Write(_level.NumObjTextiles);
+        writer.Write(_level.NumBumpTextiles);
+
+        byte[] chunk = _level.Texture32Chunk.Serialize();
+        writer.Write(_level.Texture32Chunk.UncompressedSize);
+        writer.Write(_level.Texture32Chunk.CompressedSize);
+        writer.Write(chunk);
+
+        chunk = _level.Texture16Chunk.Serialize();
+        writer.Write(_level.Texture16Chunk.UncompressedSize);
+        writer.Write(_level.Texture16Chunk.CompressedSize);
+        writer.Write(chunk);
+
+        chunk = _level.SkyAndFont32Chunk.Serialize();
+        writer.Write(_level.SkyAndFont32Chunk.UncompressedSize);
+        writer.Write(_level.SkyAndFont32Chunk.CompressedSize);
+        writer.Write(chunk);
+
+        writer.Write(_level.LaraType);
+        writer.Write(_level.WeatherType);
+        writer.Write(_level.Padding);
+
+        //Note - a TR5 Level data chunk is not compressed.
+        chunk = _level.LevelDataChunk.Serialize();
+        writer.Write(_level.LevelDataChunk.UncompressedSize);
+        writer.Write(_level.LevelDataChunk.CompressedSize);
+        writer.Write(chunk);
+
+        writer.Write(_level.NumSamples);
+
+        foreach (TR4Sample sample in _level.Samples)
+        {
+            writer.Write(sample.UncompSize);
+            writer.Write(sample.CompSize);
+            writer.Write(sample.CompressedChunk);
+        }
     }
 
     private static void DecompressTexture32Chunk(TR5Level lvl)

--- a/TRLevelControl/IO/TRLevelReader.cs
+++ b/TRLevelControl/IO/TRLevelReader.cs
@@ -1,0 +1,7 @@
+﻿namespace TRLevelControl;
+
+public class TRLevelReader : BinaryReader
+{
+    public TRLevelReader(Stream stream)
+        : base(stream) { }
+}

--- a/TRLevelControl/IO/TRLevelWriter.cs
+++ b/TRLevelControl/IO/TRLevelWriter.cs
@@ -1,0 +1,7 @@
+﻿namespace TRLevelControl;
+
+public class TRLevelWriter : BinaryWriter
+{
+    public TRLevelWriter(Stream stream)
+        : base(stream) { }
+}

--- a/TRLevelControl/Model/Base/TR1Level.cs
+++ b/TRLevelControl/Model/Base/TR1Level.cs
@@ -1,9 +1,6 @@
-﻿using TRLevelControl.Helpers;
-using TRLevelControl.Serialization;
+﻿namespace TRLevelControl.Model;
 
-namespace TRLevelControl.Model;
-
-public class TR1Level : TRLevelBase, ISerializableCompact
+public class TR1Level : TRLevelBase
 {
     /// <summary>
     /// 4 Bytes
@@ -295,85 +292,4 @@ public class TR1Level : TRLevelBase, ISerializableCompact
     /// NumSampleIndices * 4 bytes
     /// </summary>
     public uint[] SampleIndices { get; set; }
-
-    public TR1Level()
-    {
-
-    }
-
-    public byte[] Serialize()
-    {
-        using MemoryStream stream = new();
-        using (BinaryWriter writer = new(stream))
-        {
-            writer.Write((uint)Version.File);
-            writer.Write(NumImages);
-            foreach (TRTexImage8 tex in Images8) { writer.Write(tex.Serialize()); }
-            writer.Write(Unused);
-            writer.Write(NumRooms);
-            foreach (TRRoom room in Rooms) { writer.Write(room.Serialize()); }
-            writer.Write(NumFloorData);
-            foreach (ushort data in FloorData) { writer.Write(data); }
-            writer.Write(NumMeshData);
-
-            //Because mesh construction still hasnt been resolved, we will
-            //just write the raw mesh data as words for testing
-            foreach (TRMesh mesh in Meshes) { writer.Write(mesh.Serialize()); }
-            //foreach (ushort word in RawMeshData) { writer.Write(word); }
-
-            writer.Write(NumMeshPointers);
-            foreach (uint ptr in MeshPointers) { writer.Write(ptr); }
-            writer.Write(NumAnimations);
-            foreach (TRAnimation anim in Animations) { writer.Write(anim.Serialize()); }
-            writer.Write(NumStateChanges);
-            foreach (TRStateChange statec in StateChanges) { writer.Write(statec.Serialize()); }
-            writer.Write(NumAnimDispatches);
-            foreach (TRAnimDispatch dispatch in AnimDispatches) { writer.Write(dispatch.Serialize()); }
-            writer.Write(NumAnimCommands);
-            foreach (TRAnimCommand cmd in AnimCommands) { writer.Write(cmd.Serialize()); }
-            writer.Write(NumMeshTrees * 4); //To get the correct number /= 4 is done during read, make sure to reverse it here.
-            foreach (TRMeshTreeNode node in MeshTrees) { writer.Write(node.Serialize()); }
-            writer.Write(NumFrames);
-            foreach (ushort frame in Frames) { writer.Write(frame); }
-            writer.Write(NumModels);
-            foreach (TRModel model in Models) { writer.Write(model.Serialize()); }
-            writer.Write(NumStaticMeshes);
-            foreach (TRStaticMesh mesh in StaticMeshes) { writer.Write(mesh.Serialize()); }
-            writer.Write(NumObjectTextures);
-            foreach (TRObjectTexture tex in ObjectTextures) { writer.Write(tex.Serialize()); }
-            writer.Write(NumSpriteTextures);
-            foreach (TRSpriteTexture tex in SpriteTextures) { writer.Write(tex.Serialize()); }
-            writer.Write(NumSpriteSequences);
-            foreach (TRSpriteSequence sequence in SpriteSequences) { writer.Write(sequence.Serialize()); }
-            writer.Write(NumCameras);
-            foreach (TRCamera cam in Cameras) { writer.Write(cam.Serialize()); }
-            writer.Write(NumSoundSources);
-            foreach (TRSoundSource src in SoundSources) { writer.Write(src.Serialize()); }
-            writer.Write(NumBoxes);
-            foreach (TRBox box in Boxes) { writer.Write(box.Serialize()); }
-            writer.Write(NumOverlaps);
-            foreach (ushort overlap in Overlaps) { writer.Write(overlap); }
-            foreach (ushort zone in TR1BoxUtilities.FlattenZones(Zones)) { writer.Write(zone); }
-            writer.Write(NumAnimatedTextures);
-            writer.Write((ushort)AnimatedTextures.Length);
-            foreach (TRAnimatedTexture texture in AnimatedTextures) { writer.Write(texture.Serialize()); }
-            writer.Write(NumEntities);
-            foreach (TREntity entity in Entities) { writer.Write(entity.Serialize()); }
-            writer.Write(LightMap);
-            foreach (TRColour col in Palette) { writer.Write(col.Serialize()); }
-            writer.Write(NumCinematicFrames);
-            foreach (TRCinematicFrame cineframe in CinematicFrames) { writer.Write(cineframe.Serialize()); }
-            writer.Write(NumDemoData);
-            writer.Write(DemoData);
-            foreach (short sound in SoundMap) { writer.Write(sound); }
-            writer.Write(NumSoundDetails);
-            foreach (TRSoundDetails snddetail in SoundDetails) { writer.Write(snddetail.Serialize()); }
-            writer.Write(NumSamples);
-            foreach (byte sample in Samples) { writer.Write(sample); }
-            writer.Write(NumSampleIndices);
-            foreach (uint index in SampleIndices) { writer.Write(index); }
-        }
-
-        return stream.ToArray();
-    }
 }

--- a/TRLevelControl/Model/TR2/TR2Level.cs
+++ b/TRLevelControl/Model/TR2/TR2Level.cs
@@ -1,11 +1,6 @@
-﻿using TRLevelControl.Helpers;
-using TRLevelControl.Serialization;
+﻿namespace TRLevelControl.Model;
 
-//https://trwiki.earvillage.net/doku.php?id=trsone
-
-namespace TRLevelControl.Model;
-
-public class TR2Level : TRLevelBase, ISerializableCompact
+public class TR2Level : TRLevelBase
 {
     /// <summary>
     /// 256 entries * 3 components = 768 Bytes
@@ -306,86 +301,4 @@ public class TR2Level : TRLevelBase, ISerializableCompact
     /// NumSampleIndices * 4 bytes
     /// </summary>
     public uint[] SampleIndices { get; set; }
-
-    public TR2Level()
-    {
-
-    }
-
-    public byte[] Serialize()
-    {
-        using MemoryStream stream = new();
-        using (BinaryWriter writer = new(stream))
-        {
-            writer.Write((uint)Version.File);
-            foreach (TRColour col in Palette) { writer.Write(col.Serialize()); }
-            foreach (TRColour4 col in Palette16) { writer.Write(col.Serialize()); }
-            writer.Write(NumImages);
-            foreach (TRTexImage8 tex in Images8) { writer.Write(tex.Serialize()); }
-            foreach (TRTexImage16 tex in Images16) { writer.Write(tex.Serialize()); }
-            writer.Write(Unused);
-            writer.Write(NumRooms);
-            foreach (TR2Room room in Rooms) { writer.Write(room.Serialize()); }
-            writer.Write(NumFloorData);
-            foreach (ushort data in FloorData) { writer.Write(data); }
-            writer.Write(NumMeshData);
-
-            //Because mesh construction still hasnt been resolved, we will
-            //just write the raw mesh data as words for testing
-            foreach (TRMesh mesh in Meshes) { writer.Write(mesh.Serialize()); }
-            //foreach (ushort word in RawMeshData) { writer.Write(word); }
-
-            writer.Write(NumMeshPointers);
-            foreach (uint ptr in MeshPointers) { writer.Write(ptr); }
-            writer.Write(NumAnimations);
-            foreach (TRAnimation anim in Animations) { writer.Write(anim.Serialize()); }
-            writer.Write(NumStateChanges);
-            foreach (TRStateChange statec in StateChanges) { writer.Write(statec.Serialize()); }
-            writer.Write(NumAnimDispatches);
-            foreach (TRAnimDispatch dispatch in AnimDispatches) { writer.Write(dispatch.Serialize()); }
-            writer.Write(NumAnimCommands);
-            foreach (TRAnimCommand cmd in AnimCommands) { writer.Write(cmd.Serialize()); }
-            writer.Write(NumMeshTrees * 4); //To get the correct number /= 4 is done during read, make sure to reverse it here.
-            foreach (TRMeshTreeNode node in MeshTrees) { writer.Write(node.Serialize()); }
-            writer.Write(NumFrames);
-            foreach (ushort frame in Frames) { writer.Write(frame); }
-            writer.Write(NumModels);
-            foreach (TRModel model in Models) { writer.Write(model.Serialize()); }
-            writer.Write(NumStaticMeshes);
-            foreach (TRStaticMesh mesh in StaticMeshes) { writer.Write(mesh.Serialize()); }
-            writer.Write(NumObjectTextures);
-            foreach (TRObjectTexture tex in ObjectTextures) { writer.Write(tex.Serialize()); }
-            writer.Write(NumSpriteTextures);
-            foreach (TRSpriteTexture tex in SpriteTextures) { writer.Write(tex.Serialize()); }
-            writer.Write(NumSpriteSequences);
-            foreach (TRSpriteSequence sequence in SpriteSequences) { writer.Write(sequence.Serialize()); }
-            writer.Write(NumCameras);
-            foreach (TRCamera cam in Cameras) { writer.Write(cam.Serialize()); }
-            writer.Write(NumSoundSources);
-            foreach (TRSoundSource src in SoundSources) { writer.Write(src.Serialize()); }
-            writer.Write(NumBoxes);
-            foreach (TR2Box box in Boxes) { writer.Write(box.Serialize()); }
-            writer.Write(NumOverlaps);
-            foreach (ushort overlap in Overlaps) { writer.Write(overlap); }
-            //See note in TR2LevelReader re zones
-            foreach (ushort zone in TR2BoxUtilities.FlattenZones(Zones)) { writer.Write(zone); }
-            writer.Write(NumAnimatedTextures);
-            writer.Write((ushort)AnimatedTextures.Length);
-            foreach (TRAnimatedTexture texture in AnimatedTextures) { writer.Write(texture.Serialize()); }
-            writer.Write(NumEntities);
-            foreach (TR2Entity entity in Entities) { writer.Write(entity.Serialize()); }
-            writer.Write(LightMap);
-            writer.Write(NumCinematicFrames);
-            foreach (TRCinematicFrame cineframe in CinematicFrames) { writer.Write(cineframe.Serialize()); }
-            writer.Write(NumDemoData);
-            writer.Write(DemoData);
-            foreach (short sound in SoundMap) { writer.Write(sound); }
-            writer.Write(NumSoundDetails);
-            foreach (TRSoundDetails snddetail in SoundDetails) { writer.Write(snddetail.Serialize()); }
-            writer.Write(NumSampleIndices);
-            foreach (uint index in SampleIndices) { writer.Write(index); }
-        }
-
-        return stream.ToArray();
-    }
 }

--- a/TRLevelControl/Model/TR3/TR3Level.cs
+++ b/TRLevelControl/Model/TR3/TR3Level.cs
@@ -1,9 +1,6 @@
-﻿using TRLevelControl.Helpers;
-using TRLevelControl.Serialization;
+﻿namespace TRLevelControl.Model;
 
-namespace TRLevelControl.Model;
-
-public class TR3Level : TRLevelBase, ISerializableCompact
+public class TR3Level : TRLevelBase
 {
     /// <summary>
     /// 256 entries * 3 components = 768 Bytes
@@ -304,80 +301,4 @@ public class TR3Level : TRLevelBase, ISerializableCompact
     /// NumSampleIndices * 4 bytes
     /// </summary>
     public uint[] SampleIndices { get; set; }
-
-    public TR3Level()
-    {
-
-    }
-
-    public byte[] Serialize()
-    {
-        using MemoryStream stream = new();
-        using (BinaryWriter writer = new(stream))
-        {
-            writer.Write((uint)Version.File);
-            foreach (TRColour col in Palette) { writer.Write(col.Serialize()); }
-            foreach (TRColour4 col in Palette16) { writer.Write(col.Serialize()); }
-            writer.Write(NumImages);
-            foreach (TRTexImage8 tex in Images8) { writer.Write(tex.Serialize()); }
-            foreach (TRTexImage16 tex in Images16) { writer.Write(tex.Serialize()); }
-            writer.Write(Unused);
-            writer.Write(NumRooms);
-            foreach (TR3Room room in Rooms) { writer.Write(room.Serialize()); }
-            writer.Write(NumFloorData);
-            foreach (ushort data in FloorData) { writer.Write(data); }
-            writer.Write(NumMeshData);
-            foreach (TRMesh mesh in Meshes) { writer.Write(mesh.Serialize()); }
-            writer.Write(NumMeshPointers);
-            foreach (uint ptr in MeshPointers) { writer.Write(ptr); }
-            writer.Write(NumAnimations);
-            foreach (TRAnimation anim in Animations) { writer.Write(anim.Serialize()); }
-            writer.Write(NumStateChanges);
-            foreach (TRStateChange statec in StateChanges) { writer.Write(statec.Serialize()); }
-            writer.Write(NumAnimDispatches);
-            foreach (TRAnimDispatch dispatch in AnimDispatches) { writer.Write(dispatch.Serialize()); }
-            writer.Write(NumAnimCommands);
-            foreach (TRAnimCommand cmd in AnimCommands) { writer.Write(cmd.Serialize()); }
-            writer.Write(NumMeshTrees * 4); //To get the correct number /= 4 is done during read, make sure to reverse it here.
-            foreach (TRMeshTreeNode node in MeshTrees) { writer.Write(node.Serialize()); }
-            writer.Write(NumFrames);
-            foreach (ushort frame in Frames) { writer.Write(frame); }
-            writer.Write(NumModels);
-            foreach (TRModel model in Models) { writer.Write(model.Serialize()); }
-            writer.Write(NumStaticMeshes);
-            foreach (TRStaticMesh mesh in StaticMeshes) { writer.Write(mesh.Serialize()); }
-            writer.Write(NumSpriteTextures);
-            foreach (TRSpriteTexture tex in SpriteTextures) { writer.Write(tex.Serialize()); }
-            writer.Write(NumSpriteSequences);
-            foreach (TRSpriteSequence sequence in SpriteSequences) { writer.Write(sequence.Serialize()); }
-            writer.Write(NumCameras);
-            foreach (TRCamera cam in Cameras) { writer.Write(cam.Serialize()); }
-            writer.Write(NumSoundSources);
-            foreach (TRSoundSource src in SoundSources) { writer.Write(src.Serialize()); }
-            writer.Write(NumBoxes);
-            foreach (TR2Box box in Boxes) { writer.Write(box.Serialize()); }
-            writer.Write(NumOverlaps);
-            foreach (ushort overlap in Overlaps) { writer.Write(overlap); }
-            foreach (ushort zone in TR2BoxUtilities.FlattenZones(Zones)) { writer.Write(zone); }
-            writer.Write(NumAnimatedTextures);
-            writer.Write((ushort)AnimatedTextures.Length);
-            foreach (TRAnimatedTexture texture in AnimatedTextures) { writer.Write(texture.Serialize()); }
-            writer.Write(NumObjectTextures);
-            foreach (TRObjectTexture tex in ObjectTextures) { writer.Write(tex.Serialize()); }
-            writer.Write(NumEntities);
-            foreach (TR2Entity entity in Entities) { writer.Write(entity.Serialize()); }
-            writer.Write(LightMap);
-            writer.Write(NumCinematicFrames);
-            foreach (TRCinematicFrame cineframe in CinematicFrames) { writer.Write(cineframe.Serialize()); }
-            writer.Write(NumDemoData);
-            writer.Write(DemoData);
-            foreach (short sound in SoundMap) { writer.Write(sound); }
-            writer.Write(NumSoundDetails);
-            foreach (TR3SoundDetails snddetail in SoundDetails) { writer.Write(snddetail.Serialize()); }
-            writer.Write(NumSampleIndices);
-            foreach (uint index in SampleIndices) { writer.Write(index); }
-        }
-
-        return stream.ToArray();
-    }
 }

--- a/TRLevelControl/Model/TR4/TR4Level.cs
+++ b/TRLevelControl/Model/TR4/TR4Level.cs
@@ -1,8 +1,6 @@
-﻿using TRLevelControl.Serialization;
+﻿namespace TRLevelControl.Model;
 
-namespace TRLevelControl.Model;
-
-public class TR4Level : TRLevelBase, ISerializableCompact
+public class TR4Level : TRLevelBase
 {
     public ushort NumRoomTextiles { get; set; }
 
@@ -21,49 +19,4 @@ public class TR4Level : TRLevelBase, ISerializableCompact
     public uint NumSamples { get; set; }
 
     public TR4Sample[] Samples { get; set; }
-
-    public byte[] Serialize()
-    {
-        using MemoryStream stream = new();
-        using (BinaryWriter writer = new(stream))
-        {
-            writer.Write((uint)Version.File);
-            writer.Write(NumRoomTextiles);
-            writer.Write(NumObjTextiles);
-            writer.Write(NumBumpTextiles);
-
-            byte[] chunk = Texture32Chunk.Serialize();
-            writer.Write(Texture32Chunk.UncompressedSize);
-            writer.Write(Texture32Chunk.CompressedSize);
-            writer.Write(chunk);
-
-            chunk = Texture16Chunk.Serialize();
-            writer.Write(Texture16Chunk.UncompressedSize);
-            writer.Write(Texture16Chunk.CompressedSize);
-            writer.Write(chunk);
-
-            chunk = SkyAndFont32Chunk.Serialize();
-            writer.Write(SkyAndFont32Chunk.UncompressedSize);
-            writer.Write(SkyAndFont32Chunk.CompressedSize);
-            writer.Write(chunk);
-
-            chunk = LevelDataChunk.Serialize();
-            writer.Write(LevelDataChunk.UncompressedSize);
-            writer.Write(LevelDataChunk.CompressedSize);
-            writer.Write(chunk);
-
-            writer.Write(NumSamples);
-
-            //CHEAT ALERT - compressed chunk is a WAV file, so we dont bother with any compression/decompression and just
-            //write the compressed samples (WAVs) back. We will need to do this properly when modifying or adding to these samples.
-            foreach (TR4Sample sample in Samples)
-            {
-                writer.Write(sample.UncompSize);
-                writer.Write(sample.CompSize);
-                writer.Write(sample.CompressedChunk);
-            }
-        }
-
-        return stream.ToArray();
-    }
 }

--- a/TRLevelControl/Model/TR5/TR5Level.cs
+++ b/TRLevelControl/Model/TR5/TR5Level.cs
@@ -1,8 +1,6 @@
-﻿using TRLevelControl.Serialization;
+﻿namespace TRLevelControl.Model;
 
-namespace TRLevelControl.Model;
-
-public class TR5Level : TRLevelBase, ISerializableCompact
+public class TR5Level : TRLevelBase
 {
     public ushort NumRoomTextiles { get; set; }
 
@@ -27,54 +25,4 @@ public class TR5Level : TRLevelBase, ISerializableCompact
     public uint NumSamples { get; set; }
 
     public TR4Sample[] Samples { get; set; }
-
-    public byte[] Serialize()
-    {
-        using MemoryStream stream = new();
-        using (BinaryWriter writer = new(stream))
-        {
-            writer.Write((uint)Version.File);
-            writer.Write(NumRoomTextiles);
-            writer.Write(NumObjTextiles);
-            writer.Write(NumBumpTextiles);
-
-            byte[] chunk = Texture32Chunk.Serialize();
-            writer.Write(Texture32Chunk.UncompressedSize);
-            writer.Write(Texture32Chunk.CompressedSize);
-            writer.Write(chunk);
-
-            chunk = Texture16Chunk.Serialize();
-            writer.Write(Texture16Chunk.UncompressedSize);
-            writer.Write(Texture16Chunk.CompressedSize);
-            writer.Write(chunk);
-
-            chunk = SkyAndFont32Chunk.Serialize();
-            writer.Write(SkyAndFont32Chunk.UncompressedSize);
-            writer.Write(SkyAndFont32Chunk.CompressedSize);
-            writer.Write(chunk);
-
-            writer.Write(LaraType);
-            writer.Write(WeatherType);
-            writer.Write(Padding);
-
-            //Note - a TR5 Level data chunk is not compressed.
-            chunk = LevelDataChunk.Serialize();
-            writer.Write(LevelDataChunk.UncompressedSize);
-            writer.Write(LevelDataChunk.CompressedSize);
-            writer.Write(chunk);
-
-            writer.Write(NumSamples);
-
-            //CHEAT ALERT - compressed chunk is a WAV file, so we dont bother with any compression/decompression and just
-            //write the compressed samples (WAVs) back. We will need to do this properly when modifying or adding to these samples.
-            foreach (TR4Sample sample in Samples)
-            {
-                writer.Write(sample.UncompSize);
-                writer.Write(sample.CompSize);
-                writer.Write(sample.CompressedChunk);
-            }
-        }
-
-        return stream.ToArray();
-    }
 }

--- a/TRLevelControl/TRLevelControlBase.cs
+++ b/TRLevelControl/TRLevelControlBase.cs
@@ -29,6 +29,8 @@ public abstract class TRLevelControlBase<L>
     {
         using TRLevelWriter writer = new(outputStream);
 
+        writer.Write((uint)level.Version.File);
+
         _level = level;
         Write(writer);
     }

--- a/TRLevelControl/TRLevelControlBase.cs
+++ b/TRLevelControl/TRLevelControlBase.cs
@@ -13,7 +13,7 @@ public abstract class TRLevelControlBase<L>
 
     public L Read(Stream stream)
     {
-        using BinaryReader reader = new(stream);
+        using TRLevelReader reader = new(stream);
 
         _level = CreateLevel((TRFileVersion)reader.ReadUInt32());
         Read(reader);
@@ -27,15 +27,15 @@ public abstract class TRLevelControlBase<L>
 
     public void Write(L level, Stream outputStream)
     {
-        using BinaryWriter writer = new(outputStream);
+        using TRLevelWriter writer = new(outputStream);
 
         _level = level;
         Write(writer);
     }
 
     protected abstract L CreateLevel(TRFileVersion version);
-    protected abstract void Read(BinaryReader reader);
-    protected abstract void Write(BinaryWriter writer);
+    protected abstract void Read(TRLevelReader reader);
+    protected abstract void Write(TRLevelWriter writer);
 
     protected void TestVersion(L level, params TRFileVersion[] acceptedVersions)
     {

--- a/TRLevelControlTests/TR1/IOTests.cs
+++ b/TRLevelControlTests/TR1/IOTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TRFDControl;
+using TRLevelControl;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRLevelControl.Model.Base.Enums;
@@ -115,11 +116,17 @@ public class IOTests : TestBase
     {
         TR1Level lvl = GetTR1Level(TR1LevelNames.CAVES);
 
-        byte[] lvlBeforeSort = lvl.Serialize();
+        TR1LevelControl control = new();
+        using MemoryStream ms1 = new();
+        using MemoryStream ms2 = new();
+
+        control.Write(lvl, ms1);
+        byte[] lvlBeforeSort = ms1.ToArray();
 
         SoundUtilities.ResortSoundIndices(lvl);
 
-        byte[] lvlAfterSort = lvl.Serialize();
+        control.Write(lvl, ms2);
+        byte[] lvlAfterSort = ms2.ToArray();
 
         CollectionAssert.AreEqual(lvlBeforeSort, lvlAfterSort);
     }

--- a/TRLevelControlTests/TR2/IOTests.cs
+++ b/TRLevelControlTests/TR2/IOTests.cs
@@ -3,6 +3,7 @@ using System.Drawing;
 using TRFDControl;
 using TRFDControl.FDEntryTypes;
 using TRFDControl.Utilities;
+using TRLevelControl;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRLevelControl.Model.Base.Enums;
@@ -975,8 +976,13 @@ public class IOTests : TestBase
     {
         TR2Level lvl = GetTR2Level(TR2LevelNames.MONASTERY);
 
+        TR2LevelControl control = new();
+        using MemoryStream ms1 = new();
+        using MemoryStream ms2 = new();
+
         // Store the untouched raw data
-        byte[] lvlAsBytes = lvl.Serialize();
+        control.Write(lvl, ms1);
+        byte[] lvlAsBytes = ms1.ToArray();
 
         // Convert each tile to a bitmap, and then convert it back
         foreach (TRTexImage16 tile in lvl.Images16)
@@ -985,7 +991,10 @@ public class IOTests : TestBase
             tile.Pixels = TextureUtilities.ImportFromBitmap(bmp);
         }
 
+        control.Write(lvl, ms2);
+        byte[] lvlAfterWrite = ms2.ToArray();
+
         // Confirm the raw data still matches
-        CollectionAssert.AreEqual(lvlAsBytes, lvl.Serialize(), "Read does not match byte for byte");
+        CollectionAssert.AreEqual(lvlAsBytes, lvlAfterWrite, "Read does not match byte for byte");
     }
 }


### PR DESCRIPTION
The main level writing is now handled in each control class. I have also introduced `TRLevelReader` and `TRLevelWriter`, which will be later expanded on to include common logic across all levels and to replace the various utility classes; this will be done gradually per property or group of properties in conjunction with #468.

e.g. in TR1-3 levels, `NumImages` will be removed and `Images8`/`Images16` will become lists. The control classes will use `_level.Images8 = reader.ReadImage8s(numImages)` and `writer.Write(_level.Images8)` and the reader/writer here will handle the specifics.

Part of #507.