### PR TITLE
Add cloned enemy mode

### DIFF
--- a/TREnvironmentEditor/EMEditorMapping.cs
+++ b/TREnvironmentEditor/EMEditorMapping.cs
@@ -75,4 +75,17 @@ public class EMEditorMapping
         ConditionalOneOf?.ForEach(s => s.RemapTextures(AlternativeTextures));
         Mirrored?.RemapTextures(AlternativeTextures);
     }
+
+    public void SetCommunityPatch(bool isCommunityPatch)
+    {
+        All?.SetCommunityPatch(isCommunityPatch);
+        ConditionalAll?.ForEach(s => s.SetCommunityPatch(isCommunityPatch));
+        NonPurist?.SetCommunityPatch(isCommunityPatch);
+        Any?.ForEach(s => s.SetCommunityPatch(isCommunityPatch));
+        AllWithin?.ForEach(a => a.ForEach(s => s.SetCommunityPatch(isCommunityPatch)));
+        ConditionalAllWithin?.ForEach(s => s.SetCommunityPatch(isCommunityPatch));
+        OneOf?.ForEach(s => s.SetCommunityPatch(isCommunityPatch));
+        ConditionalOneOf?.ForEach(s => s.SetCommunityPatch(isCommunityPatch));
+        Mirrored?.SetCommunityPatch(isCommunityPatch);
+    }
 }

--- a/TREnvironmentEditor/Model/BaseEMFunction.cs
+++ b/TREnvironmentEditor/Model/BaseEMFunction.cs
@@ -19,9 +19,14 @@ public abstract class BaseEMFunction
     public BaseEMFunction HardVariant { get; set; }
     public List<EMTag> Tags { get; set; }
 
+    protected bool _isCommunityPatch;
+
     public abstract void ApplyToLevel(TR1Level level);
     public abstract void ApplyToLevel(TR2Level level);
     public abstract void ApplyToLevel(TR3Level level);
+
+    public void SetCommunityPatch(bool isCommunityPatch)
+        => _isCommunityPatch = isCommunityPatch;
 
     /// <summary>
     /// Gets the expected vertices for a flat tile.

--- a/TREnvironmentEditor/Model/EMConditionalEditorSet.cs
+++ b/TREnvironmentEditor/Model/EMConditionalEditorSet.cs
@@ -28,4 +28,10 @@ public class EMConditionalEditorSet
         OnTrue?.ForEach(s => s.RemapTextures(indexMap));
         OnFalse?.ForEach(s => s.RemapTextures(indexMap));
     }
+
+    public void SetCommunityPatch(bool isCommunityPatch)
+    {
+        OnTrue?.ForEach(s => s.SetCommunityPatch(isCommunityPatch));
+        OnFalse?.ForEach(s => s.SetCommunityPatch(isCommunityPatch));
+    }
 }

--- a/TREnvironmentEditor/Model/EMConditionalGroupedSet.cs
+++ b/TREnvironmentEditor/Model/EMConditionalGroupedSet.cs
@@ -28,4 +28,10 @@ public class EMConditionalGroupedSet : ITextureModifier
         OnTrue?.RemapTextures(indexMap);
         OnFalse?.RemapTextures(indexMap);
     }
+
+    public void SetCommunityPatch(bool isCommunityPatch)
+    {
+        OnTrue?.SetCommunityPatch(isCommunityPatch);
+        OnFalse?.SetCommunityPatch(isCommunityPatch);
+    }
 }

--- a/TREnvironmentEditor/Model/EMConditionalSingleEditorSet.cs
+++ b/TREnvironmentEditor/Model/EMConditionalSingleEditorSet.cs
@@ -32,4 +32,10 @@ public class EMConditionalSingleEditorSet : ITextureModifier
         OnTrue?.RemapTextures(indexMap);
         OnFalse?.RemapTextures(indexMap);
     }
+
+    public void SetCommunityPatch(bool isCommunityPatch)
+    {
+        OnTrue?.SetCommunityPatch(isCommunityPatch);
+        OnFalse?.SetCommunityPatch(isCommunityPatch);
+    }
 }

