### PR TITLE
Fix secret/vehicle checks

### DIFF
--- a/TRRandomizerCore/Randomizers/TR2/TR2EnemyRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR2/TR2EnemyRandomizer.cs
@@ -730,74 +730,53 @@ public class TR2EnemyRandomizer : BaseTR2Randomizer
             TR2Entity mercDriver = level.Data.Entities.Find(e => e.TypeID == TR2Type.MercSnowmobDriver);
             if (mercDriver != null)
             {
-                short room, angle;
-                int x, y, z;
+                TR2Entity skidoo = new()
+                {
+                    TypeID = TR2Type.RedSnowmobile,
+                    Intensity1 = -1,
+                    Intensity2 = -1
+                };
+                level.Data.Entities.Add(skidoo);
 
-                // we will only spawn one skidoo, so only need one random location
                 Location randomLocation = VehicleUtilities.GetRandomLocation(level, TR2Type.RedSnowmobile, _generator);
                 if (randomLocation != null)
                 {
-                    room = (short)randomLocation.Room;
-                    x = randomLocation.X;
-                    y = randomLocation.Y;
-                    z = randomLocation.Z;
-                    angle = randomLocation.Angle;
+                    skidoo.Room = (short)randomLocation.Room;
+                    skidoo.X = randomLocation.X;
+                    skidoo.Y = randomLocation.Y;
+                    skidoo.Z = randomLocation.Z;
+                    skidoo.Angle = randomLocation.Angle;
                 }
                 else
                 {
-                    // if the level does not have skidoo locations for some reason, just spawn it on the MercSnowMobDriver
-                    room = mercDriver.Room;
-                    x = mercDriver.X;
-                    y = mercDriver.Y;
-                    z = mercDriver.Z;
-                    angle = mercDriver.Angle;
+                    skidoo.Room = mercDriver.Room;
+                    skidoo.X = mercDriver.X;
+                    skidoo.Y = mercDriver.Y;
+                    skidoo.Z = mercDriver.Z;
+                    skidoo.Angle = mercDriver.Angle;
                 }
-
-                level.Data.Entities.Add(new()
-                {
-                    TypeID = TR2Type.RedSnowmobile,
-                    Room = room,
-                    X = x,
-                    Y = y,
-                    Z = z,
-                    Angle = angle,
-                    Flags = 0,
-                    Intensity1 = -1,
-                    Intensity2 = -1
-                });
             }
         }
-        else //For Tibet level 
+        else
         {
-            TR2Entity Skidoo = level.Data.Entities.Find(e => e.TypeID == TR2Type.RedSnowmobile);
-
-            if (Skidoo != null)
+            TR2Entity skidoo = level.Data.Entities.Find(e => e.TypeID == TR2Type.RedSnowmobile);
+            if (skidoo != null)
             {
-                short room, angle;
-                int x, y, z;
-
-                // we will only spawn one skidoo, so only need one random location
                 Location randomLocation = VehicleUtilities.GetRandomLocation(level, TR2Type.RedSnowmobile, _generator);
                 if (randomLocation != null)
                 {
-                    room = (short)randomLocation.Room;
-                    x = randomLocation.X;
-                    y = randomLocation.Y;
-                    z = randomLocation.Z;
-                    angle = randomLocation.Angle;
-
-                    //Update Skidoo info
-                    Skidoo.Room = room;
-                    Skidoo.X = x;
-                    Skidoo.Y = y;
-                    Skidoo.Z = z;
-                    Skidoo.Angle = angle;
-                    Skidoo.Flags = 0;
-                    Skidoo.Intensity1 = -1;
-                    Skidoo.Intensity2 = -1;
-                }                    
+                    skidoo.Room = (short)randomLocation.Room;
+                    skidoo.X = randomLocation.X;
+                    skidoo.Y = randomLocation.Y;
+                    skidoo.Z = randomLocation.Z;
+                    skidoo.Angle = randomLocation.Angle;
+                }
+                else
+                {
+                    // A secret depends on this skidoo, so just rotate it for variety.
+                    skidoo.Angle = (short)(_generator.Next(0, 8) * (ushort.MaxValue + 1) / 8);
+                }
             }
