### PR TITLE
Fix Aldwych pillar manipulation

### DIFF
--- a/TREnvironmentEditor/Model/Types/Surfaces/EMClickFunction.cs
+++ b/TREnvironmentEditor/Model/Types/Surfaces/EMClickFunction.cs
@@ -14,6 +14,7 @@ public class EMClickFunction : BaseEMFunction
     public EMLocationExpander LocationExpander { get; set; }
     public sbyte? FloorClicks { get; set; }
     public sbyte? CeilingClicks { get; set; }
+    public bool RetainItemPositions { get; set; }
 
     protected List<EMLocation> _locations;
 
@@ -31,7 +32,7 @@ public class EMClickFunction : BaseEMFunction
             MoveSector(sector, level.Rooms[location.Room].Info);
 
             // Move any entities that share the same floor sector up or down the relevant number of clicks
-            if (FloorClicks.HasValue)
+            if (FloorClicks.HasValue && !RetainItemPositions)
             {
                 foreach (TREntity entity in level.Entities)
                 {
@@ -62,7 +63,7 @@ public class EMClickFunction : BaseEMFunction
             MoveSector(sector, level.Rooms[location.Room].Info);
 
             // Move any entities that share the same floor sector up or down the relevant number of clicks
-            if (FloorClicks.HasValue)
+            if (FloorClicks.HasValue && !RetainItemPositions)
             {
                 foreach (TR2Entity entity in level.Entities)
                 {
@@ -93,7 +94,7 @@ public class EMClickFunction : BaseEMFunction
             MoveSector(sector, level.Rooms[location.Room].Info);
 
             // Move any entities that share the same floor sector up or down the relevant number of clicks
-            if (FloorClicks.HasValue)
+            if (FloorClicks.HasValue && !RetainItemPositions)
             {
                 foreach (TR2Entity entity in level.Entities)
                 {

--- a/TRRandomizerCore/Resources/TR3/Environment/SEWER.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR3/Environment/SEWER.TR2-Environment.json
@@ -40,7 +40,8 @@
             "Z": 19968,
             "Room": 1
           },
-          "FloorClicks": 2
+          "FloorClicks": 2,
+          "RetainItemPositions": true
         }
       ]
     },
@@ -58,7 +59,8 @@
             "Z": 25088,
             "Room": 1
           },
-          "FloorClicks": 2
+          "FloorClicks": 2,
+          "RetainItemPositions": true
         }
       ]
     },
@@ -76,7 +78,8 @@
             "Z": 19968,
             "Room": 1
           },
-          "FloorClicks": 2
+          "FloorClicks": 2,
+          "RetainItemPositions": true
         }
       ]
     },
@@ -94,7 +97,8 @@
             "Z": 19968,
             "Room": 1
           },
-          "FloorClicks": 2
+          "FloorClicks": 2,
+          "RetainItemPositions": true
         }
       ]
     },


### PR DESCRIPTION
The (untriggered) animating items that are usually here are repurposed for pickup items as the level is short on entity space. The pillars here are not normal walls, instead the ceilings and floors touch, so environment mods lower the floors so the geometry matches the texturing and so to allow Lara to enter the crawlspaces. The problem was that this click function also moves any items on the floor accordingly because item/secret rando takes place first. The fix is to allow overriding this part of the function.

![image](https://github.com/LostArtefacts/TR-Rando/assets/33758420/b4661870-edf5-4943-a386-6e0051aaffa1)

Checked all other uses of this function and this is the only case affected by this.

Resolves #528.