### PR TITLE
Randomize Torso eggs in TRUB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - fixed inaccurate pickup statistics in TR1 when playing one-item mode (#591)
 - fixed additional secret rewards being placed in non-existent rooms when not randomizing secrets in TR1 (#591)
 - fixed a secret becoming invisible after blowing up the final area in Bartoli's Hideout (#591)
+- fixed Torso-sized eggs not being randomized in TRUB (#593)
 
 ## [V1.8.1](https://github.com/LostArtefacts/TR-Rando/compare/V1.8.0...V1.8.1) - 2023-12-15
 - fixed floor data issues in mirrored levels in TRUB (#583)

--- a/TRRandomizerCore/Randomizers/TR1/TR1EnemyRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/TR1EnemyRandomizer.cs
@@ -239,6 +239,14 @@ public class TR1EnemyRandomizer : BaseTR1Randomizer
             AmendToQLarson(level);
         }
 
+        if (level.IsExpansion)
+        {
+            // Ensure big eggs are randomized by converting to normal ones because
+            // big eggs are never part of the enemy pool.
+            level.Data.Entities.FindAll(e => e.TypeID == TR1Type.AdamEgg)
+                .ForEach(e => e.TypeID = TR1Type.AtlanteanEgg);
+        }
+
         RandoDifficulty difficulty = GetImpliedDifficulty();
 
         // Get the list of enemy types currently in the level


### PR DESCRIPTION
Resolves #593.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

We don't randomize big eggs because of the way Torso is handled manually in Great Pyramid. Big TRUB eggs don't need any special handling so we just convert to regular ones so they get detected as enemies and hence randomized from there.
