### PR TITLE
Fix pickup issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR-Rando/compare/V1.8.1...master) - xxxx-xx-xx
+- fixed some pickups appearing in unreachable locations in TR2 (#591)
+- fixed inaccurate pickup statistics in TR1 when playing one-item mode (#591)
+- fixed additional secret rewards being placed in non-existent rooms when not randomizing secrets in TR1 (#591)
+- fixed a secret becoming invisible after blowing up the final area in Bartoli's Hideout (#591)
 
 ## [V1.8.1](https://github.com/LostArtefacts/TR-Rando/compare/V1.8.0...V1.8.1) - 2023-12-15
 - fixed floor data issues in mirrored levels in TRUB (#583)

--- a/TRRandomizerCore/Randomizers/TR1/TR1ItemRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/TR1ItemRandomizer.cs
@@ -285,6 +285,7 @@ public class TR1ItemRandomizer : BaseTR1Randomizer
         }
 
         // Look for extra utility/ammo items and hide them
+        level.Script.UnobtainablePickups ??= 0;
         for (int i = 0; i < level.Data.Entities.Count; i++)
         {
             TR1Entity entity = level.Data.Entities[i];
@@ -299,6 +300,7 @@ public class TR1ItemRandomizer : BaseTR1Randomizer
             {
                 ItemUtilities.HideEntity(entity);
                 ItemFactory.FreeItem(level.Name, i);
+                level.Script.UnobtainablePickups++;
             }
         }
     }

--- a/TRRandomizerCore/Randomizers/TR1/TR1SecretRewardRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/TR1SecretRewardRandomizer.cs
@@ -49,8 +49,11 @@ public class TR1SecretRewardRandomizer : BaseTR1Randomizer
         stdItemTypes.Remove(TR1Type.Pistols_S_P); // A bit cruel as a reward?
 
         int secretRoom = RoomWaterUtilities.DefaultRoomCountDictionary[level.Name];
-        List<Location> rewardPositions = secretMapping.Rooms.First().RewardPositions;
         List<int> rewardIndices = new(secretMapping.RewardEntities);
+
+        // Pile extra pickups on top of existing ones, either in their default spots
+        // or in the generated reward rooms.
+        List<Location> rewardPositions = new(rewardIndices.Select(i => level.Data.Entities[i].GetLocation()));
 
         // Give at least one item per secret, never less than the original reward item count,
         // and potentially some extra bonus items.
@@ -68,9 +71,10 @@ public class TR1SecretRewardRandomizer : BaseTR1Randomizer
 
         while (rewardIndices.Count < rewardCount)
         {
-            TR1Entity item = ItemFactory.CreateItem(level.Name, level.Data.Entities, rewardPositions[_generator.Next(0, rewardPositions.Count)], true);
+            Location location = rewardPositions[_generator.Next(0, rewardPositions.Count)];
+            TR1Entity item = ItemFactory.CreateItem(level.Name, level.Data.Entities, location, true);
             rewardIndices.Add(level.Data.Entities.IndexOf(item));
-            item.Room = (short)secretRoom;
+            item.Room = (short)location.Room;
         }
 
         foreach (int rewardIndex in rewardIndices)

--- a/TRRandomizerCore/Randomizers/TR1/TR1SecretRewardRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/TR1SecretRewardRandomizer.cs
@@ -48,7 +48,6 @@ public class TR1SecretRewardRandomizer : BaseTR1Randomizer
         stdItemTypes.Remove(TR1Type.PistolAmmo_S_P); // Sprite/model not available
         stdItemTypes.Remove(TR1Type.Pistols_S_P); // A bit cruel as a reward?
 
-        int secretRoom = RoomWaterUtilities.DefaultRoomCountDictionary[level.Name];
         List<int> rewardIndices = new(secretMapping.RewardEntities);
 
         // Pile extra pickups on top of existing ones, either in their default spots

--- a/TRRandomizerCore/Resources/TR2/Environment/VENICE.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR2/Environment/VENICE.TR2-Environment.json
@@ -2096,6 +2096,32 @@
           }
         }
       ]
+    },
+    {
+      "Condition": {
+        "ConditionType": 0,
+        "EntityIndex": 125,
+        "X": 36352,
+        "Y": -256,
+        "Z": 35328,
+        "Room": 131
+      },
+      "OnFalse": [
+        {
+          "EMType": 71,
+          "Locations": [
+            {
+              "X": 37376,
+              "Y": 3840,
+              "Z": 18944,
+              "Room": 73
+            }
+          ],
+          "ActionItem": {
+            "Parameter": 125
+          }
+        }
+      ]
     }
   ],
   "ConditionalOneOf": [],

--- a/TRRandomizerCore/Resources/TR2/Environment/XIAN.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR2/Environment/XIAN.TR2-Environment.json
@@ -552,6 +552,30 @@
     ],
     [
       {
+        "Comments": "Move any pickups before making new walls.",
+        "EMType": 43,
+        "SectorLocations": [
+          {
+            "X": 53834,
+            "Y": -9216,
+            "Z": 61058,
+            "Room": 2
+          },
+          {
+            "X": 51702,
+            "Y": -9216,
+            "Z": 60953,
+            "Room": 2
+          }
+        ],
+        "TargetLocation": {
+          "X": 52736,
+          "Y": -9216,
+          "Z": 62976,
+          "Room": 2
+        }
+      },
+      {
         "Comments": "Make some blocks before the arena.",
         "EMType": 1,
         "Tags": [


### PR DESCRIPTION
Resolves #591.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The logic for converting skidoo drivers is a workaround to avoid crashes in TR2 when too many of those are present (the savegame buffer cannot cope). Before we were converting extra drivers into pickups and then just flooring the items, but lots of these would still end up in unreachable places. Now we just shift them to another existing pickup in the level.

The changes for the other fixes are quite straight-forward.