--- a/TREnvironmentEditor/Model/EMEditorGroupedSet.cs
+++ b/TREnvironmentEditor/Model/EMEditorGroupedSet.cs
@@ -40,4 +40,10 @@ public class EMEditorGroupedSet : ITextureModifier
         Leader.RemapTextures(indexMap);
         Followers.ForEach(s => s.RemapTextures(indexMap));
     }
+
+    public void SetCommunityPatch(bool isCommunityPatch)
+    {
+        Leader.SetCommunityPatch(isCommunityPatch);
+        Followers.ForEach(s => s.SetCommunityPatch(isCommunityPatch));
+    }
 }

--- a/TREnvironmentEditor/Model/EMEditorSet.cs
+++ b/TREnvironmentEditor/Model/EMEditorSet.cs
@@ -81,6 +81,11 @@ public class EMEditorSet : List<BaseEMFunction>, ITextureModifier
         }
     }
 
+    public void SetCommunityPatch(bool isCommunityPatch)
+    {
+        ForEach(m => m.SetCommunityPatch(isCommunityPatch));
+    }
+
     private static BaseEMFunction GetModToExecute(BaseEMFunction mod, EMOptions options)
     {
         if (options != null)

--- a/TREnvironmentEditor/Model/Types/Entities/EMAddEntityFunction.cs
+++ b/TREnvironmentEditor/Model/Types/Entities/EMAddEntityFunction.cs
@@ -18,7 +18,8 @@ public class EMAddEntityFunction : BaseEMFunction
 
     public override void ApplyToLevel(TR1Level level)
     {
-        if (level.NumEntities < _defaultEntityLimit)
+        int limit = _isCommunityPatch ? 10240 : _defaultEntityLimit;
+        if (level.NumEntities < limit)
         {
             EMLevelData data = GetData(level);
             if (TargetRelocation != null)
@@ -78,7 +79,8 @@ public class EMAddEntityFunction : BaseEMFunction
 
     public override void ApplyToLevel(TR3Level level)
     {
-        if (level.NumEntities < _defaultEntityLimit)
+        int limit = _isCommunityPatch ? 1024 : _defaultEntityLimit;
+        if (level.NumEntities < limit)
         {
             EMLevelData data = GetData(level);
             if (TargetRelocation != null)

--- a/TRLevelControl/Model/Base/TREntity.cs
+++ b/TRLevelControl/Model/Base/TREntity.cs
@@ -1,8 +1,9 @@
-﻿using TRLevelControl.Serialization;
+﻿using System;
+using TRLevelControl.Serialization;
 
 namespace TRLevelControl.Model;
 
-public class TREntity : ISerializableCompact
+public class TREntity : ISerializableCompact, ICloneable
 {
     public short TypeID { get; set; }
     
@@ -79,4 +80,22 @@ public class TREntity : ISerializableCompact
 
         return stream.ToArray();
     }
+
+    public TREntity Clone()
+    {
+        return new()
+        {
+            TypeID = TypeID,
+            Room = Room,
+            X = X,
+            Y = Y,
+            Z = Z,
+            Angle = Angle,
+            Intensity = Intensity,
+            Flags = Flags,
+        };
+    }
+
+    object ICloneable.Clone()
+        => Clone();
 }

--- a/TRRandomizerCore/Editors/RandomizerSettings.cs
+++ b/TRRandomizerCore/Editors/RandomizerSettings.cs
@@ -74,6 +74,10 @@ public class RandomizerSettings
     public bool HideEnemiesUntilTriggered { get; set; }
     public bool ReplaceRequiredEnemies { get; set; }
     public bool GiveUnarmedItems { get; set; }
+    public bool UseEnemyClones { get; set; }
+    public uint EnemyMultiplier { get; set; }
+    public bool CloneOriginalEnemies { get; set; }
+    public bool UseKillableClonePierres { get; set; }
     public bool GlitchedSecrets { get; set; }
     public bool GuaranteeSecrets { get; set; }
     public bool UseRewardRoomCameras { get; set; }
@@ -216,6 +220,10 @@ public class RandomizerSettings
             .ToList();
 
         GiveUnarmedItems = config.GetBool(nameof(GiveUnarmedItems), true);
+        UseEnemyClones = config.GetBool(nameof(UseEnemyClones));
+        EnemyMultiplier = config.GetUInt(nameof(EnemyMultiplier), 2);
+        CloneOriginalEnemies = config.GetBool(nameof(CloneOriginalEnemies));
+        UseKillableClonePierres = config.GetBool(nameof(UseKillableClonePierres), true);
 
         RandomizeTextures = config.GetBool(nameof(RandomizeTextures));
         TextureSeed = config.GetInt(nameof(TextureSeed), defaultSeed);
@@ -365,6 +373,10 @@ public class RandomizerSettings
         config[nameof(HideEnemiesUntilTriggered)] = HideEnemiesUntilTriggered;
         config[nameof(ReplaceRequiredEnemies)] = ReplaceRequiredEnemies;
         config[nameof(GiveUnarmedItems)] = GiveUnarmedItems;
+        config[nameof(UseEnemyClones)] = UseEnemyClones;
+        config[nameof(EnemyMultiplier)] = EnemyMultiplier;
+        config[nameof(CloneOriginalEnemies)] = CloneOriginalEnemies;
+        config[nameof(UseKillableClonePierres)] = UseKillableClonePierres;
 
         config[nameof(RandomizeTextures)] = RandomizeTextures;
         config[nameof(TextureSeed)] = TextureSeed;

--- a/TRRandomizerCore/Randomizers/TR1/TR1EnvironmentRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/TR1EnvironmentRandomizer.cs
@@ -93,6 +93,7 @@ public class TR1EnvironmentRandomizer : BaseTR1Randomizer, IMirrorControl
         EMEditorMapping mapping = EMEditorMapping.Get(GetResourcePath(@"TR1\Environment\" + level.Name + "-Environment.json"));
         if (mapping != null)
         {
+            mapping.SetCommunityPatch(ScriptEditor.Edition.IsCommunityPatch);
             ApplyMappingToLevel(level, mapping);
         }
 

--- a/TRRandomizerCore/Randomizers/TR2/TR2EnvironmentRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR2/TR2EnvironmentRandomizer.cs
@@ -90,6 +90,7 @@ public class TR2EnvironmentRandomizer : BaseTR2Randomizer, IMirrorControl
         EMEditorMapping mapping = EMEditorMapping.Get(GetResourcePath(@"TR2\Environment\" + level.Name + "-Environment.json"));
         if (mapping != null)
         {
+            mapping.SetCommunityPatch(ScriptEditor.Edition.IsCommunityPatch);
             if (level.IsUKBox)
             {
                 // The mapping is configured for EPC and Multipatch texture indices, but should

--- a/TRRandomizerCore/Randomizers/TR3/TR3EnvironmentRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/TR3EnvironmentRandomizer.cs
@@ -101,6 +101,7 @@ public class TR3EnvironmentRandomizer : BaseTR3Randomizer, IMirrorControl
         EMEditorMapping mapping = EMEditorMapping.Get(GetResourcePath(json));
         if (mapping != null)
         {
+            mapping.SetCommunityPatch(ScriptEditor.Edition.IsCommunityPatch);
             ApplyMappingToLevel(level, mapping);
         }
 

--- a/TRRandomizerCore/Resources/TR1/Environment/LEVEL3B.PHD-Environment.json
+++ b/TRRandomizerCore/Resources/TR1/Environment/LEVEL3B.PHD-Environment.json
@@ -5881,10 +5881,9 @@
   "ConditionalAll": [
     {
       "Condition": {
-        "Comments": "If Larson has been converted into a (Great Pyramid) scion, add an alternative enemy and a level-end trigger.",
-        "ConditionType": 0,
-        "EntityIndex": 30,
-        "EntityType": 145
+        "Comments": "If Larson doesn't end the level, add a Great Pyramid scion to do so.",
+        "ConditionType": 41,
+        "ModelID": 145
       },
       "OnTrue": [
         {
@@ -5913,10 +5912,11 @@
           "IgnoreSectorEntities": true
         },
         {
-          "Comments": "Move the scion to the mesh location (it's here to avoid potential slope softlock).",
-          "EMType": 44,
-          "EntityIndex": 30,
-          "TargetLocation": {
+          "Comments": "Add the invisible scion.",
+          "EMType": 51,
+          "TypeID": 145,
+          "Intensity": -1,
+          "Location": {
             "X": 39424,
             "Y": 4864,
             "Z": 55808,
@@ -5925,32 +5925,7 @@
           }
         },
         {
-          "Comments": "Alternative normal enemy to fight.",
-          "EMType": 51,
-          "TypeID": 19,
-          "Intensity": -1,
-          "Location": {
-            "X": 40448,
-            "Y": 4864,
-            "Z": 56832,
-            "Room": 11,
-            "Angle": -32768
-          }
-        },
-        {
-          "Comments": "Convert the new enemy into one the level supports.",
-          "EMType": 47,
-          "EntityIndices": [
-            -1
-          ],
-          "NewEnemyType": 1,
-          "Exclusions": [
-            30,
-            33
-          ]
-        },
-        {
-          "Comments": "Trigger the new enemy.",
+          "Comments": "Trigger the scion.",
           "EMType": 68,
           "Location": {
             "X": 43520,

--- a/TRRandomizerCore/Resources/TR1/Environment/LEVEL5.PHD-Environment.json
+++ b/TRRandomizerCore/Resources/TR1/Environment/LEVEL5.PHD-Environment.json
@@ -2,39 +2,6 @@
   "All": [],
   "NonPurist": [
     {
-      "Comments": "Fix the bat triggers for room 71 - param 74 is duplicated so the third bat doesn't spawn.",
-      "EMType": 61,
-      "Locations": [
-        {
-          "X": 55808,
-          "Y": -4608,
-          "Z": 61952,
-          "Room": 70
-        },
-        {
-          "X": 53760,
-          "Y": -4608,
-          "Z": 64000,
-          "Room": 70
-        }
-      ],
-      "Trigger": {
-        "Mask": 31,
-        "Actions": [
-          {
-            "Parameter": 73
-          },
-          {
-            "Parameter": 74
-          },
-          {
-            "Parameter": 75
-          }
-        ]
-      },
-      "Replace": true
-    },
-    {
       "Comments": "Change the shortcut slope at the beginning.",
       "EMType": 7,
       "Location": {

--- a/TRRandomizerCore/Resources/TR1/Environment/LEVEL8C.PHD-Environment.json
+++ b/TRRandomizerCore/Resources/TR1/Environment/LEVEL8C.PHD-Environment.json
@@ -3,7 +3,7 @@
   "NonPurist": [
     {
       "Comments": "Ensure the enemies in room 15 are always triggered rather than only from the invisible platform.",
-      "EMType": 61,
+      "EMType": 63,
       "Locations": [
         {
           "X": 47616,
@@ -12,16 +12,49 @@
           "Room": 14
         }
       ],
-      "Trigger": {
-        "Mask": 31,
-        "Actions": [
-          {
-            "Parameter": 34
-          },
-          {
-            "Parameter": 35
-          }
-        ]
+      "BaseLocation": {
+        "X": 45568,
+        "Y": -8704,
+        "Z": 54784,
+        "Room": 3
+      }
+    },
+    {
+      "EMType": 69,
+      "Location": {
+        "X": 47616,
+        "Y": -5376,
+        "Z": 33280,
+        "Room": 14
+      },
+      "TrigType": 0
+    },
+    {
+      "EMType": 71,
+      "Locations": [
+        {
+          "X": 47616,
+          "Y": -5376,
+          "Z": 33280,
+          "Room": 14
+        }
+      ],
+      "ActionItem": {
+        "Parameter": 10
+      }
+    },
+    {
+      "EMType": 71,
+      "Locations": [
+        {
+          "X": 47616,
+          "Y": -5376,
+          "Z": 33280,
+          "Room": 14
+        }
+      ],
+      "ActionItem": {
+        "Action": 10
       }
     },
     {

--- a/TRRandomizerCore/TRRandomizerController.cs
+++ b/TRRandomizerCore/TRRandomizerController.cs
@@ -1563,6 +1563,32 @@ public class TRRandomizerController
         set => LevelRandomizer.GiveUnarmedItems = value;
     }
 
+    public bool UseEnemyClones
+    {
+        get => LevelRandomizer.UseEnemyClones;
+        set => LevelRandomizer.UseEnemyClones = value;
+    }
+
+    public uint EnemyMultiplier
+    {
+        get => LevelRandomizer.EnemyMultiplier;
+        set => LevelRandomizer.EnemyMultiplier = value;
+    }
+
+    public static uint MaxEnemyMultiplier => TR1EnemyRandomizer.MaxClones;
+
+    public bool CloneOriginalEnemies
+    {
+        get => LevelRandomizer.CloneOriginalEnemies;
+        set => LevelRandomizer.CloneOriginalEnemies = value;
+    }
+
+    public bool UseKillableClonePierres
+    {
+        get => LevelRandomizer.UseKillableClonePierres;
+        set => LevelRandomizer.UseKillableClonePierres = value;
+    }
+
     public bool RandomizeOutfits
     {
         get => LevelRandomizer.RandomizeOutfits;

--- a/TRRandomizerCore/TRRandomizerType.cs
+++ b/TRRandomizerCore/TRRandomizerType.cs
@@ -56,5 +56,6 @@ public enum TRRandomizerType
     HardEnvironment,
     Traps,
     ChallengeRooms,
-    DynamicEnemyTextures
+    DynamicEnemyTextures,
+    ClonedEnemies,
 }

--- a/TRRandomizerCore/TRVersionSupport.cs
+++ b/TRRandomizerCore/TRVersionSupport.cs
@@ -43,6 +43,7 @@ internal class TRVersionSupport
         TRRandomizerType.AmbientTracks,
         TRRandomizerType.Ammoless,
         TRRandomizerType.Braid,
+        TRRandomizerType.ClonedEnemies,
         TRRandomizerType.DisableDemos,
         TRRandomizerType.Health,
         TRRandomizerType.LevelSequence,

--- a/TRRandomizerView/Controls/EditorControl.xaml
+++ b/TRRandomizerView/Controls/EditorControl.xaml
@@ -316,6 +316,7 @@
                                         HasDifficulty="True"
                                         HasDragonSpawn="{Binding Data.IsDragonSpawnTypeSupported, Source={StaticResource proxy}}"
                                         HasBirdMonsterBehaviour="{Binding Data.IsBirdMonsterBehaviourTypeSupported, Source={StaticResource proxy}}"
+                                        HasClonedEnemyMode="{Binding Data.IsClonedEnemiesTypeSupported, Source={StaticResource proxy}}"
                                         ControllerProxy="{Binding Data, Source={StaticResource proxy}}">
                 </windows:AdvancedWindow>
             </ctrl:ManagedSeedAdvancedControl.AdvancedWindowToOpen>

--- a/TRRandomizerView/Model/ControllerOptions.cs
+++ b/TRRandomizerView/Model/ControllerOptions.cs
@@ -72,6 +72,12 @@ public class ControllerOptions : INotifyPropertyChanged
     private string _secretPack;
     private string[] _availableSecretPacks;
 
+    private bool _useEnemyClones;
+    private uint _enemyMultiplier;
+    private uint _maxEnemyMultiplier;
+    private bool _cloneOriginalEnemies;
+    private bool _useKillableClonePierres;
+
     private List<BoolItemControlClass> _secretBoolItemControls, _itemBoolItemControls, _enemyBoolItemControls, _textureBoolItemControls, _audioBoolItemControls, _outfitBoolItemControls, _textBoolItemControls, _startBoolItemControls, _environmentBoolItemControls, _healthBoolItemControls, _weatherBoolItemControls;
     private List<BoolItemIDControlClass> _selectableEnemies;
     private bool _useEnemyExclusions, _showExclusionWarnings;
@@ -2439,6 +2445,56 @@ public class ControllerOptions : INotifyPropertyChanged
         }
     }
 
+    public bool UseEnemyClones
+    {
+        get => _useEnemyClones;
+        set
+        {
+            _useEnemyClones = value;
+            FirePropertyChanged();
+        }
+    }
+
+    public uint EnemyMultiplier
+    {
+        get => _enemyMultiplier;
+        set
+        {
+            _enemyMultiplier = value;
+            FirePropertyChanged();
+        }
+    }
+
+    public uint MaxEnemyMultiplier
+    {
+        get => _maxEnemyMultiplier;
+        private set
+        {
+            _maxEnemyMultiplier = value;
+            FirePropertyChanged();
+        }
+    }
+
+    public bool CloneOriginalEnemies
+    {
+        get => _cloneOriginalEnemies;
+        set
+        {
+            _cloneOriginalEnemies = value;
+            FirePropertyChanged();
+        }
+    }
+
+    public bool UseKillableClonePierres
+    {
+        get => _useKillableClonePierres;
+        set
+        {
+            _useKillableClonePierres = value;
+            FirePropertyChanged();
+        }
+    }
+
     public List<BoolItemControlClass> TextureBoolItemControls
     {
         get => _textureBoolItemControls;
@@ -3109,6 +3165,12 @@ public class ControllerOptions : INotifyPropertyChanged
         ShowExclusionWarnings = _controller.ShowExclusionWarnings;
         LoadEnemyExclusions();
 
+        UseEnemyClones = _controller.UseEnemyClones;
+        MaxEnemyMultiplier = TRRandomizerController.MaxEnemyMultiplier;
+        EnemyMultiplier = _controller.EnemyMultiplier;        
+        CloneOriginalEnemies = _controller.CloneOriginalEnemies;
+        UseKillableClonePierres = _controller.UseKillableClonePierres;
+
         RandomizeSecrets = _controller.RandomizeSecrets;
         SecretSeed = _controller.SecretSeed;
         IsHardSecrets.Value = _controller.HardSecrets;
@@ -3400,6 +3462,11 @@ public class ControllerOptions : INotifyPropertyChanged
         SelectableEnemyControls.FindAll(c => c.Value).ForEach(c => excludedEnemies.Add((short)c.ID));
         _controller.ExcludedEnemies = excludedEnemies;
 
+        _controller.UseEnemyClones = UseEnemyClones;
+        _controller.EnemyMultiplier = EnemyMultiplier;
+        _controller.CloneOriginalEnemies = CloneOriginalEnemies;
+        _controller.UseKillableClonePierres = UseKillableClonePierres;
+
         _controller.RandomizeSecrets = RandomizeSecrets;
         _controller.SecretSeed = SecretSeed;
         _controller.HardSecrets = IsHardSecrets.Value;
@@ -3606,6 +3673,7 @@ public class ControllerOptions : INotifyPropertyChanged
     public bool IsAtlanteanEggBehaviourTypeSupported => IsRandomizationSupported(TRRandomizerType.AtlanteanEggBehaviour);
     public bool IsHiddenEnemiesTypeSupported => IsRandomizationSupported(TRRandomizerType.HiddenEnemies);
     public bool IsLarsonBehaviourTypeSupported => IsRandomizationSupported(TRRandomizerType.LarsonBehaviour);
+    public bool IsClonedEnemiesTypeSupported => IsRandomizationSupported(TRRandomizerType.ClonedEnemies);
     public bool IsDisableDemosTypeSupported => IsRandomizationSupported(TRRandomizerType.DisableDemos);
     public bool IsItemSpriteTypeSupported => IsRandomizationSupported(TRRandomizerType.ItemSprite);
 

--- a/TRRandomizerView/Windows/AdvancedWindow.xaml
+++ b/TRRandomizerView/Windows/AdvancedWindow.xaml
@@ -89,6 +89,7 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
             <Grid.ColumnDefinitions>
@@ -1747,6 +1748,117 @@
                             Margin="0,5,0,0">
                         <Label Style="{StaticResource OptionDescriptionStyle}"
                                Content="The number of levels with cold water."/>
+                    </Border>
+                </Grid>
+            </StackPanel>
+            
+            <!-- Enemy Clones -->
+            <StackPanel
+                Grid.Row="22"
+                Visibility="{Binding HasClonedEnemyMode, Converter={StaticResource BoolToCollapsedConverter}}">
+                <TextBlock
+                    Style="{StaticResource HeaderStyle}"
+                    Text="Cloned Enemy Mode"/>
+
+                <Grid Margin="0,5,0,0">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" SharedSizeGroup="SSG1"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+
+                    <Border>
+                        <CheckBox
+                            IsChecked="{Binding ControllerProxy.UseEnemyClones, Mode=TwoWay}"
+                            VerticalAlignment="Center">
+                            <Label
+                                Padding="0"
+                                Content="Clone enemies" />
+                        </CheckBox>
+                    </Border>
+
+                    <Border Grid.Column="1">
+                        <Label
+                            Style="{StaticResource OptionDescriptionStyle}"
+                            Content="Enable enemy cloning mode. Clones will spawn in the same location as their originals."/>
+                    </Border>
+
+                    <Border
+                        Grid.Row="1"
+                        IsEnabled="{Binding ControllerProxy.UseEnemyClones, Mode=TwoWay}">
+                        <CheckBox
+                            IsChecked="{Binding ControllerProxy.CloneOriginalEnemies, Mode=TwoWay}"
+                            VerticalAlignment="Center">
+                            <Label
+                                Padding="0"
+                                Content="Use original enemies" />
+                        </CheckBox>
+                    </Border>
+
+                    <Border
+                        Grid.Column="1"
+                        Grid.Row="1"
+                        IsEnabled="{Binding ControllerProxy.UseEnemyClones, Mode=TwoWay}">
+                        <Label 
+                            Style="{StaticResource OptionDescriptionStyle}"
+                            Content="Override all other enemy options and revert to using the original enemies plus their clones only."/>
+                    </Border>
+
+                    <Border
+                        Grid.Row="2"
+                        IsEnabled="{Binding ControllerProxy.UseEnemyClones, Mode=TwoWay}">
+                        <CheckBox
+                            IsChecked="{Binding ControllerProxy.UseKillableClonePierres, Mode=TwoWay}"
+                            VerticalAlignment="Center">
+                            <Label
+                                Padding="0"
+                                Content="Make all Pierres killable" />
+                        </CheckBox>
+                    </Border>
+
+                    <Border
+                        Grid.Column="1"
+                        Grid.Row="2"
+                        IsEnabled="{Binding ControllerProxy.UseEnemyClones, Mode=TwoWay}">
+                        <Label 
+                            Style="{StaticResource OptionDescriptionStyle}"
+                            Content="Makes Pierre always killable, otherwise only one will ever spawn at a time."/>
+                    </Border>
+
+                    <Border
+                        Margin="0,3,0,0"
+                        Grid.Row="3"
+                        IsEnabled="{Binding ControllerProxy.UseEnemyClones, Mode=TwoWay}">
+                        <StackPanel
+                            Orientation="Horizontal" 
+                            HorizontalAlignment="Left">
+                            <Label
+                                Content="Multiplier"
+                                VerticalAlignment="Center"
+                                Padding="0,0,5,0"
+                                Margin="0"/>
+
+                            <ctrl:NumericUpDown 
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center"
+                                Value="{Binding ControllerProxy.EnemyMultiplier, Mode=TwoWay}"
+                                MinValue="2"
+                                MaxValue="{Binding ControllerProxy.MaxEnemyMultiplier}"/>
+                        </StackPanel>
+                    </Border>
+
+                    <Border
+                        Grid.Column="1"
+                        Grid.Row="3"
+                        IsEnabled="{Binding ControllerProxy.UseEnemyClones, Mode=TwoWay}">
+                        <Label
+                            Style="{StaticResource OptionDescriptionStyle}"
+                            Content="Set the total enemy count per instance e.g. 2 implies each enemy will be cloned once; 3 implies cloned twice etc."/>
                     </Border>
                 </Grid>
             </StackPanel>

--- a/TRRandomizerView/Windows/AdvancedWindow.xaml
+++ b/TRRandomizerView/Windows/AdvancedWindow.xaml
@@ -1790,7 +1790,7 @@
 
                     <Border
                         Grid.Row="1"
-                        IsEnabled="{Binding ControllerProxy.UseEnemyClones, Mode=TwoWay}">
+                        IsEnabled="{Binding ControllerProxy.UseEnemyClones}">
                         <CheckBox
                             IsChecked="{Binding ControllerProxy.CloneOriginalEnemies, Mode=TwoWay}"
                             VerticalAlignment="Center">
@@ -1803,15 +1803,15 @@
                     <Border
                         Grid.Column="1"
                         Grid.Row="1"
-                        IsEnabled="{Binding ControllerProxy.UseEnemyClones, Mode=TwoWay}">
+                        IsEnabled="{Binding ControllerProxy.UseEnemyClones}">
                         <Label 
                             Style="{StaticResource OptionDescriptionStyle}"
-                            Content="Override all other enemy options and revert to using the original enemies plus their clones only."/>
+                            Content="Override enemy type randomization and revert to using the original enemies plus their clones only."/>
                     </Border>
 
                     <Border
                         Grid.Row="2"
-                        IsEnabled="{Binding ControllerProxy.UseEnemyClones, Mode=TwoWay}">
+                        IsEnabled="{Binding ControllerProxy.UseEnemyClones}">
                         <CheckBox
                             IsChecked="{Binding ControllerProxy.UseKillableClonePierres, Mode=TwoWay}"
                             VerticalAlignment="Center">
@@ -1824,7 +1824,7 @@
                     <Border
                         Grid.Column="1"
                         Grid.Row="2"
-                        IsEnabled="{Binding ControllerProxy.UseEnemyClones, Mode=TwoWay}">
+                        IsEnabled="{Binding ControllerProxy.UseEnemyClones}">
                         <Label 
                             Style="{StaticResource OptionDescriptionStyle}"
                             Content="Makes Pierre always killable, otherwise only one will ever spawn at a time."/>
@@ -1833,7 +1833,7 @@
                     <Border
                         Margin="0,3,0,0"
                         Grid.Row="3"
-                        IsEnabled="{Binding ControllerProxy.UseEnemyClones, Mode=TwoWay}">
+                        IsEnabled="{Binding ControllerProxy.UseEnemyClones}">
                         <StackPanel
                             Orientation="Horizontal" 
                             HorizontalAlignment="Left">
@@ -1855,7 +1855,7 @@
                     <Border
                         Grid.Column="1"
                         Grid.Row="3"
-                        IsEnabled="{Binding ControllerProxy.UseEnemyClones, Mode=TwoWay}">
+                        IsEnabled="{Binding ControllerProxy.UseEnemyClones}">
                         <Label
                             Style="{StaticResource OptionDescriptionStyle}"
                             Content="Set the total enemy count per instance e.g. 2 implies each enemy will be cloned once; 3 implies cloned twice etc."/>

--- a/TRRandomizerView/Windows/AdvancedWindow.xaml.cs
+++ b/TRRandomizerView/Windows/AdvancedWindow.xaml.cs
@@ -114,6 +114,11 @@ public partial class AdvancedWindow : Window
         nameof(HasWeatherMode), typeof(bool), typeof(AdvancedWindow)
     );
 
+    public static readonly DependencyProperty HasClonedEnemyModeProperty = DependencyProperty.Register
+    (
+        nameof(HasClonedEnemyMode), typeof(bool), typeof(AdvancedWindow)
+    );
+
     public static readonly DependencyProperty ControllerProperty = DependencyProperty.Register
     (
         nameof(ControllerProxy), typeof(ControllerOptions), typeof(AdvancedWindow)
@@ -237,6 +242,12 @@ public partial class AdvancedWindow : Window
     {
         get => (bool)GetValue(HasWeatherModeProperty);
         set => SetValue(HasWeatherModeProperty, value);
+    }
+
+    public bool HasClonedEnemyMode
+    {
+        get => (bool)GetValue(HasClonedEnemyModeProperty);
+        set => SetValue(HasClonedEnemyModeProperty, value);
     }
 
     public ControllerOptions ControllerProxy


### PR DESCRIPTION
Adds support to play cloned enemy mode. This is limited to T1M only for now to avoid savegame buffer size issues in the later games. The option allows using randomized enemy types, or leaving the default types in their place, and then simply cloning each enemy the desired number of times. Each clone (aside from eggs) will be angled differently to allow for some variance in movement when they spawn.

This needed an update in the environment project to detect when T1M is in use, otherwise the function to add an entity would fail in cases where the level item count exceeds the default of 256. So for example, mods that a new door, switch or trap would not work properly. This should be useful in the future for other aspects we change that have limits, so it has been added for TR2 and 3 as well.

The JSON environment updates relate mainly to instances where we manipulate enemy triggers:
- In Qualopec, we now convert Larson to a raptor before randomization takes place, so that he can be cloned. The mods add a hidden scion to end the level instead of adding the extra enemy.
- In Colosseum, we fix bat 73's trigger during enemy randomization so that it too can be included in cloning.
- In Sanctuary, we previously added an extra trigger for enemies 34 and 35 (#463) in case players did not visit the secret platform; the issue there was that if the enemies are eggs, it's impossible to reach the lever without glitches. Now we duplicate the secret platform trigger and convert it to the right type to make sure we capture the cloned enemies as well.

Resolves #536.