### PR TITLE
Mirror unique floor data only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR-Rando/compare/V1.8.0...master) - xxxx-xx-xx
+- fixed floor data issues in mirrored levels in TRUB (#583)
 
 ## [V1.8.0](https://github.com/LostArtefacts/TR-Rando/compare/V1.7.3...V1.8.0) - 2023-12-10
 - added support for Unfinished Business and playing in combined game mode for TR1 (#580)

--- a/TREnvironmentEditor/Model/Types/Mirroring/EMMirrorFunction.cs
+++ b/TREnvironmentEditor/Model/Types/Mirroring/EMMirrorFunction.cs
@@ -183,7 +183,7 @@ public class EMMirrorFunction : BaseEMFunction
         }
 
         // Change slants and climbable entries
-        foreach (TRRoomSector sector in sectors)
+        foreach (TRRoomSector sector in sectors.DistinctBy(s => s.FDIndex))
         {
             if (sector.FDIndex != 0)
             {


### PR DESCRIPTION
Resolves #583.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Avoids repeatedly mirroring floor data when entry lists are shared between sectors.
