### PR TITLE
Fix enemy-dependent secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR-Rando/compare/V1.8.3...master) - xxxx-xx-xx
+- fixed item locking logic so that secrets that rely on specific enemies will always be obtainable (#570)
 
 ## [V1.8.3](https://github.com/LostArtefacts/TR-Rando/compare/V1.8.2...V1.8.3) - 2024-01-21
 - fixed incorrect items sometimes being allocated as secret rewards in Thames Wharf (#597)

--- a/TRRandomizerCore/Editors/TR2RandoEditor.cs
+++ b/TRRandomizerCore/Editors/TR2RandoEditor.cs
@@ -136,6 +136,7 @@ public class TR2RandoEditor : TR2LevelEditor, ISettingsProvider
         if (Settings.DevelopmentMode)
         {
             (tr23ScriptEditor.Script as TR23Script).LevelSelectEnabled = true;
+            (tr23ScriptEditor.Script as TR23Script).DozyEnabled = true;
             scriptEditor.SaveScript();
         }
 
@@ -265,7 +266,8 @@ public class TR2RandoEditor : TR2LevelEditor, ISettingsProvider
                     BackupPath = backupDirectory,
                     SaveMonitor = monitor,
                     Settings = Settings,
-                    TextureMonitor = textureMonitor
+                    TextureMonitor = textureMonitor,
+                    ItemFactory = itemFactory,
                 }.Randomize(Settings.EnemySeed);
             }
 

--- a/TRRandomizerCore/Helpers/ItemFactory.cs
+++ b/TRRandomizerCore/Helpers/ItemFactory.cs
@@ -119,4 +119,9 @@ public class ItemFactory<T>
     {
         return _lockedItems.ContainsKey(level) && _lockedItems[level].Contains(itemIndex);
     }
+
+    public List<int> GetLockedItems(string level)
+    {
+        return _lockedItems.ContainsKey(level) ? new(_lockedItems[level]) : new();
+    }
 }

--- a/TRRandomizerCore/Randomizers/Shared/SecretPicker.cs
+++ b/TRRandomizerCore/Randomizers/Shared/SecretPicker.cs
@@ -214,7 +214,7 @@ public class SecretPicker<T>
         _distanceDivisor = Math.Max(_minDistanceDivisor, totalCount);
     }
 
-    public void FinaliseSecretPool(IEnumerable<Location> usedLocations, string level)
+    public void FinaliseSecretPool(IEnumerable<Location> usedLocations, string level, Func<int, List<int>> lockedItemAction)
     {
         // Secrets in packs are permitted to enforce level state
         if (usedLocations.Any(l => l.LevelState == LevelState.Mirrored))
@@ -229,7 +229,10 @@ public class SecretPicker<T>
         foreach (Location location in usedLocations.Where(l => l.EntityIndex != -1))
         {
             // Indicates that a secret relies on another item to remain in its original position
-            ItemFactory.LockItem(level, location.EntityIndex);
+            foreach (int itemIndex in lockedItemAction(location.EntityIndex))
+            {
+                ItemFactory.LockItem(level, itemIndex);
+            }
         }
 
 #if DEBUG

--- a/TRRandomizerCore/Randomizers/TR1/TR1SecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/TR1SecretRandomizer.cs
@@ -475,7 +475,7 @@ public class TR1SecretRandomizer : BaseTR1Randomizer, ISecretRandomizer
         floorData.WriteToLevel(level.Data);
 
         AddDamageControl(level, pickedLocations);
-        _secretPicker.FinaliseSecretPool(pickedLocations, level.Name);
+        _secretPicker.FinaliseSecretPool(pickedLocations, level.Name, itemIndex => new() { itemIndex });
     }
 
     private void AddDamageControl(TR1CombinedLevel level, List<Location> locations)

--- a/TRRandomizerCore/Randomizers/TR3/TR3EnemyRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/TR3EnemyRandomizer.cs
@@ -189,6 +189,20 @@ public class TR3EnemyRandomizer : BaseTR3Randomizer
             }
         }
 
+        // Some secrets may have locked enemies in place - we must retain those types
+        foreach (int itemIndex in ItemFactory.GetLockedItems(level.Name))
+        {
+            TR3Entity item = level.Data.Entities[itemIndex];
+            if (TR3TypeUtilities.IsEnemyType(item.TypeID))
+            {
+                List<TR3Type> family = TR3TypeUtilities.GetFamily(TR3TypeUtilities.GetAliasForLevel(level.Name, item.TypeID));
+                if (!newEntities.Any(family.Contains))
+                {
+                    newEntities.Add(family[_generator.Next(0, family.Count)]);
+                }
+            }
+        }
+
         if (!Settings.DocileWillard || Settings.OneEnemyMode || Settings.IncludedEnemies.Count < newEntities.Capacity)
         {
             // Willie isn't excludable in his own right because supporting a Willie-only game is impossible
@@ -445,9 +459,11 @@ public class TR3EnemyRandomizer : BaseTR3Randomizer
         {
             TR3Type currentEntityType = currentEntity.TypeID;
             TR3Type newEntityType = currentEntityType;
+            int enemyIndex = level.Data.Entities.IndexOf(currentEntity);
 
             // If it's an existing enemy that has to remain in the same spot, skip it
-            if (TR3EnemyUtilities.IsEnemyRequired(level.Name, currentEntityType))
+            if (TR3EnemyUtilities.IsEnemyRequired(level.Name, currentEntityType)
+                || ItemFactory.IsItemLocked(level.Name, enemyIndex))
             {
                 continue;
             }

--- a/TRRandomizerCore/Resources/TR2/Locations/locations.json
+++ b/TRRandomizerCore/Resources/TR2/Locations/locations.json
@@ -1145,7 +1145,7 @@
       "Z": 22580,
       "Room": 91,
       "Difficulty": "Hard",
-      "EntityIndex": 79,
+      "EntityIndex": 78,
       "PackID": "apel",
       "RequiresGlitch": true
     },
@@ -1597,7 +1597,7 @@
       "X": 66560,
       "Y": -840,
       "Z": 25692,
-      "Room": 98,
+      "Room": 103,
       "Difficulty": "Hard",
       "PackID": "apel",
       "RequiresGlitch": true
@@ -1635,7 +1635,7 @@
       "X": 41877,
       "Y": -3761,
       "Z": 31643,
-      "Room": 130,
+      "Room": 135,
       "Difficulty": "Hard",
       "PackID": "apel",
       "RequiresGlitch": true
@@ -3721,7 +3721,7 @@
       "Z": 86650,
       "Room": 0,
       "Difficulty": "Hard",
-      "EntityIndex": 4,
+      "EntityIndex": 3,
       "PackID": "apel"
     },
     {


### PR DESCRIPTION
Resolves #570.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This allows secrets to lock enemy types where those types are needed to collect it. It will also lock any pickups under the enemy. Previously we were only locking the pickup, but we need that item to be dropped in a certain way, hence locking the enemy will achieve that.

I've not extended this to TR1 because there are no secrets like this there currently, plus item drop logic is handled differently so it's currently too complicated to implement. It's available in TR3 because the handling is identical to TR2, but currently not used in any secrets there.

I've also adjusted some Bartoli's secrets that had wrong room numbers. Thanks to Zenuriko for extensive testing here.