### PR TITLE
Fix TR2 environment issues

### DIFF
--- a/TRRandomizerCore/Resources/TR2/Environment/ICECAVE.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR2/Environment/ICECAVE.TR2-Environment.json
@@ -2034,6 +2034,30 @@
           }
         }
       ]
+    },
+    {
+      "Condition": {
+        "Comments": "Check if a specific secret is present.",
+        "ConditionType": 1,
+        "RoomIndex": 88
+      },
+      "OnTrue": [
+        {
+          "Comments": "Undo any flooding that may have been performed.",
+          "EMType": 3,
+          "RoomNumbers": [
+            76,
+            23,
+            88
+          ],
+          "WaterTextures": [
+            1366,
+            1562,
+            1563,
+            1564
+          ]
+        }
+      ]
     }
   ],
   "ConditionalOneOf": [],

--- a/TRRandomizerCore/Resources/TR2/Environment/LIVING.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR2/Environment/LIVING.TR2-Environment.json
@@ -227,7 +227,7 @@
           "Intensity2": 6400,
           "MeshID": 35
         },
-        "IgnoreSectorEntities": true
+        "IgnoreSectorEntities": false
       }
     ],
     [


### PR DESCRIPTION
This adds a check for Ice Palace to undo flooding in a certain spot if a secret is present there. And in Living Quarters, we place a random static mesh but now it will only be done if there is not an item already on the floor.

Resolves #553.