### PR TITLE
Exclude crystals from reward randomization

### DIFF
--- a/TRRandomizerCore/Randomizers/TR3/TR3SecretRewardRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/TR3SecretRewardRandomizer.cs
@@ -44,6 +44,11 @@ public class TR3SecretRewardRandomizer : BaseTR3Randomizer
 
         foreach (int rewardIndex in secretMapping.RewardEntities)
         {
+            if (level.Data.Entities[rewardIndex].TypeID == (short)TR3Entities.SaveCrystal_P)
+            {
+                continue;
+            }
+
             level.Data.Entities[rewardIndex].TypeID = (short)stdItemTypes[_generator.Next(0, stdItemTypes.Count)];
         }
     }


### PR DESCRIPTION
There are only 4 crystals out of 120 reward items in the game, so we just exclude them from being randomized to avoid the floating issue. It also allows anyone playing with PSX crystal mode in tomb3 to know to expect the same number of crystals in each level, as these are excluded by default in normal item randomization.
Resolves #541.