### PR TITLE
Fix Crash Site piranhas

### DIFF
--- a/TRRandomizerCore/Levels/TR3CombinedLevel.cs
+++ b/TRRandomizerCore/Levels/TR3CombinedLevel.cs
@@ -74,6 +74,11 @@ public class TR3CombinedLevel
     public bool IsCoastalSequence => Sequence == 5;
 
     /// <summary>
+    /// Whether or not this level is in the sequence of original Crash Site.
+    /// </summary>
+    public bool IsCrashSequence => Sequence == 6;
+
+    /// <summary>
     /// Whether or not this level is in the sequence of original Madubu Gorge.
     /// </summary>
     public bool IsMadubuSequence => Sequence == 7;

--- a/TRRandomizerCore/Processors/TR3/TR3SequenceProcessor.cs
+++ b/TRRandomizerCore/Processors/TR3/TR3SequenceProcessor.cs
@@ -129,6 +129,11 @@ public class TR3SequenceProcessor : TR3LevelProcessor
             // underground as there is no way to pass otherwise.
             AmendSouthPacificSpikes(level);
         }
+        else if (level.Is(TR3LevelNames.CRASH) && !level.IsCrashSequence)
+        {
+            // Piranhas don't attack the raptor when it falls into the pool, so Lara can't (easily) pull the lever.
+            AmendCrashSitePiranhas(level);
+        }
 
         if (Settings.RandomizeSequencing)
         {
@@ -350,6 +355,18 @@ public class TR3SequenceProcessor : TR3LevelProcessor
             {
                 entity.Invisible = false;
             }
+        }
+    }
+
+    private static void AmendCrashSitePiranhas(TR3CombinedLevel level)
+    {
+        TR2Entity piranhas = Array.Find(
+            level.Data.Entities, e => e.TypeID == (short)TR3Entities.Piranhas_N && e.Room == 61);
+        if (piranhas != null)
+        {
+            // Move them behind the gate, which is an unreachable room
+            piranhas.X = 59904;
+            piranhas.Room = 65;
         }
     }
 }


### PR DESCRIPTION
Piranha behaviour is tied to the level sequence, so if Crash Site is off-sequence, we move them behind the gate in this area to allow pulling the lever. Lara can still take damage if she gets too close, so they still remain a bit of a hazard.

![image](https://github.com/LostArtefacts/TR-Rando/assets/33758420/305453c4-cc5c-48ad-a3a6-55e07ee607f5)

Resolves #530.