### PR TITLE
Fix secret and reward issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR-Rando/compare/V1.8.2...master) - xxxx-xx-xx
+- fixed incorrect items sometimes being allocated as secret rewards in Thames Wharf (#597)
+- fixed an inaccessible secret in Offshore Rig when the main area is drained (#597)
 
 ## [V1.8.2](https://github.com/LostArtefacts/TR-Rando/compare/V1.8.1...V1.8.2) - 2024-01-14
 - fixed some pickups appearing in unreachable locations in TR2 (#591)

--- a/TRRandomizerCore/Randomizers/TR3/TR3ItemRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/TR3ItemRandomizer.cs
@@ -46,7 +46,7 @@ public class TR3ItemRandomizer : BaseTR3Randomizer
             FindUnarmedLevelPistols(_levelInstance);
 
             _picker.Initialise(_levelInstance.Name, GetItemLocationPool(_levelInstance, false), Settings, _generator);
-            _secretMapping = TR3SecretMapping.Get(GetResourcePath($@"TR3\SecretMapping\{_levelInstance.Name}-SecretMapping.json"), IsJPVersion);
+            _secretMapping = TR3SecretMapping.Get(_levelInstance);
 
             // #312 If this is the assault course, import required models. On failure, don't perform any item rando.
             if (_levelInstance.IsAssault && !ImportAssaultModels(_levelInstance))

--- a/TRRandomizerCore/Randomizers/TR3/TR3SecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/TR3SecretRandomizer.cs
@@ -174,7 +174,7 @@ public class TR3SecretRandomizer : BaseTR3Randomizer, ISecretRandomizer
 
     private void ActualiseRewardRoom(TR3CombinedLevel level, TRSecretRoom<TR2Entity> placeholder)
     {
-        TR3SecretMapping secretMapping = TR3SecretMapping.Get(GetResourcePath($@"TR3\SecretMapping\{level.Name}-SecretMapping.json"), IsJPVersion);
+        TR3SecretMapping secretMapping = TR3SecretMapping.Get(level);
         if (secretMapping == null)
         {
             return;

--- a/TRRandomizerCore/Randomizers/TR3/TR3SecretRewardRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/TR3SecretRewardRandomizer.cs
@@ -34,7 +34,7 @@ public class TR3SecretRewardRandomizer : BaseTR3Randomizer
             return;
         }
 
-        TR3SecretMapping secretMapping = TR3SecretMapping.Get(GetResourcePath($@"TR3\SecretMapping\{level.Name}-SecretMapping.json"), IsJPVersion);
+        TR3SecretMapping secretMapping = TR3SecretMapping.Get(level);
 
         List<TR3Type> stdItemTypes = TR3TypeUtilities.GetStandardPickupTypes();
         // A bit cruel as rewards?

--- a/TRRandomizerCore/Resources/TR2/Environment/RIG.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR2/Environment/RIG.TR2-Environment.json
@@ -1492,9 +1492,15 @@
   "ConditionalOneOf": [
     {
       "Condition": {
-        "Comments": "If room 2 does not contain a secret, drain the plane area.",
+        "Comments": "If neither rooms 2 nor 96 contain a secret, drain the plane area.",
         "ConditionType": 1,
-        "RoomIndex": 2
+        "RoomIndex": 2,
+        "Or": [
+          {
+            "ConditionType": 1,
+            "RoomIndex": 96
+          }
+        ]
       },
       "OnFalse": {
         "Leader": [

--- a/TRRandomizerCore/Secrets/TR3SecretMapping.cs
+++ b/TRRandomizerCore/Secrets/TR3SecretMapping.cs
@@ -1,20 +1,25 @@
 ﻿using Newtonsoft.Json;
 using TREnvironmentEditor;
+using TRLevelControl.Helpers;
 using TRLevelControl.Model;
+using TRRandomizerCore.Levels;
 
 namespace TRRandomizerCore.Secrets;
 
 public class TR3SecretMapping : TRSecretMapping<TR3Entity>
 {
-    public static TR3SecretMapping Get(string packPath, bool japaneseVersion)
+    public static TR3SecretMapping Get(TR3CombinedLevel level)
     {
+        string packPath = $@"Resources\TR3\SecretMapping\{level.Name}-SecretMapping.json";
         if (!File.Exists(packPath))
         {
             return null;
         }
 
         TR3SecretMapping mapping = JsonConvert.DeserializeObject<TR3SecretMapping>(File.ReadAllText(packPath), EMEditorMapping.Converter);
-        if (japaneseVersion && mapping.JPRewardEntities != null)
+        if (level.Is(TR3LevelNames.THAMES)
+            && level.Data.Entities.Any(e => e.TypeID == TR3Type.TeethSpikesOrBarbedWire && e.Room == 8)
+            && mapping.JPRewardEntities != null)
         {
             mapping.RewardEntities = mapping.JPRewardEntities;
         }


### PR DESCRIPTION
Resolves #597.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This switches to a more explicit JP level version test for Thames Wharf as relying on the script is not always accurate. The existence of the additional set of spikes offsets the reward item indices, so if it goes undetected the wrong items will be moved to the reward room.

Also updated a condition for Offshore Rig draining to test for another particular secret.