-
         }
 
         // Check in case there are too many skidoo drivers

--- a/TRRandomizerCore/Resources/TR2/Locations/locations.json
+++ b/TRRandomizerCore/Resources/TR2/Locations/locations.json
@@ -700,6 +700,7 @@
       "Y": 638,
       "Z": 69120,
       "Room": 109,
+      "TargetType": 14,
       "VehicleRequired": true
     },
     {
@@ -1107,7 +1108,9 @@
       "Room": 152,
       "Difficulty": "Hard",
       "PackID": "apel",
-      "RequiresGlitch": true
+      "RequiresGlitch": true,
+      "TargetType": 14,
+      "VehicleRequired": true
     },
     {
       "X": 25647,
@@ -4565,6 +4568,7 @@
       "Y": 0,
       "Z": 47003,
       "Room": 3,
+      "TargetType": 13,
       "VehicleRequired": true
     },
     {
@@ -4650,6 +4654,7 @@
       "Z": 49199,
       "Room": 6,
       "Difficulty": "Hard",
+      "TargetType": 13,
       "VehicleRequired": true
     },
     {
@@ -4658,6 +4663,7 @@
       "Z": 17923,
       "Room": 76,
       "Difficulty": "Hard",
+      "TargetType": 13,
       "VehicleRequired": true
     },
     {
@@ -4666,6 +4672,7 @@
       "Z": 32289,
       "Room": 23,
       "Difficulty": "Hard",
+      "TargetType": 13,
       "VehicleRequired": true
     },
     {
@@ -4674,6 +4681,7 @@
       "Z": 28614,
       "Room": 25,
       "Difficulty": "Hard",
+      "TargetType": 13,
       "VehicleRequired": true
     },
     {
@@ -4724,6 +4732,7 @@
       "Z": 58372,
       "Room": 67,
       "Difficulty": "Hard",
+      "TargetType": 13,
       "VehicleRequired": true
     },
     {
@@ -4828,6 +4837,7 @@
       "Z": 2622,
       "Room": 107,
       "Difficulty": "Hard",
+      "TargetType": 13,
       "VehicleRequired": true
     },
     {
@@ -4844,6 +4854,7 @@
       "Z": 57276,
       "Room": 50,
       "RequiresGlitch": true,
+      "TargetType": 13,
       "VehicleRequired": true
     },
     {
@@ -4852,6 +4863,7 @@
       "Z": 86049,
       "Room": 44,
       "RequiresGlitch": true,
+      "TargetType": 13,
       "VehicleRequired": true
     },
     {
@@ -4860,6 +4872,7 @@
       "Z": 73760,
       "Room": 42,
       "RequiresGlitch": true,
+      "TargetType": 13,
       "VehicleRequired": true
     },
     {
@@ -4870,6 +4883,7 @@
       "Difficulty": "Hard",
       "PackID": "apel",
       "RequiresGlitch": true,
+      "TargetType": 13,
       "VehicleRequired": true
     },
     {
@@ -4878,6 +4892,7 @@
       "Z": 45105,
       "Room": 89,
       "RequiresGlitch": true,
+      "TargetType": 13,
       "VehicleRequired": true
     },
     {


### PR DESCRIPTION
* Updated each secret location that depends on a vehicle to add the vehicle type.
* If randomizing vehicles and a secret exists in the level that has a dependency on that vehicle type, the vehicle location will not be randomized. This avoids issues with the path from the vehicle to the secret being impossible, the idea being that the secret is placed based on the vehicle's original position.
* Tidied up some of the logic to test locations, and to spawn/move skidoos.

Resolves #550.