### PR TITLE
Refactor animation collections

### DIFF
--- a/TREnvironmentEditor/Model/Conditions/Models/EMModelExistsCondition.cs
+++ b/TREnvironmentEditor/Model/Conditions/Models/EMModelExistsCondition.cs
@@ -8,19 +8,19 @@ public class EMModelExistsCondition : BaseEMCondition
 
     protected override bool Evaluate(TR1Level level)
     {
-        TRModel model = level.Models.ToList().Find(m => m.ID == ModelID);
+        TRModel model = level.Models.Find(m => m.ID == ModelID);
         return model != null;
     }
 
     protected override bool Evaluate(TR2Level level)
     {
-        TRModel model = level.Models.ToList().Find(m => m.ID == ModelID);
+        TRModel model = level.Models.Find(m => m.ID == ModelID);
         return model != null;
     }
 
     protected override bool Evaluate(TR3Level level)
     {
-        TRModel model = level.Models.ToList().Find(m => m.ID == ModelID);
+        TRModel model = level.Models.Find(m => m.ID == ModelID);
         return model != null;
     }
 }

--- a/TREnvironmentEditor/Model/Conditions/Models/EMUnconditionalBirdCheck.cs
+++ b/TREnvironmentEditor/Model/Conditions/Models/EMUnconditionalBirdCheck.cs
@@ -11,7 +11,7 @@ public class EMUnconditionalBirdCheck : BaseEMCondition
 
     protected override bool Evaluate(TR2Level level)
     {
-        TRModel model = Array.Find(level.Models, m => m.ID == (uint)TR2Type.BirdMonster);
+        TRModel model = level.Models.Find(m => m.ID == (uint)TR2Type.BirdMonster);
         if (model != null)
         {
             return level.Animations[model.Animation + 20].FrameEnd == level.Animations[model.Animation + 19].FrameEnd;

--- a/TREnvironmentEditor/Model/Types/Mirroring/EMMirrorFunction.cs
+++ b/TREnvironmentEditor/Model/Types/Mirroring/EMMirrorFunction.cs
@@ -1263,7 +1263,7 @@ public class EMMirrorFunction : BaseEMFunction
         }
     }
 
-    private static void MirrorDependentFaces(TRModel[] models, ISet<ushort> textureReferences, Func<uint, TRMesh[]> meshAction)
+    private static void MirrorDependentFaces(IEnumerable<TRModel> models, ISet<ushort> textureReferences, Func<uint, TRMesh[]> meshAction)
     {
         foreach (TRModel model in models)
         {

--- a/TREnvironmentEditor/Model/Types/Models/EMConvertModelFunction.cs
+++ b/TREnvironmentEditor/Model/Types/Models/EMConvertModelFunction.cs
@@ -15,21 +15,21 @@ public class EMConvertModelFunction : BaseEMFunction
 
     public override void ApplyToLevel(TR2Level level)
     {
-        ConvertModel(level.Models);
+        ConvertModel(level.Models.ToList());
         UpdateModelEntities(level.Entities);
     }
 
     public override void ApplyToLevel(TR3Level level)
     {
-        ConvertModel(level.Models);
+        ConvertModel(level.Models.ToList());
         UpdateModelEntities(level.Entities);
     }
 
-    private void ConvertModel(TRModel[] models)
+    private void ConvertModel(List<TRModel> models)
     {
-        if (Array.Find(models, m => m.ID == NewModelID) == null)
+        if (models.Find(m => m.ID == NewModelID) == null)
         {
-            TRModel oldModel = Array.Find(models, m => m.ID == OldModelID);
+            TRModel oldModel = models.Find(m => m.ID == OldModelID);
             if (oldModel != null)
             {
                 oldModel.ID = NewModelID;

--- a/TREnvironmentEditor/Model/Types/Models/EMConvertModelFunction.cs
+++ b/TREnvironmentEditor/Model/Types/Models/EMConvertModelFunction.cs
@@ -15,13 +15,13 @@ public class EMConvertModelFunction : BaseEMFunction
 
     public override void ApplyToLevel(TR2Level level)
     {
-        ConvertModel(level.Models.ToList());
+        ConvertModel(level.Models);
         UpdateModelEntities(level.Entities);
     }
 
     public override void ApplyToLevel(TR3Level level)
     {
-        ConvertModel(level.Models.ToList());
+        ConvertModel(level.Models);
         UpdateModelEntities(level.Entities);
     }
 

--- a/TREnvironmentEditor/Model/Types/Models/EMImportNonGraphicsModelFunction.cs
+++ b/TREnvironmentEditor/Model/Types/Models/EMImportNonGraphicsModelFunction.cs
@@ -32,7 +32,7 @@ public class EMImportNonGraphicsModelFunction : BaseEMFunction
 
     public override void ApplyToLevel(TR2Level level)
     {
-        List<EMMeshTextureData> data = PrepareImportData(level.Models);
+        List<EMMeshTextureData> data = PrepareImportData(level.Models.ToList());
         if (data.Count == 0)
         {
             return;
@@ -53,7 +53,7 @@ public class EMImportNonGraphicsModelFunction : BaseEMFunction
 
     public override void ApplyToLevel(TR3Level level)
     {
-        List<EMMeshTextureData> data = PrepareImportData(level.Models);
+        List<EMMeshTextureData> data = PrepareImportData(level.Models.ToList());
         if (data.Count == 0)
         {
             return;
@@ -72,12 +72,12 @@ public class EMImportNonGraphicsModelFunction : BaseEMFunction
         RemapFaces(data, level.NumObjectTextures - 1, modelID => TRMeshUtilities.GetModelMeshes(level, (TR3Type)modelID));
     }
 
-    private List<EMMeshTextureData> PrepareImportData(TRModel[] existingModels)
+    private List<EMMeshTextureData> PrepareImportData(List<TRModel> existingModels)
     {
         List<EMMeshTextureData> importData = new();
         foreach (EMMeshTextureData data in Data)
         {
-            if (Array.Find(existingModels, m => m.ID == data.ModelID) == null)
+            if (existingModels.Find(m => m.ID == data.ModelID) == null)
             {
                 importData.Add(data);
             }

--- a/TREnvironmentEditor/Model/Types/Models/EMImportNonGraphicsModelFunction.cs
+++ b/TREnvironmentEditor/Model/Types/Models/EMImportNonGraphicsModelFunction.cs
@@ -32,7 +32,7 @@ public class EMImportNonGraphicsModelFunction : BaseEMFunction
 
     public override void ApplyToLevel(TR2Level level)
     {
-        List<EMMeshTextureData> data = PrepareImportData(level.Models.ToList());
+        List<EMMeshTextureData> data = PrepareImportData(level.Models);
         if (data.Count == 0)
         {
             return;
@@ -53,7 +53,7 @@ public class EMImportNonGraphicsModelFunction : BaseEMFunction
 
     public override void ApplyToLevel(TR3Level level)
     {
-        List<EMMeshTextureData> data = PrepareImportData(level.Models.ToList());
+        List<EMMeshTextureData> data = PrepareImportData(level.Models);
         if (data.Count == 0)
         {
             return;

--- a/TRLevelControl/Control/TR1LevelControl.cs
+++ b/TRLevelControl/Control/TR1LevelControl.cs
@@ -178,12 +178,11 @@ public class TR1LevelControl : TRLevelControlBase<TR1Level>
         }
 
         //Models
-        _level.NumModels = reader.ReadUInt32();
-        _level.Models = new TRModel[_level.NumModels];
-
-        for (int i = 0; i < _level.NumModels; i++)
+        uint numModels = reader.ReadUInt32();
+        _level.Models = new();
+        for (int i = 0; i < numModels; i++)
         {
-            _level.Models[i] = TR2FileReadUtilities.ReadModel(reader);
+            _level.Models.Add(TR2FileReadUtilities.ReadModel(reader));
         }
 
         //Static Meshes
@@ -364,7 +363,7 @@ public class TR1LevelControl : TRLevelControlBase<TR1Level>
         writer.Write((uint)_level.Frames.Count);
         foreach (ushort frame in _level.Frames) { writer.Write(frame); }
 
-        writer.Write(_level.NumModels);
+        writer.Write((uint)_level.Models.Count);
         foreach (TRModel model in _level.Models) { writer.Write(model.Serialize()); }
         writer.Write(_level.NumStaticMeshes);
         foreach (TRStaticMesh mesh in _level.StaticMeshes) { writer.Write(mesh.Serialize()); }

--- a/TRLevelControl/Control/TR1LevelControl.cs
+++ b/TRLevelControl/Control/TR1LevelControl.cs
@@ -130,52 +130,51 @@ public class TR1LevelControl : TRLevelControlBase<TR1Level>
         _level.Meshes = ConstructMeshData(_level.MeshPointers, _level.RawMeshData);
 
         //Animations
-        _level.NumAnimations = reader.ReadUInt32();
-        _level.Animations = new TRAnimation[_level.NumAnimations];
-        for (int i = 0; i < _level.NumAnimations; i++)
+        uint numAnimations = reader.ReadUInt32();
+        _level.Animations = new();
+        for (int i = 0; i < numAnimations; i++)
         {
-            _level.Animations[i] = TR2FileReadUtilities.ReadAnimation(reader);
+            _level.Animations.Add(TR2FileReadUtilities.ReadAnimation(reader));
         }
 
         //State Changes
-        _level.NumStateChanges = reader.ReadUInt32();
-        _level.StateChanges = new TRStateChange[_level.NumStateChanges];
-        for (int i = 0; i < _level.NumStateChanges; i++)
+        uint numStateChanges = reader.ReadUInt32();
+        _level.StateChanges = new();
+        for (int i = 0; i < numStateChanges; i++)
         {
-            _level.StateChanges[i] = TR2FileReadUtilities.ReadStateChange(reader);
+            _level.StateChanges.Add(TR2FileReadUtilities.ReadStateChange(reader));
         }
 
         //Animation Dispatches
-        _level.NumAnimDispatches = reader.ReadUInt32();
-        _level.AnimDispatches = new TRAnimDispatch[_level.NumAnimDispatches];
-        for (int i = 0; i < _level.NumAnimDispatches; i++)
+        uint numAnimDispatches = reader.ReadUInt32();
+        _level.AnimDispatches = new();
+        for (int i = 0; i < numAnimDispatches; i++)
         {
-            _level.AnimDispatches[i] = TR2FileReadUtilities.ReadAnimDispatch(reader);
+            _level.AnimDispatches.Add(TR2FileReadUtilities.ReadAnimDispatch(reader));
         }
 
         //Animation Commands
-        _level.NumAnimCommands = reader.ReadUInt32();
-        _level.AnimCommands = new TRAnimCommand[_level.NumAnimCommands];
-        for (int i = 0; i < _level.NumAnimCommands; i++)
+        uint numAnimCommands = reader.ReadUInt32();
+        _level.AnimCommands = new();
+        for (int i = 0; i < numAnimCommands; i++)
         {
-            _level.AnimCommands[i] = TR2FileReadUtilities.ReadAnimCommand(reader);
+            _level.AnimCommands.Add(TR2FileReadUtilities.ReadAnimCommand(reader));
         }
 
         //Mesh Trees
-        _level.NumMeshTrees = reader.ReadUInt32();
-        _level.NumMeshTrees /= 4;
-        _level.MeshTrees = new TRMeshTreeNode[_level.NumMeshTrees];
-        for (int i = 0; i < _level.NumMeshTrees; i++)
+        uint numMeshTrees = reader.ReadUInt32() / 4;
+        _level.MeshTrees = new();
+        for (int i = 0; i < numMeshTrees; i++)
         {
-            _level.MeshTrees[i] = TR2FileReadUtilities.ReadMeshTreeNode(reader);
+            _level.MeshTrees.Add(TR2FileReadUtilities.ReadMeshTreeNode(reader));
         }
 
         //Frames
-        _level.NumFrames = reader.ReadUInt32();
-        _level.Frames = new ushort[_level.NumFrames];
-        for (int i = 0; i < _level.NumFrames; i++)
+        uint numFrames = reader.ReadUInt32();
+        _level.Frames = new();
+        for (int i = 0; i < numFrames; i++)
         {
-            _level.Frames[i] = reader.ReadUInt16();
+            _level.Frames.Add(reader.ReadUInt16());
         }
 
         //Models
@@ -352,17 +351,17 @@ public class TR1LevelControl : TRLevelControlBase<TR1Level>
         writer.Write(_level.NumMeshPointers);
         foreach (uint ptr in _level.MeshPointers) { writer.Write(ptr); }
 
-        writer.Write(_level.NumAnimations);
+        writer.Write((uint)_level.Animations.Count);
         foreach (TRAnimation anim in _level.Animations) { writer.Write(anim.Serialize()); }
-        writer.Write(_level.NumStateChanges);
+        writer.Write((uint)_level.StateChanges.Count);
         foreach (TRStateChange statec in _level.StateChanges) { writer.Write(statec.Serialize()); }
-        writer.Write(_level.NumAnimDispatches);
+        writer.Write((uint)_level.AnimDispatches.Count);
         foreach (TRAnimDispatch dispatch in _level.AnimDispatches) { writer.Write(dispatch.Serialize()); }
-        writer.Write(_level.NumAnimCommands);
+        writer.Write((uint)_level.AnimCommands.Count);
         foreach (TRAnimCommand cmd in _level.AnimCommands) { writer.Write(cmd.Serialize()); }
-        writer.Write(_level.NumMeshTrees * 4); //To get the correct number /= 4 is done during read, make sure to reverse it here.
+        writer.Write((uint)(_level.MeshTrees.Count * 4)); //To get the correct number /= 4 is done during read, make sure to reverse it here.
         foreach (TRMeshTreeNode node in _level.MeshTrees) { writer.Write(node.Serialize()); }
-        writer.Write(_level.NumFrames);
+        writer.Write((uint)_level.Frames.Count);
         foreach (ushort frame in _level.Frames) { writer.Write(frame); }
 
         writer.Write(_level.NumModels);

--- a/TRLevelControl/Control/TR2LevelControl.cs
+++ b/TRLevelControl/Control/TR2LevelControl.cs
@@ -185,12 +185,11 @@ public class TR2LevelControl : TRLevelControlBase<TR2Level>
         }
 
         //Models
-        _level.NumModels = reader.ReadUInt32();
-        _level.Models = new TRModel[_level.NumModels];
-
-        for (int i = 0; i < _level.NumModels; i++)
+        uint numModels = reader.ReadUInt32();
+        _level.Models = new();
+        for (int i = 0; i < numModels; i++)
         {
-            _level.Models[i] = TR2FileReadUtilities.ReadModel(reader);
+            _level.Models.Add(TR2FileReadUtilities.ReadModel(reader));
         }
 
         //Static Meshes
@@ -372,7 +371,7 @@ public class TR2LevelControl : TRLevelControlBase<TR2Level>
         writer.Write((uint)_level.Frames.Count);
         foreach (ushort frame in _level.Frames) { writer.Write(frame); }
 
-        writer.Write(_level.NumModels);
+        writer.Write((uint)_level.Models.Count);
         foreach (TRModel model in _level.Models) { writer.Write(model.Serialize()); }
         writer.Write(_level.NumStaticMeshes);
         foreach (TRStaticMesh mesh in _level.StaticMeshes) { writer.Write(mesh.Serialize()); }

--- a/TRLevelControl/Control/TR2LevelControl.cs
+++ b/TRLevelControl/Control/TR2LevelControl.cs
@@ -137,52 +137,51 @@ public class TR2LevelControl : TRLevelControlBase<TR2Level>
         _level.Meshes = ConstructMeshData(_level.MeshPointers, _level.RawMeshData);
 
         //Animations
-        _level.NumAnimations = reader.ReadUInt32();
-        _level.Animations = new TRAnimation[_level.NumAnimations];
-        for (int i = 0; i < _level.NumAnimations; i++)
+        uint numAnimations = reader.ReadUInt32();
+        _level.Animations = new();
+        for (int i = 0; i < numAnimations; i++)
         {
-            _level.Animations[i] = TR2FileReadUtilities.ReadAnimation(reader);
+            _level.Animations.Add(TR2FileReadUtilities.ReadAnimation(reader));
         }
 
         //State Changes
-        _level.NumStateChanges = reader.ReadUInt32();
-        _level.StateChanges = new TRStateChange[_level.NumStateChanges];
-        for (int i = 0; i < _level.NumStateChanges; i++)
+        uint numStateChanges = reader.ReadUInt32();
+        _level.StateChanges = new();
+        for (int i = 0; i < numStateChanges; i++)
         {
-            _level.StateChanges[i] = TR2FileReadUtilities.ReadStateChange(reader);
+            _level.StateChanges.Add(TR2FileReadUtilities.ReadStateChange(reader));
         }
 
         //Animation Dispatches
-        _level.NumAnimDispatches = reader.ReadUInt32();
-        _level.AnimDispatches = new TRAnimDispatch[_level.NumAnimDispatches];
-        for (int i = 0; i < _level.NumAnimDispatches; i++)
+        uint numAnimDispatches = reader.ReadUInt32();
+        _level.AnimDispatches = new();
+        for (int i = 0; i < numAnimDispatches; i++)
         {
-            _level.AnimDispatches[i] = TR2FileReadUtilities.ReadAnimDispatch(reader);
+            _level.AnimDispatches.Add(TR2FileReadUtilities.ReadAnimDispatch(reader));
         }
 
         //Animation Commands
-        _level.NumAnimCommands = reader.ReadUInt32();
-        _level.AnimCommands = new TRAnimCommand[_level.NumAnimCommands];
-        for (int i = 0; i < _level.NumAnimCommands; i++)
+        uint numAnimCommands = reader.ReadUInt32();
+        _level.AnimCommands = new();
+        for (int i = 0; i < numAnimCommands; i++)
         {
-            _level.AnimCommands[i] = TR2FileReadUtilities.ReadAnimCommand(reader);
+            _level.AnimCommands.Add(TR2FileReadUtilities.ReadAnimCommand(reader));
         }
 
         //Mesh Trees
-        _level.NumMeshTrees = reader.ReadUInt32();
-        _level.NumMeshTrees /= 4;
-        _level.MeshTrees = new TRMeshTreeNode[_level.NumMeshTrees];
-        for (int i = 0; i < _level.NumMeshTrees; i++)
+        uint numMeshTrees = reader.ReadUInt32() / 4;
+        _level.MeshTrees = new();
+        for (int i = 0; i < numMeshTrees; i++)
         {
-            _level.MeshTrees[i] = TR2FileReadUtilities.ReadMeshTreeNode(reader);
+            _level.MeshTrees.Add(TR2FileReadUtilities.ReadMeshTreeNode(reader));
         }
 
         //Frames
-        _level.NumFrames = reader.ReadUInt32();
-        _level.Frames = new ushort[_level.NumFrames];
-        for (int i = 0; i < _level.NumFrames; i++)
+        uint numFrames = reader.ReadUInt32();
+        _level.Frames = new();
+        for (int i = 0; i < numFrames; i++)
         {
-            _level.Frames[i] = reader.ReadUInt16();
+            _level.Frames.Add(reader.ReadUInt16());
         }
 
         //Models
@@ -360,17 +359,17 @@ public class TR2LevelControl : TRLevelControlBase<TR2Level>
         writer.Write(_level.NumMeshPointers);
         foreach (uint ptr in _level.MeshPointers) { writer.Write(ptr); }
 
-        writer.Write(_level.NumAnimations);
+        writer.Write((uint)_level.Animations.Count);
         foreach (TRAnimation anim in _level.Animations) { writer.Write(anim.Serialize()); }
-        writer.Write(_level.NumStateChanges);
+        writer.Write((uint)_level.StateChanges.Count);
         foreach (TRStateChange statec in _level.StateChanges) { writer.Write(statec.Serialize()); }
-        writer.Write(_level.NumAnimDispatches);
+        writer.Write((uint)_level.AnimDispatches.Count);
         foreach (TRAnimDispatch dispatch in _level.AnimDispatches) { writer.Write(dispatch.Serialize()); }
-        writer.Write(_level.NumAnimCommands);
+        writer.Write((uint)_level.AnimCommands.Count);
         foreach (TRAnimCommand cmd in _level.AnimCommands) { writer.Write(cmd.Serialize()); }
-        writer.Write(_level.NumMeshTrees * 4); //To get the correct number /= 4 is done during read, make sure to reverse it here.
+        writer.Write((uint)_level.MeshTrees.Count * 4); //To get the correct number /= 4 is done during read, make sure to reverse it here.
         foreach (TRMeshTreeNode node in _level.MeshTrees) { writer.Write(node.Serialize()); }
-        writer.Write(_level.NumFrames);
+        writer.Write((uint)_level.Frames.Count);
         foreach (ushort frame in _level.Frames) { writer.Write(frame); }
 
         writer.Write(_level.NumModels);

--- a/TRLevelControl/Control/TR3LevelControl.cs
+++ b/TRLevelControl/Control/TR3LevelControl.cs
@@ -141,52 +141,51 @@ public class TR3LevelControl : TRLevelControlBase<TR3Level>
         _level.Meshes = ConstructMeshData(_level.MeshPointers, _level.RawMeshData);
 
         //Animations
-        _level.NumAnimations = reader.ReadUInt32();
-        _level.Animations = new TRAnimation[_level.NumAnimations];
-        for (int i = 0; i < _level.NumAnimations; i++)
+        uint numAnimations = reader.ReadUInt32();
+        _level.Animations = new();
+        for (int i = 0; i < numAnimations; i++)
         {
-            _level.Animations[i] = TR2FileReadUtilities.ReadAnimation(reader);
+            _level.Animations.Add(TR2FileReadUtilities.ReadAnimation(reader));
         }
 
         //State Changes
-        _level.NumStateChanges = reader.ReadUInt32();
-        _level.StateChanges = new TRStateChange[_level.NumStateChanges];
-        for (int i = 0; i < _level.NumStateChanges; i++)
+        uint numStateChanges = reader.ReadUInt32();
+        _level.StateChanges = new();
+        for (int i = 0; i < numStateChanges; i++)
         {
-            _level.StateChanges[i] = TR2FileReadUtilities.ReadStateChange(reader);
+            _level.StateChanges.Add(TR2FileReadUtilities.ReadStateChange(reader));
         }
 
         //Animation Dispatches
-        _level.NumAnimDispatches = reader.ReadUInt32();
-        _level.AnimDispatches = new TRAnimDispatch[_level.NumAnimDispatches];
-        for (int i = 0; i < _level.NumAnimDispatches; i++)
+        uint numAnimDispatches = reader.ReadUInt32();
+        _level.AnimDispatches = new();
+        for (int i = 0; i < numAnimDispatches; i++)
         {
-            _level.AnimDispatches[i] = TR2FileReadUtilities.ReadAnimDispatch(reader);
+            _level.AnimDispatches.Add(TR2FileReadUtilities.ReadAnimDispatch(reader));
         }
 
         //Animation Commands
-        _level.NumAnimCommands = reader.ReadUInt32();
-        _level.AnimCommands = new TRAnimCommand[_level.NumAnimCommands];
-        for (int i = 0; i < _level.NumAnimCommands; i++)
+        uint numAnimCommands = reader.ReadUInt32();
+        _level.AnimCommands = new();
+        for (int i = 0; i < numAnimCommands; i++)
         {
-            _level.AnimCommands[i] = TR2FileReadUtilities.ReadAnimCommand(reader);
+            _level.AnimCommands.Add(TR2FileReadUtilities.ReadAnimCommand(reader));
         }
 
         //Mesh Trees
-        _level.NumMeshTrees = reader.ReadUInt32();
-        _level.NumMeshTrees /= 4;
-        _level.MeshTrees = new TRMeshTreeNode[_level.NumMeshTrees];
-        for (int i = 0; i < _level.NumMeshTrees; i++)
+        uint numMeshTrees = reader.ReadUInt32() / 4;
+        _level.MeshTrees = new();
+        for (int i = 0; i < numMeshTrees; i++)
         {
-            _level.MeshTrees[i] = TR2FileReadUtilities.ReadMeshTreeNode(reader);
+            _level.MeshTrees.Add(TR2FileReadUtilities.ReadMeshTreeNode(reader));
         }
 
         //Frames
-        _level.NumFrames = reader.ReadUInt32();
-        _level.Frames = new ushort[_level.NumFrames];
-        for (int i = 0; i < _level.NumFrames; i++)
+        uint numFrames = reader.ReadUInt32();
+        _level.Frames = new();
+        for (int i = 0; i < numFrames; i++)
         {
-            _level.Frames[i] = reader.ReadUInt16();
+            _level.Frames.Add(reader.ReadUInt16());
         }
 
         //Models
@@ -362,17 +361,17 @@ public class TR3LevelControl : TRLevelControlBase<TR3Level>
         writer.Write(_level.NumMeshPointers);
         foreach (uint ptr in _level.MeshPointers) { writer.Write(ptr); }
 
-        writer.Write(_level.NumAnimations);
+        writer.Write((uint)_level.Animations.Count);
         foreach (TRAnimation anim in _level.Animations) { writer.Write(anim.Serialize()); }
-        writer.Write(_level.NumStateChanges);
+        writer.Write((uint)_level.StateChanges.Count);
         foreach (TRStateChange statec in _level.StateChanges) { writer.Write(statec.Serialize()); }
-        writer.Write(_level.NumAnimDispatches);
+        writer.Write((uint)_level.AnimDispatches.Count);
         foreach (TRAnimDispatch dispatch in _level.AnimDispatches) { writer.Write(dispatch.Serialize()); }
-        writer.Write(_level.NumAnimCommands);
+        writer.Write((uint)_level.AnimCommands.Count);
         foreach (TRAnimCommand cmd in _level.AnimCommands) { writer.Write(cmd.Serialize()); }
-        writer.Write(_level.NumMeshTrees * 4); //To get the correct number /= 4 is done during read, make sure to reverse it here.
+        writer.Write((uint)_level.MeshTrees.Count * 4); //To get the correct number /= 4 is done during read, make sure to reverse it here.
         foreach (TRMeshTreeNode node in _level.MeshTrees) { writer.Write(node.Serialize()); }
-        writer.Write(_level.NumFrames);
+        writer.Write((uint)_level.Frames.Count);
         foreach (ushort frame in _level.Frames) { writer.Write(frame); }
 
         writer.Write(_level.NumModels);

--- a/TRLevelControl/Control/TR3LevelControl.cs
+++ b/TRLevelControl/Control/TR3LevelControl.cs
@@ -189,12 +189,11 @@ public class TR3LevelControl : TRLevelControlBase<TR3Level>
         }
 
         //Models
-        _level.NumModels = reader.ReadUInt32();
-        _level.Models = new TRModel[_level.NumModels];
-
-        for (int i = 0; i < _level.NumModels; i++)
+        uint numModels = reader.ReadUInt32();
+        _level.Models = new();
+        for (int i = 0; i < numModels; i++)
         {
-            _level.Models[i] = TR2FileReadUtilities.ReadModel(reader);
+            _level.Models.Add(TR2FileReadUtilities.ReadModel(reader));
         }
 
         //Static Meshes
@@ -374,7 +373,7 @@ public class TR3LevelControl : TRLevelControlBase<TR3Level>
         writer.Write((uint)_level.Frames.Count);
         foreach (ushort frame in _level.Frames) { writer.Write(frame); }
 
-        writer.Write(_level.NumModels);
+        writer.Write((uint)_level.Models.Count);
         foreach (TRModel model in _level.Models) { writer.Write(model.Serialize()); }
         writer.Write(_level.NumStaticMeshes);
         foreach (TRStaticMesh mesh in _level.StaticMeshes) { writer.Write(mesh.Serialize()); }

--- a/TRLevelControl/Helpers/TRMeshUtilities.cs
+++ b/TRLevelControl/Helpers/TRMeshUtilities.cs
@@ -418,12 +418,8 @@ public static class TRMeshUtilities
 
     public static int InsertMeshTreeNode(TR2Level level, TRMeshTreeNode newNode)
     {
-        List<TRMeshTreeNode> nodes = level.MeshTrees.ToList();
-        nodes.Add(newNode);
-        level.MeshTrees = nodes.ToArray();
-        level.NumMeshTrees++;
-
-        return level.MeshTrees.Length - 1;
+        level.MeshTrees.Add(newNode);
+        return level.MeshTrees.Count - 1;
     }
 
     public static int InsertMeshTreeNode(TR3Level level, TRMeshTreeNode newNode)

--- a/TRLevelControl/Helpers/TRMeshUtilities.cs
+++ b/TRLevelControl/Helpers/TRMeshUtilities.cs
@@ -141,12 +141,12 @@ public static class TRMeshUtilities
 
     public static TRMeshTreeNode[] GetModelMeshTrees(TR2Level level, TRModel model)
     {
-        return GetModelMeshTrees(level.MeshTrees.ToList(), model);
+        return GetModelMeshTrees(level.MeshTrees, model);
     }
 
     public static TRMeshTreeNode[] GetModelMeshTrees(TR3Level level, TRModel model)
     {
-        return GetModelMeshTrees(level.MeshTrees.ToList(), model);
+        return GetModelMeshTrees(level.MeshTrees, model);
     }
 
     public static TRMeshTreeNode[] GetModelMeshTrees(List<TRMeshTreeNode> meshTrees, TRModel model)

--- a/TRLevelControl/Helpers/TRMeshUtilities.cs
+++ b/TRLevelControl/Helpers/TRMeshUtilities.cs
@@ -141,22 +141,22 @@ public static class TRMeshUtilities
 
     public static TRMeshTreeNode[] GetModelMeshTrees(TR2Level level, TRModel model)
     {
-        return GetModelMeshTrees(level.MeshTrees, model);
+        return GetModelMeshTrees(level.MeshTrees.ToList(), model);
     }
 
     public static TRMeshTreeNode[] GetModelMeshTrees(TR3Level level, TRModel model)
     {
-        return GetModelMeshTrees(level.MeshTrees, model);
+        return GetModelMeshTrees(level.MeshTrees.ToList(), model);
     }
 
-    public static TRMeshTreeNode[] GetModelMeshTrees(TRMeshTreeNode[] meshTrees, TRModel model)
+    public static TRMeshTreeNode[] GetModelMeshTrees(List<TRMeshTreeNode> meshTrees, TRModel model)
     {
         List<TRMeshTreeNode> nodes = new();
         int index = (int)model.MeshTree / 4;
         for (int i = 0; i < model.NumMeshes; i++)
         {
             int offset = index + i;
-            if (offset < meshTrees.Length)
+            if (offset < meshTrees.Count)
             {
                 nodes.Add(meshTrees[offset]);
             }
@@ -412,12 +412,8 @@ public static class TRMeshUtilities
     /// </summary>
     public static int InsertMeshTreeNode(TR1Level level, TRMeshTreeNode newNode)
     {
-        List<TRMeshTreeNode> nodes = level.MeshTrees.ToList();
-        nodes.Add(newNode);
-        level.MeshTrees = nodes.ToArray();
-        level.NumMeshTrees++;
-
-        return level.MeshTrees.Length - 1;
+        level.MeshTrees.Add(newNode);
+        return level.MeshTrees.Count - 1;
     }
 
     public static int InsertMeshTreeNode(TR2Level level, TRMeshTreeNode newNode)

--- a/TRLevelControl/Helpers/TRMeshUtilities.cs
+++ b/TRLevelControl/Helpers/TRMeshUtilities.cs
@@ -424,11 +424,7 @@ public static class TRMeshUtilities
 
     public static int InsertMeshTreeNode(TR3Level level, TRMeshTreeNode newNode)
     {
-        List<TRMeshTreeNode> nodes = level.MeshTrees.ToList();
-        nodes.Add(newNode);
-        level.MeshTrees = nodes.ToArray();
-        level.NumMeshTrees++;
-
-        return level.MeshTrees.Length - 1;
+        level.MeshTrees.Add(newNode);
+        return level.MeshTrees.Count - 1;
     }
 }

--- a/TRLevelControl/Helpers/TRMeshUtilities.cs
+++ b/TRLevelControl/Helpers/TRMeshUtilities.cs
@@ -6,7 +6,7 @@ public static class TRMeshUtilities
 {
     public static TRMesh GetModelFirstMesh(TR1Level level, TR1Type entity)
     {
-        TRModel model = level.Models.ToList().Find(e => e.ID == (uint)entity);
+        TRModel model = level.Models.Find(e => e.ID == (uint)entity);
         if (model != null)
         {
             return GetModelFirstMesh(level, model);
@@ -16,7 +16,7 @@ public static class TRMeshUtilities
 
     public static TRMesh GetModelFirstMesh(TR2Level level, TR2Type entity)
     {
-        TRModel model = level.Models.ToList().Find(e => e.ID == (uint)entity);
+        TRModel model = level.Models.Find(e => e.ID == (uint)entity);
         if (model != null)
         {
             return GetModelFirstMesh(level, model);
@@ -26,7 +26,7 @@ public static class TRMeshUtilities
 
     public static TRMesh GetModelFirstMesh(TR3Level level, TR3Type entity)
     {
-        TRModel model = level.Models.ToList().Find(e => e.ID == (uint)entity);
+        TRModel model = level.Models.Find(e => e.ID == (uint)entity);
         if (model != null)
         {
             return GetModelFirstMesh(level, model);

--- a/TRLevelControl/Model/Base/TR1Level.cs
+++ b/TRLevelControl/Model/Base/TR1Level.cs
@@ -54,65 +54,12 @@ public class TR1Level : TRLevelBase
     /// </summary>
     public uint[] MeshPointers { get; set; }
 
-    /// <summary>
-    /// 4 bytes
-    /// </summary>
-    public uint NumAnimations { get; set; }
-
-    /// <summary>
-    /// NumAnimations * 32 bytes
-    /// </summary>
-    public TRAnimation[] Animations { get; set; }
-
-    /// <summary>
-    /// 4 bytes
-    /// </summary>
-    public uint NumStateChanges { get; set; }
-
-    /// <summary>
-    /// NumStateChanges * 6 bytes
-    /// </summary>
-    public TRStateChange[] StateChanges { get; set; }
-
-    /// <summary>
-    /// 4 bytes
-    /// </summary>
-    public uint NumAnimDispatches { get; set; }
-
-    /// <summary>
-    /// NumAnimDispatches * 8 bytes
-    /// </summary>
-    public TRAnimDispatch[] AnimDispatches { get; set; }
-
-    /// <summary>
-    /// 4 bytes
-    /// </summary>
-    public uint NumAnimCommands { get; set; }
-
-    /// <summary>
-    /// NumAnimCommands * 2 bytes
-    /// </summary>
-    public TRAnimCommand[] AnimCommands { get; set; }
-
-    /// <summary>
-    /// 4 bytes
-    /// </summary>
-    public uint NumMeshTrees { get; set; }
-
-    /// <summary>
-    /// NumMeshTrees * 4 bytes
-    /// </summary>
-    public TRMeshTreeNode[] MeshTrees { get; set; }
-
-    /// <summary>
-    /// 4 bytes
-    /// </summary>
-    public uint NumFrames { get; set; }
-
-    /// <summary>
-    /// NumFrames * 2 bytes
-    /// </summary>
-    public ushort[] Frames { get; set; }
+    public List<TRAnimation> Animations { get; set; }
+    public List<TRStateChange> StateChanges { get; set; }
+    public List<TRAnimDispatch> AnimDispatches { get; set; }
+    public List<TRAnimCommand> AnimCommands { get; set; }
+    public List<TRMeshTreeNode> MeshTrees { get; set; }
+    public List<ushort> Frames { get; set; }
 
     /// <summary>
     /// 4 bytes

--- a/TRLevelControl/Model/Base/TR1Level.cs
+++ b/TRLevelControl/Model/Base/TR1Level.cs
@@ -60,16 +60,7 @@ public class TR1Level : TRLevelBase
     public List<TRAnimCommand> AnimCommands { get; set; }
     public List<TRMeshTreeNode> MeshTrees { get; set; }
     public List<ushort> Frames { get; set; }
-
-    /// <summary>
-    /// 4 bytes
-    /// </summary>
-    public uint NumModels { get; set; }
-
-    /// <summary>
-    /// NumModels * 18 bytes
-    /// </summary>
-    public TRModel[] Models { get; set; }
+    public List<TRModel> Models { get; set; }
 
     /// <summary>
     /// 4 bytes

--- a/TRLevelControl/Model/TR2/TR2Level.cs
+++ b/TRLevelControl/Model/TR2/TR2Level.cs
@@ -57,65 +57,12 @@ public class TR2Level : TRLevelBase
     /// </summary>
     public uint[] MeshPointers { get; set; }
 
-    /// <summary>
-    /// 4 bytes
-    /// </summary>
-    public uint NumAnimations { get; set; }
-
-    /// <summary>
-    /// NumAnimations * 32 bytes
-    /// </summary>
-    public TRAnimation[] Animations { get; set; }
-
-    /// <summary>
-    /// 4 bytes
-    /// </summary>
-    public uint NumStateChanges { get; set; }
-
-    /// <summary>
-    /// NumStateChanges * 6 bytes
-    /// </summary>
-    public TRStateChange[] StateChanges { get; set; }
-
-    /// <summary>
-    /// 4 bytes
-    /// </summary>
-    public uint NumAnimDispatches { get; set; }
-
-    /// <summary>
-    /// NumAnimDispatches * 8 bytes
-    /// </summary>
-    public TRAnimDispatch[] AnimDispatches { get; set; }
-
-    /// <summary>
-    /// 4 bytes
-    /// </summary>
-    public uint NumAnimCommands { get; set; }
-
-    /// <summary>
-    /// NumAnimCommands * 2 bytes
-    /// </summary>
-    public TRAnimCommand[] AnimCommands { get; set; }
-
-    /// <summary>
-    /// 4 bytes
-    /// </summary>
-    public uint NumMeshTrees { get; set; }
-
-    /// <summary>
-    /// NumMeshTrees * 4 bytes
-    /// </summary>
-    public TRMeshTreeNode[] MeshTrees { get; set; }
-
-    /// <summary>
-    /// 4 bytes
-    /// </summary>
-    public uint NumFrames { get; set; }
-
-    /// <summary>
-    /// NumFrames * 2 bytes
-    /// </summary>
-    public ushort[] Frames { get; set; }
+    public List<TRAnimation> Animations { get; set; }
+    public List<TRStateChange> StateChanges { get; set; }
+    public List<TRAnimDispatch> AnimDispatches { get; set; }
+    public List<TRAnimCommand> AnimCommands { get; set; }
+    public List<TRMeshTreeNode> MeshTrees { get; set; }
+    public List<ushort> Frames { get; set; }
 
     /// <summary>
     /// 4 bytes

--- a/TRLevelControl/Model/TR2/TR2Level.cs
+++ b/TRLevelControl/Model/TR2/TR2Level.cs
@@ -63,16 +63,7 @@ public class TR2Level : TRLevelBase
     public List<TRAnimCommand> AnimCommands { get; set; }
     public List<TRMeshTreeNode> MeshTrees { get; set; }
     public List<ushort> Frames { get; set; }
-
-    /// <summary>
-    /// 4 bytes
-    /// </summary>
-    public uint NumModels { get; set; }
-
-    /// <summary>
-    /// NumModels * 18 bytes
-    /// </summary>
-    public TRModel[] Models { get; set; }
+    public List<TRModel> Models { get; set; }
 
     /// <summary>
     /// 4 bytes

--- a/TRLevelControl/Model/TR3/TR3Level.cs
+++ b/TRLevelControl/Model/TR3/TR3Level.cs
@@ -57,65 +57,12 @@ public class TR3Level : TRLevelBase
     /// </summary>
     public uint[] MeshPointers { get; set; }
 
-    /// <summary>
-    /// 4 bytes
-    /// </summary>
-    public uint NumAnimations { get; set; }
-
-    /// <summary>
-    /// NumAnimations * 32 bytes
-    /// </summary>
-    public TRAnimation[] Animations { get; set; }
-
-    /// <summary>
-    /// 4 bytes
-    /// </summary>
-    public uint NumStateChanges { get; set; }
-
-    /// <summary>
-    /// NumStateChanges * 6 bytes
-    /// </summary>
-    public TRStateChange[] StateChanges { get; set; }
-
-    /// <summary>
-    /// 4 bytes
-    /// </summary>
-    public uint NumAnimDispatches { get; set; }
-
-    /// <summary>
-    /// NumAnimDispatches * 8 bytes
-    /// </summary>
-    public TRAnimDispatch[] AnimDispatches { get; set; }
-
-    /// <summary>
-    /// 4 bytes
-    /// </summary>
-    public uint NumAnimCommands { get; set; }
-
-    /// <summary>
-    /// NumAnimCommands * 2 bytes
-    /// </summary>
-    public TRAnimCommand[] AnimCommands { get; set; }
-
-    /// <summary>
-    /// 4 bytes
-    /// </summary>
-    public uint NumMeshTrees { get; set; }
-
-    /// <summary>
-    /// NumMeshTrees * 4 bytes
-    /// </summary>
-    public TRMeshTreeNode[] MeshTrees { get; set; }
-
-    /// <summary>
-    /// 4 bytes
-    /// </summary>
-    public uint NumFrames { get; set; }
-
-    /// <summary>
-    /// NumFrames * 2 bytes
-    /// </summary>
-    public ushort[] Frames { get; set; }
+    public List<TRAnimation> Animations { get; set; }
+    public List<TRStateChange> StateChanges { get; set; }
+    public List<TRAnimDispatch> AnimDispatches { get; set; }
+    public List<TRAnimCommand> AnimCommands { get; set; }
+    public List<TRMeshTreeNode> MeshTrees { get; set; }
+    public List<ushort> Frames { get; set; }
 
     /// <summary>
     /// 4 bytes

--- a/TRLevelControl/Model/TR3/TR3Level.cs
+++ b/TRLevelControl/Model/TR3/TR3Level.cs
@@ -63,16 +63,7 @@ public class TR3Level : TRLevelBase
     public List<TRAnimCommand> AnimCommands { get; set; }
     public List<TRMeshTreeNode> MeshTrees { get; set; }
     public List<ushort> Frames { get; set; }
-
-    /// <summary>
-    /// 4 bytes
-    /// </summary>
-    public uint NumModels { get; set; }
-
-    /// <summary>
-    /// NumModels * 18 bytes
-    /// </summary>
-    public TRModel[] Models { get; set; }
+    public List<TRModel> Models { get; set; }
 
     /// <summary>
     /// 4 bytes

--- a/TRLevelControl/Model/TR4/TR4LevelDataChunk.cs
+++ b/TRLevelControl/Model/TR4/TR4LevelDataChunk.cs
@@ -35,10 +35,7 @@ public class TR4LevelDataChunk : ISerializableCompact
     public List<TRAnimCommand> AnimCommands { get; set; }
     public List<TRMeshTreeNode> MeshTrees { get; set; }
     public List<ushort> Frames { get; set; }
-
-    public uint NumModels { get; set; }
-
-    public TRModel[] Models { get; set; }
+    public List<TRModel> Models { get; set; }
 
     public uint NumStaticMeshes { get; set; }
 
@@ -179,8 +176,7 @@ public class TR4LevelDataChunk : ISerializableCompact
                 writer.Write(frame);
             }
 
-            writer.Write(NumModels);
-
+            writer.Write((uint)Models.Count);
             foreach (TRModel model in Models)
             {
                 writer.Write(model.Serialize());

--- a/TRLevelControl/Model/TR4/TR4LevelDataChunk.cs
+++ b/TRLevelControl/Model/TR4/TR4LevelDataChunk.cs
@@ -29,29 +29,12 @@ public class TR4LevelDataChunk : ISerializableCompact
 
     public uint[] MeshPointers { get; set; }
 
-    public uint NumAnimations { get; set; }
-
-    public TR4Animation[] Animations { get; set; }
-
-    public uint NumStateChanges { get; set; }
-
-    public TRStateChange[] StateChanges { get; set; }
-
-    public uint NumAnimDispatches { get; set; }
-
-    public TRAnimDispatch[] AnimDispatches { get; set; }
-
-    public uint NumAnimCommands { get; set; }
-
-    public TRAnimCommand[] AnimCommands { get; set; }
-
-    public uint NumMeshTrees { get; set; }
-
-    public TRMeshTreeNode[] MeshTrees { get; set; }
-
-    public uint NumFrames { get; set; }
-
-    public ushort[] Frames { get; set; }
+    public List<TR4Animation> Animations { get; set; }
+    public List<TRStateChange> StateChanges { get; set; }
+    public List<TRAnimDispatch> AnimDispatches { get; set; }
+    public List<TRAnimCommand> AnimCommands { get; set; }
+    public List<TRMeshTreeNode> MeshTrees { get; set; }
+    public List<ushort> Frames { get; set; }
 
     public uint NumModels { get; set; }
 
@@ -160,43 +143,37 @@ public class TR4LevelDataChunk : ISerializableCompact
                 writer.Write(data);
             }
 
-            writer.Write(NumAnimations);
-
+            writer.Write((uint)Animations.Count);
             foreach (TR4Animation anim in Animations)
             {
                 writer.Write(anim.Serialize());
             }
 
-            writer.Write(NumStateChanges);
-
+            writer.Write((uint)StateChanges.Count);
             foreach (TRStateChange sc in StateChanges)
             {
                 writer.Write(sc.Serialize());
             }
 
-            writer.Write(NumAnimDispatches);
-
+            writer.Write((uint)AnimDispatches.Count);
             foreach (TRAnimDispatch ad in AnimDispatches)
             {
                 writer.Write(ad.Serialize());
             }
 
-            writer.Write(NumAnimCommands);
-
+            writer.Write((uint)AnimCommands.Count);
             foreach (TRAnimCommand ac in AnimCommands)
             {
                 writer.Write(ac.Serialize());
             }
 
-            writer.Write(NumMeshTrees * 4); //To get the correct number /= 4 is done during read, make sure to reverse it here.
-
+            writer.Write((uint)MeshTrees.Count * 4); //To get the correct number /= 4 is done during read, make sure to reverse it here.
             foreach (TRMeshTreeNode node in MeshTrees)
             {
                 writer.Write(node.Serialize());
             }
 
-            writer.Write(NumFrames);
-
+            writer.Write((uint)Frames.Count);
             foreach (ushort frame in Frames)
             {
                 writer.Write(frame);

--- a/TRLevelControl/Model/TR5/TR5LevelDataChunk.cs
+++ b/TRLevelControl/Model/TR5/TR5LevelDataChunk.cs
@@ -34,10 +34,7 @@ public class TR5LevelDataChunk
     public List<TRAnimCommand> AnimCommands { get; set; }
     public List<TRMeshTreeNode> MeshTrees { get; set; }
     public List<ushort> Frames { get; set; }
-
-    public uint NumModels { get; set; }
-
-    public TR5Model[] Models { get; set; }
+    public List<TR5Model> Models { get; set; }
 
     public uint NumStaticMeshes { get; set; }
 
@@ -178,8 +175,7 @@ public class TR5LevelDataChunk
                 writer.Write(frame);
             }
 
-            writer.Write(NumModels);
-
+            writer.Write((uint)Models.Count);
             foreach (TR5Model model in Models)
             {
                 writer.Write(model.Serialize());

--- a/TRLevelControl/Model/TR5/TR5LevelDataChunk.cs
+++ b/TRLevelControl/Model/TR5/TR5LevelDataChunk.cs
@@ -28,29 +28,12 @@ public class TR5LevelDataChunk
 
     public uint[] MeshPointers { get; set; }
 
-    public uint NumAnimations { get; set; }
-
-    public TR4Animation[] Animations { get; set; }
-
-    public uint NumStateChanges { get; set; }
-
-    public TRStateChange[] StateChanges { get; set; }
-
-    public uint NumAnimDispatches { get; set; }
-
-    public TRAnimDispatch[] AnimDispatches { get; set; }
-
-    public uint NumAnimCommands { get; set; }
-
-    public TRAnimCommand[] AnimCommands { get; set; }
-
-    public uint NumMeshTrees { get; set; }
-
-    public TRMeshTreeNode[] MeshTrees { get; set; }
-
-    public uint NumFrames { get; set; }
-
-    public ushort[] Frames { get; set; }
+    public List<TR4Animation> Animations { get; set; }
+    public List<TRStateChange> StateChanges { get; set; }
+    public List<TRAnimDispatch> AnimDispatches { get; set; }
+    public List<TRAnimCommand> AnimCommands { get; set; }
+    public List<TRMeshTreeNode> MeshTrees { get; set; }
+    public List<ushort> Frames { get; set; }
 
     public uint NumModels { get; set; }
 
@@ -159,43 +142,37 @@ public class TR5LevelDataChunk
                 writer.Write(data);
             }
 
-            writer.Write(NumAnimations);
-
+            writer.Write((uint)Animations.Count);
             foreach (TR4Animation anim in Animations)
             {
                 writer.Write(anim.Serialize());
             }
 
-            writer.Write(NumStateChanges);
-
+            writer.Write((uint)StateChanges.Count);
             foreach (TRStateChange sc in StateChanges)
             {
                 writer.Write(sc.Serialize());
             }
 
-            writer.Write(NumAnimDispatches);
-
+            writer.Write((uint)AnimDispatches.Count);
             foreach (TRAnimDispatch ad in AnimDispatches)
             {
                 writer.Write(ad.Serialize());
             }
 
-            writer.Write(NumAnimCommands);
-
+            writer.Write((uint)AnimCommands.Count);
             foreach (TRAnimCommand ac in AnimCommands)
             {
                 writer.Write(ac.Serialize());
             }
 
-            writer.Write(NumMeshTrees * 4); //To get the correct number /= 4 is done during read, make sure to reverse it here.
-
+            writer.Write((uint)MeshTrees.Count * 4); //To get the correct number /= 4 is done during read, make sure to reverse it here.
             foreach (TRMeshTreeNode node in MeshTrees)
             {
                 writer.Write(node.Serialize());
             }
 
-            writer.Write(NumFrames);
-
+            writer.Write((uint)Frames.Count);
             foreach (ushort frame in Frames)
             {
                 writer.Write(frame);

--- a/TRLevelControl/TR4FileReadUtilities.cs
+++ b/TRLevelControl/TR4FileReadUtilities.cs
@@ -174,12 +174,11 @@ internal static class TR4FileReadUtilities
         }
 
         //Models
-        lvl.LevelDataChunk.NumModels = reader.ReadUInt32();
-        lvl.LevelDataChunk.Models = new TRModel[lvl.LevelDataChunk.NumModels];
-
-        for (int i = 0; i < lvl.LevelDataChunk.NumModels; i++)
+        uint numModels = reader.ReadUInt32();
+        lvl.LevelDataChunk.Models = new();
+        for (int i = 0; i < numModels; i++)
         {
-            lvl.LevelDataChunk.Models[i] = TR2FileReadUtilities.ReadModel(reader);
+            lvl.LevelDataChunk.Models.Add(TR2FileReadUtilities.ReadModel(reader));
         }
     }
 

--- a/TRLevelControl/TR4FileReadUtilities.cs
+++ b/TRLevelControl/TR4FileReadUtilities.cs
@@ -123,55 +123,54 @@ internal static class TR4FileReadUtilities
     public static void PopulateAnimations(BinaryReader reader, TR4Level lvl)
     {
         //Animations
-        lvl.LevelDataChunk.NumAnimations = reader.ReadUInt32();
-        lvl.LevelDataChunk.Animations = new TR4Animation[lvl.LevelDataChunk.NumAnimations];
-        for (int i = 0; i < lvl.LevelDataChunk.NumAnimations; i++)
+        uint numAnimations = reader.ReadUInt32();
+        lvl.LevelDataChunk.Animations = new();
+        for (int i = 0; i < numAnimations; i++)
         {
-            lvl.LevelDataChunk.Animations[i] = TR4FileReadUtilities.ReadAnimation(reader);
+            lvl.LevelDataChunk.Animations.Add(ReadAnimation(reader));
         }
 
         //State Changes
-        lvl.LevelDataChunk.NumStateChanges = reader.ReadUInt32();
-        lvl.LevelDataChunk.StateChanges = new TRStateChange[lvl.LevelDataChunk.NumStateChanges];
-        for (int i = 0; i < lvl.LevelDataChunk.NumStateChanges; i++)
+        uint numStateChanges = reader.ReadUInt32();
+        lvl.LevelDataChunk.StateChanges = new();
+        for (int i = 0; i < numStateChanges; i++)
         {
-            lvl.LevelDataChunk.StateChanges[i] = TR2FileReadUtilities.ReadStateChange(reader);
+            lvl.LevelDataChunk.StateChanges.Add(TR2FileReadUtilities.ReadStateChange(reader));
         }
 
         //Animation Dispatches
-        lvl.LevelDataChunk.NumAnimDispatches = reader.ReadUInt32();
-        lvl.LevelDataChunk.AnimDispatches = new TRAnimDispatch[lvl.LevelDataChunk.NumAnimDispatches];
-        for (int i = 0; i < lvl.LevelDataChunk.NumAnimDispatches; i++)
+        uint numAnimDispatches = reader.ReadUInt32();
+        lvl.LevelDataChunk.AnimDispatches = new();
+        for (int i = 0; i < numAnimDispatches; i++)
         {
-            lvl.LevelDataChunk.AnimDispatches[i] = TR2FileReadUtilities.ReadAnimDispatch(reader);
+            lvl.LevelDataChunk.AnimDispatches.Add(TR2FileReadUtilities.ReadAnimDispatch(reader));
         }
 
         //Animation Commands
-        lvl.LevelDataChunk.NumAnimCommands = reader.ReadUInt32();
-        lvl.LevelDataChunk.AnimCommands = new TRAnimCommand[lvl.LevelDataChunk.NumAnimCommands];
-        for (int i = 0; i < lvl.LevelDataChunk.NumAnimCommands; i++)
+        uint numAnimCommands = reader.ReadUInt32();
+        lvl.LevelDataChunk.AnimCommands = new();
+        for (int i = 0; i < numAnimCommands; i++)
         {
-            lvl.LevelDataChunk.AnimCommands[i] = TR2FileReadUtilities.ReadAnimCommand(reader);
+            lvl.LevelDataChunk.AnimCommands.Add(TR2FileReadUtilities.ReadAnimCommand(reader));
         }
     }
 
     public static void PopulateMeshTreesFramesModels(BinaryReader reader, TR4Level lvl)
     {
         //Mesh Trees
-        lvl.LevelDataChunk.NumMeshTrees = reader.ReadUInt32();
-        lvl.LevelDataChunk.NumMeshTrees /= 4;
-        lvl.LevelDataChunk.MeshTrees = new TRMeshTreeNode[lvl.LevelDataChunk.NumMeshTrees];
-        for (int i = 0; i < lvl.LevelDataChunk.NumMeshTrees; i++)
+        uint numMeshTrees = reader.ReadUInt32() / 4;
+        lvl.LevelDataChunk.MeshTrees = new();
+        for (int i = 0; i < numMeshTrees; i++)
         {
-            lvl.LevelDataChunk.MeshTrees[i] = TR2FileReadUtilities.ReadMeshTreeNode(reader);
+            lvl.LevelDataChunk.MeshTrees.Add(TR2FileReadUtilities.ReadMeshTreeNode(reader));
         }
 
         //Frames
-        lvl.LevelDataChunk.NumFrames = reader.ReadUInt32();
-        lvl.LevelDataChunk.Frames = new ushort[lvl.LevelDataChunk.NumFrames];
-        for (int i = 0; i < lvl.LevelDataChunk.NumFrames; i++)
+        uint numFrames = reader.ReadUInt32();
+        lvl.LevelDataChunk.Frames = new();
+        for (int i = 0; i < numFrames; i++)
         {
-            lvl.LevelDataChunk.Frames[i] = reader.ReadUInt16();
+            lvl.LevelDataChunk.Frames.Add(reader.ReadUInt16());
         }
 
         //Models

--- a/TRLevelControl/TR5FileReadUtilities.cs
+++ b/TRLevelControl/TR5FileReadUtilities.cs
@@ -240,55 +240,54 @@ internal static class TR5FileReadUtilities
     public static void PopulateAnimations(BinaryReader reader, TR5Level lvl)
     {
         //Animations
-        lvl.LevelDataChunk.NumAnimations = reader.ReadUInt32();
-        lvl.LevelDataChunk.Animations = new TR4Animation[lvl.LevelDataChunk.NumAnimations];
-        for (int i = 0; i < lvl.LevelDataChunk.NumAnimations; i++)
+        uint numAnimations = reader.ReadUInt32();
+        lvl.LevelDataChunk.Animations = new();
+        for (int i = 0; i < numAnimations; i++)
         {
-            lvl.LevelDataChunk.Animations[i] = TR4FileReadUtilities.ReadAnimation(reader);
+            lvl.LevelDataChunk.Animations.Add(TR4FileReadUtilities.ReadAnimation(reader));
         }
 
         //State Changes
-        lvl.LevelDataChunk.NumStateChanges = reader.ReadUInt32();
-        lvl.LevelDataChunk.StateChanges = new TRStateChange[lvl.LevelDataChunk.NumStateChanges];
-        for (int i = 0; i < lvl.LevelDataChunk.NumStateChanges; i++)
+        uint numStateChanges = reader.ReadUInt32();
+        lvl.LevelDataChunk.StateChanges = new();
+        for (int i = 0; i < numStateChanges; i++)
         {
-            lvl.LevelDataChunk.StateChanges[i] = TR2FileReadUtilities.ReadStateChange(reader);
+            lvl.LevelDataChunk.StateChanges.Add(TR2FileReadUtilities.ReadStateChange(reader));
         }
 
         //Animation Dispatches
-        lvl.LevelDataChunk.NumAnimDispatches = reader.ReadUInt32();
-        lvl.LevelDataChunk.AnimDispatches = new TRAnimDispatch[lvl.LevelDataChunk.NumAnimDispatches];
-        for (int i = 0; i < lvl.LevelDataChunk.NumAnimDispatches; i++)
+        uint numAnimDispatches = reader.ReadUInt32();
+        lvl.LevelDataChunk.AnimDispatches = new();
+        for (int i = 0; i < numAnimDispatches; i++)
         {
-            lvl.LevelDataChunk.AnimDispatches[i] = TR2FileReadUtilities.ReadAnimDispatch(reader);
+            lvl.LevelDataChunk.AnimDispatches.Add(TR2FileReadUtilities.ReadAnimDispatch(reader));
         }
 
         //Animation Commands
-        lvl.LevelDataChunk.NumAnimCommands = reader.ReadUInt32();
-        lvl.LevelDataChunk.AnimCommands = new TRAnimCommand[lvl.LevelDataChunk.NumAnimCommands];
-        for (int i = 0; i < lvl.LevelDataChunk.NumAnimCommands; i++)
+        uint numAnimCommands = reader.ReadUInt32();
+        lvl.LevelDataChunk.AnimCommands = new();
+        for (int i = 0; i < numAnimCommands; i++)
         {
-            lvl.LevelDataChunk.AnimCommands[i] = TR2FileReadUtilities.ReadAnimCommand(reader);
+            lvl.LevelDataChunk.AnimCommands.Add(TR2FileReadUtilities.ReadAnimCommand(reader));
         }
     }
 
     public static void PopulateMeshTreesFramesModels(BinaryReader reader, TR5Level lvl)
     {
         //Mesh Trees
-        lvl.LevelDataChunk.NumMeshTrees = reader.ReadUInt32();
-        lvl.LevelDataChunk.NumMeshTrees /= 4;
-        lvl.LevelDataChunk.MeshTrees = new TRMeshTreeNode[lvl.LevelDataChunk.NumMeshTrees];
-        for (int i = 0; i < lvl.LevelDataChunk.NumMeshTrees; i++)
+        uint numMeshTrees = reader.ReadUInt32() / 4;
+        lvl.LevelDataChunk.MeshTrees = new();
+        for (int i = 0; i < numMeshTrees; i++)
         {
-            lvl.LevelDataChunk.MeshTrees[i] = TR2FileReadUtilities.ReadMeshTreeNode(reader);
+            lvl.LevelDataChunk.MeshTrees.Add(TR2FileReadUtilities.ReadMeshTreeNode(reader));
         }
 
         //Frames
-        lvl.LevelDataChunk.NumFrames = reader.ReadUInt32();
-        lvl.LevelDataChunk.Frames = new ushort[lvl.LevelDataChunk.NumFrames];
-        for (int i = 0; i < lvl.LevelDataChunk.NumFrames; i++)
+        uint numFrames = reader.ReadUInt32();
+        lvl.LevelDataChunk.Frames = new();
+        for (int i = 0; i < numFrames; i++)
         {
-            lvl.LevelDataChunk.Frames[i] = reader.ReadUInt16();
+            lvl.LevelDataChunk.Frames.Add(reader.ReadUInt16());
         }
 
         //Models

--- a/TRLevelControl/TR5FileReadUtilities.cs
+++ b/TRLevelControl/TR5FileReadUtilities.cs
@@ -291,12 +291,11 @@ internal static class TR5FileReadUtilities
         }
 
         //Models
-        lvl.LevelDataChunk.NumModels = reader.ReadUInt32();
-        lvl.LevelDataChunk.Models = new TR5Model[lvl.LevelDataChunk.NumModels];
-
-        for (int i = 0; i < lvl.LevelDataChunk.NumModels; i++)
+        uint numModels = reader.ReadUInt32();
+        lvl.LevelDataChunk.Models = new();
+        for (int i = 0; i < numModels; i++)
         {
-            lvl.LevelDataChunk.Models[i] = ReadTR5Model(reader);
+            lvl.LevelDataChunk.Models.Add(ReadTR5Model(reader));
         }
     }
 

--- a/TRLevelToolset/Controls/DataControls/TR/TRAnimationControl.cs
+++ b/TRLevelToolset/Controls/DataControls/TR/TRAnimationControl.cs
@@ -10,12 +10,12 @@ internal class TRANimationControl : IDrawable
     {
         if (ImGui.TreeNodeEx("Animations Data", ImGuiTreeNodeFlags.OpenOnArrow))
         {
-            ImGui.Text("Animations count: " + IOManager.CurrentLevelAsTR1?.NumAnimations);
-            ImGui.Text("State change count: " + IOManager.CurrentLevelAsTR1?.NumStateChanges);
-            ImGui.Text("Animation dispatch count: " + IOManager.CurrentLevelAsTR1?.NumAnimations);
-            ImGui.Text("Animation command count: " + IOManager.CurrentLevelAsTR1?.NumAnimCommands);
-            ImGui.Text("Mesh tree count: " + IOManager.CurrentLevelAsTR1?.NumMeshTrees);
-            ImGui.Text("Total frames count: " + IOManager.CurrentLevelAsTR1?.NumFrames);
+            ImGui.Text("Animations count: " + IOManager.CurrentLevelAsTR1?.Animations.Count);
+            ImGui.Text("State change count: " + IOManager.CurrentLevelAsTR1?.StateChanges.Count);
+            ImGui.Text("Animation dispatch count: " + IOManager.CurrentLevelAsTR1?.Animations.Count);
+            ImGui.Text("Animation command count: " + IOManager.CurrentLevelAsTR1?.AnimCommands.Count);
+            ImGui.Text("Mesh tree count: " + IOManager.CurrentLevelAsTR1?.MeshTrees.Count);
+            ImGui.Text("Total frames count: " + IOManager.CurrentLevelAsTR1?.Frames.Count);
 
             ImGui.TreePop();
         }

--- a/TRLevelToolset/Controls/DataControls/TR/TRModelControl.cs
+++ b/TRLevelToolset/Controls/DataControls/TR/TRModelControl.cs
@@ -10,7 +10,7 @@ internal class TRModelControl : IDrawable
     {
         if (ImGui.TreeNodeEx("Model Data", ImGuiTreeNodeFlags.OpenOnArrow))
         {
-            ImGui.Text("Model count: " + IOManager.CurrentLevelAsTR1?.NumModels);
+            ImGui.Text("Model count: " + IOManager.CurrentLevelAsTR1?.Models.Count);
 
             ImGui.TreePop();
         }

--- a/TRModelTransporter/Handlers/Animations/AnimationTransportHandler.cs
+++ b/TRModelTransporter/Handlers/Animations/AnimationTransportHandler.cs
@@ -132,16 +132,12 @@ public class AnimationTransportHandler
         bool firstAnimationConfigured = false;
         Dictionary<int, int> indexMap = new();
 
-        List<TRAnimDispatch> animDispatches = level.AnimDispatches.ToList();
-        List<TRStateChange> stateChanges = level.StateChanges.ToList();
-        List<TRAnimCommand> animCommands = level.AnimCommands.ToList();
-
         foreach (int oldAnimationIndex in animations.Keys)
         {
             TR2PackedAnimation packedAnimation = animations[oldAnimationIndex];
-            AnimationUtilities.UnpackStateChanges(animDispatches, stateChanges, packedAnimation);
+            AnimationUtilities.UnpackStateChanges(level.AnimDispatches, level.StateChanges, packedAnimation);
             AnimationUtilities.UnpackAnimSounds(level, packedAnimation);
-            AnimationUtilities.UnpackAnimCommands(animCommands, packedAnimation);
+            AnimationUtilities.UnpackAnimCommands(level.AnimCommands, packedAnimation);
 
             int newAnimationIndex = AnimationUtilities.UnpackAnimation(level, packedAnimation);
             indexMap[oldAnimationIndex] = newAnimationIndex;
@@ -152,15 +148,6 @@ public class AnimationTransportHandler
                 firstAnimationConfigured = true;
             }
         }
-
-        level.AnimDispatches = animDispatches.ToArray();
-        level.NumAnimDispatches = (uint)animDispatches.Count;
-
-        level.StateChanges = stateChanges.ToArray();
-        level.NumStateChanges = (uint)stateChanges.Count;
-
-        level.AnimCommands = animCommands.ToArray();
-        level.NumAnimCommands = (uint)animCommands.Count;
 
         foreach (TR2PackedAnimation packedAnimation in animations.Values)
         {

--- a/TRModelTransporter/Handlers/Animations/AnimationTransportHandler.cs
+++ b/TRModelTransporter/Handlers/Animations/AnimationTransportHandler.cs
@@ -174,16 +174,12 @@ public class AnimationTransportHandler
         bool firstAnimationConfigured = false;
         Dictionary<int, int> indexMap = new();
 
-        List<TRAnimDispatch> animDispatches = level.AnimDispatches.ToList();
-        List<TRStateChange> stateChanges = level.StateChanges.ToList();
-        List<TRAnimCommand> animCommands = level.AnimCommands.ToList();
-
         foreach (int oldAnimationIndex in animations.Keys)
         {
             TR3PackedAnimation packedAnimation = animations[oldAnimationIndex];
-            AnimationUtilities.UnpackStateChanges(animDispatches, stateChanges, packedAnimation);
+            AnimationUtilities.UnpackStateChanges(level.AnimDispatches, level.StateChanges, packedAnimation);
             AnimationUtilities.UnpackAnimSounds(level, packedAnimation);
-            AnimationUtilities.UnpackAnimCommands(animCommands, packedAnimation);
+            AnimationUtilities.UnpackAnimCommands(level.AnimCommands, packedAnimation);
 
             int newAnimationIndex = AnimationUtilities.UnpackAnimation(level, packedAnimation);
             indexMap[oldAnimationIndex] = newAnimationIndex;
@@ -194,15 +190,6 @@ public class AnimationTransportHandler
                 firstAnimationConfigured = true;
             }
         }
-
-        level.AnimDispatches = animDispatches.ToArray();
-        level.NumAnimDispatches = (uint)animDispatches.Count;
-
-        level.StateChanges = stateChanges.ToArray();
-        level.NumStateChanges = (uint)stateChanges.Count;
-
-        level.AnimCommands = animCommands.ToArray();
-        level.NumAnimCommands = (uint)animCommands.Count;
 
         foreach (TR3PackedAnimation packedAnimation in animations.Values)
         {

--- a/TRModelTransporter/Handlers/Animations/AnimationTransportHandler.cs
+++ b/TRModelTransporter/Handlers/Animations/AnimationTransportHandler.cs
@@ -90,16 +90,12 @@ public class AnimationTransportHandler
         bool firstAnimationConfigured = false;
         Dictionary<int, int> indexMap = new();
 
-        List<TRAnimDispatch> animDispatches = level.AnimDispatches.ToList();
-        List<TRStateChange> stateChanges = level.StateChanges.ToList();
-        List<TRAnimCommand> animCommands = level.AnimCommands.ToList();
-
         foreach (int oldAnimationIndex in animations.Keys)
         {
             TR1PackedAnimation packedAnimation = animations[oldAnimationIndex];
-            AnimationUtilities.UnpackStateChanges(animDispatches, stateChanges, packedAnimation);
+            AnimationUtilities.UnpackStateChanges(level.AnimDispatches, level.StateChanges, packedAnimation);
             AnimationUtilities.UnpackAnimSounds(level, packedAnimation);
-            AnimationUtilities.UnpackAnimCommands(animCommands, packedAnimation);
+            AnimationUtilities.UnpackAnimCommands(level.AnimCommands, packedAnimation);
 
             int newAnimationIndex = AnimationUtilities.UnpackAnimation(level, packedAnimation);
             indexMap[oldAnimationIndex] = newAnimationIndex;
@@ -110,15 +106,6 @@ public class AnimationTransportHandler
                 firstAnimationConfigured = true;
             }
         }
-
-        level.AnimDispatches = animDispatches.ToArray();
-        level.NumAnimDispatches = (uint)animDispatches.Count;
-
-        level.StateChanges = stateChanges.ToArray();
-        level.NumStateChanges = (uint)stateChanges.Count;
-
-        level.AnimCommands = animCommands.ToArray();
-        level.NumAnimCommands = (uint)animCommands.Count;
 
         // Re-map the NextAnimations of each of the animation and dispatches
         // now we know the indices of each of the newly inserted animations.

--- a/TRModelTransporter/Handlers/Animations/AnimationUtilities.cs
+++ b/TRModelTransporter/Handlers/Animations/AnimationUtilities.cs
@@ -14,7 +14,7 @@ public static class AnimationUtilities
 
     public static int GetModelAnimationCount(TR2Level level, TRModel model)
     {
-        return GetModelAnimationCount(level.Models, model, level.NumAnimations);
+        return GetModelAnimationCount(level.Models, model, (uint)level.Animations.Count);
     }
 
     public static int GetModelAnimationCount(TR3Level level, TRModel model)
@@ -485,12 +485,8 @@ public static class AnimationUtilities
 
     public static int UnpackAnimation(TR2Level level, TR2PackedAnimation animation)
     {
-        List<TRAnimation> levelAnimations = level.Animations.ToList();
-        levelAnimations.Add(animation.Animation);
-        level.Animations = levelAnimations.ToArray();
-        level.NumAnimations++;
-
-        return levelAnimations.Count - 1;
+        level.Animations.Add(animation.Animation);
+        return level.Animations.Count - 1;
     }
 
     public static int UnpackAnimation(TR3Level level, TR3PackedAnimation animation)
@@ -516,12 +512,8 @@ public static class AnimationUtilities
 
     public static void ImportAnimationFrames(TR2Level level, TR2ModelDefinition definition)
     {
-        List<ushort> levelFrames = level.Frames.ToList();
-        definition.Model.FrameOffset = (uint)levelFrames.Count * 2;
-
-        levelFrames.AddRange(definition.AnimationFrames);
-        level.Frames = levelFrames.ToArray();
-        level.NumFrames = (uint)levelFrames.Count;
+        definition.Model.FrameOffset = (uint)level.Frames.Count * 2;
+        level.Frames.AddRange(definition.AnimationFrames);
 
         foreach (TR2PackedAnimation packedAnimation in definition.Animations.Values)
         {

--- a/TRModelTransporter/Handlers/Animations/AnimationUtilities.cs
+++ b/TRModelTransporter/Handlers/Animations/AnimationUtilities.cs
@@ -9,7 +9,7 @@ public static class AnimationUtilities
 {
     public static int GetModelAnimationCount(TR1Level level, TRModel model)
     {
-        return GetModelAnimationCount(level.Models, model, level.NumAnimations);
+        return GetModelAnimationCount(level.Models, model, (uint)level.Animations.Count);
     }
 
     public static int GetModelAnimationCount(TR2Level level, TRModel model)
@@ -108,15 +108,15 @@ public static class AnimationUtilities
 
     public static void PackAnimCommands(TR2Level level, TRAnimation animation, TR2PackedAnimation packedAnimation)
     {
-        packedAnimation.Commands = PackAnimCommands(level.AnimCommands, animation);
+        packedAnimation.Commands = PackAnimCommands(level.AnimCommands.ToList(), animation);
     }
 
     public static void PackAnimCommands(TR3Level level, TRAnimation animation, TR3PackedAnimation packedAnimation)
     {
-        packedAnimation.Commands = PackAnimCommands(level.AnimCommands, animation);
+        packedAnimation.Commands = PackAnimCommands(level.AnimCommands.ToList(), animation);
     }
 
-    private static Dictionary<int, TR1PackedAnimationCommand> PackAnimCommands(TRAnimCommand[] animCommands, TRAnimation animation)
+    private static Dictionary<int, TR1PackedAnimationCommand> PackAnimCommands(List<TRAnimCommand> animCommands, TRAnimation animation)
     {
         Dictionary<int, TR1PackedAnimationCommand> cmds = new();
 
@@ -266,21 +266,21 @@ public static class AnimationUtilities
 
     public static ushort[] GetAnimationFrames(TR2Level level, TRModel model)
     {
-        return GetAnimationFrames(model, level.Models, level.Frames);
+        return GetAnimationFrames(model, level.Models, level.Frames.ToList());
     }
 
     public static ushort[] GetAnimationFrames(TR3Level level, TRModel model)
     {
-        return GetAnimationFrames(model, level.Models, level.Frames);
+        return GetAnimationFrames(model, level.Models, level.Frames.ToList());
     }
 
-    public static ushort[] GetAnimationFrames(TRModel model, TRModel[] allModels, ushort[] allFrames)
+    public static ushort[] GetAnimationFrames(TRModel model, TRModel[] allModels, List<ushort> allFrames)
     {
         int modelIndex = allModels.ToList().IndexOf(model);
         uint endFrame = 0;
         if (modelIndex == allModels.Length - 1)
         {
-            endFrame = (uint)allFrames.Length;
+            endFrame = (uint)allFrames.Count;
         }
         else
         {
@@ -291,7 +291,7 @@ public static class AnimationUtilities
         }
 
         List<ushort> frames = new();
-        for (uint i = model.FrameOffset / 2; i < endFrame; i++)
+        for (int i = (int)model.FrameOffset / 2; i < endFrame; i++)
         {
             frames.Add(allFrames[i]);
         }
@@ -479,12 +479,8 @@ public static class AnimationUtilities
 
     public static int UnpackAnimation(TR1Level level, TR1PackedAnimation animation)
     {
-        List<TRAnimation> levelAnimations = level.Animations.ToList();
-        levelAnimations.Add(animation.Animation);
-        level.Animations = levelAnimations.ToArray();
-        level.NumAnimations++;
-
-        return levelAnimations.Count - 1;
+        level.Animations.Add(animation.Animation);
+        return level.Animations.Count - 1;
     }
 
     public static int UnpackAnimation(TR2Level level, TR2PackedAnimation animation)
@@ -509,12 +505,8 @@ public static class AnimationUtilities
 
     public static void ImportAnimationFrames(TR1Level level, TR1ModelDefinition definition)
     {
-        List<ushort> levelFrames = level.Frames.ToList();
-        definition.Model.FrameOffset = (uint)levelFrames.Count * 2;
-
-        levelFrames.AddRange(definition.AnimationFrames);
-        level.Frames = levelFrames.ToArray();
-        level.NumFrames = (uint)levelFrames.Count;
+        definition.Model.FrameOffset = (uint)level.Frames.Count * 2;
+        level.Frames.AddRange(definition.AnimationFrames);
 
         foreach (TR1PackedAnimation packedAnimation in definition.Animations.Values)
         {

--- a/TRModelTransporter/Handlers/Animations/AnimationUtilities.cs
+++ b/TRModelTransporter/Handlers/Animations/AnimationUtilities.cs
@@ -9,24 +9,24 @@ public static class AnimationUtilities
 {
     public static int GetModelAnimationCount(TR1Level level, TRModel model)
     {
-        return GetModelAnimationCount(level.Models, model, (uint)level.Animations.Count);
+        return GetModelAnimationCount(level.Models, model, level.Animations.Count);
     }
 
     public static int GetModelAnimationCount(TR2Level level, TRModel model)
     {
-        return GetModelAnimationCount(level.Models, model, (uint)level.Animations.Count);
+        return GetModelAnimationCount(level.Models.ToList(), model, level.Animations.Count);
     }
 
     public static int GetModelAnimationCount(TR3Level level, TRModel model)
     {
-        return GetModelAnimationCount(level.Models, model, (uint)level.Animations.Count);
+        return GetModelAnimationCount(level.Models.ToList(), model, level.Animations.Count);
     }
 
-    public static int GetModelAnimationCount(TRModel[] models, TRModel model, uint totalAnimations)
+    public static int GetModelAnimationCount(List<TRModel> models, TRModel model, int totalAnimations)
     {
         TRModel nextModel = model;
         int modelIndex = models.ToList().IndexOf(model) + 1;
-        while (modelIndex < models.Length)
+        while (modelIndex < models.Count)
         {
             nextModel = models[modelIndex++];
             if (nextModel.Animation != ushort.MaxValue)
@@ -266,25 +266,25 @@ public static class AnimationUtilities
 
     public static ushort[] GetAnimationFrames(TR2Level level, TRModel model)
     {
-        return GetAnimationFrames(model, level.Models, level.Frames.ToList());
+        return GetAnimationFrames(model, level.Models.ToList(), level.Frames.ToList());
     }
 
     public static ushort[] GetAnimationFrames(TR3Level level, TRModel model)
     {
-        return GetAnimationFrames(model, level.Models, level.Frames.ToList());
+        return GetAnimationFrames(model, level.Models.ToList(), level.Frames.ToList());
     }
 
-    public static ushort[] GetAnimationFrames(TRModel model, TRModel[] allModels, List<ushort> allFrames)
+    public static ushort[] GetAnimationFrames(TRModel model, List<TRModel> allModels, List<ushort> allFrames)
     {
         int modelIndex = allModels.ToList().IndexOf(model);
         uint endFrame = 0;
-        if (modelIndex == allModels.Length - 1)
+        if (modelIndex == allModels.Count - 1)
         {
             endFrame = (uint)allFrames.Count;
         }
         else
         {
-            while (endFrame == 0 && modelIndex < allModels.Length)
+            while (endFrame == 0 && modelIndex < allModels.Count)
             {
                 endFrame = allModels[++modelIndex].FrameOffset / 2;
             }

--- a/TRModelTransporter/Handlers/Animations/AnimationUtilities.cs
+++ b/TRModelTransporter/Handlers/Animations/AnimationUtilities.cs
@@ -19,7 +19,7 @@ public static class AnimationUtilities
 
     public static int GetModelAnimationCount(TR3Level level, TRModel model)
     {
-        return GetModelAnimationCount(level.Models, model, level.NumAnimations);
+        return GetModelAnimationCount(level.Models, model, (uint)level.Animations.Count);
     }
 
     public static int GetModelAnimationCount(TRModel[] models, TRModel model, uint totalAnimations)
@@ -491,12 +491,8 @@ public static class AnimationUtilities
 
     public static int UnpackAnimation(TR3Level level, TR3PackedAnimation animation)
     {
-        List<TRAnimation> levelAnimations = level.Animations.ToList();
-        levelAnimations.Add(animation.Animation);
-        level.Animations = levelAnimations.ToArray();
-        level.NumAnimations++;
-
-        return levelAnimations.Count - 1;
+        level.Animations.Add(animation.Animation);
+        return level.Animations.Count - 1;
     }
 
     public static void ImportAnimationFrames(TR1Level level, TR1ModelDefinition definition)
@@ -523,12 +519,8 @@ public static class AnimationUtilities
 
     public static void ImportAnimationFrames(TR3Level level, TR3ModelDefinition definition)
     {
-        List<ushort> levelFrames = level.Frames.ToList();
-        definition.Model.FrameOffset = (uint)levelFrames.Count * 2;
-
-        levelFrames.AddRange(definition.AnimationFrames);
-        level.Frames = levelFrames.ToArray();
-        level.NumFrames = (uint)levelFrames.Count;
+        definition.Model.FrameOffset = (uint)level.Frames.Count * 2;
+        level.Frames.AddRange(definition.AnimationFrames);
 
         foreach (TR3PackedAnimation packedAnimation in definition.Animations.Values)
         {

--- a/TRModelTransporter/Handlers/Animations/AnimationUtilities.cs
+++ b/TRModelTransporter/Handlers/Animations/AnimationUtilities.cs
@@ -14,12 +14,12 @@ public static class AnimationUtilities
 
     public static int GetModelAnimationCount(TR2Level level, TRModel model)
     {
-        return GetModelAnimationCount(level.Models.ToList(), model, level.Animations.Count);
+        return GetModelAnimationCount(level.Models, model, level.Animations.Count);
     }
 
     public static int GetModelAnimationCount(TR3Level level, TRModel model)
     {
-        return GetModelAnimationCount(level.Models.ToList(), model, level.Animations.Count);
+        return GetModelAnimationCount(level.Models, model, level.Animations.Count);
     }
 
     public static int GetModelAnimationCount(List<TRModel> models, TRModel model, int totalAnimations)
@@ -266,17 +266,17 @@ public static class AnimationUtilities
 
     public static ushort[] GetAnimationFrames(TR2Level level, TRModel model)
     {
-        return GetAnimationFrames(model, level.Models.ToList(), level.Frames.ToList());
+        return GetAnimationFrames(model, level.Models, level.Frames.ToList());
     }
 
     public static ushort[] GetAnimationFrames(TR3Level level, TRModel model)
     {
-        return GetAnimationFrames(model, level.Models.ToList(), level.Frames.ToList());
+        return GetAnimationFrames(model, level.Models, level.Frames.ToList());
     }
 
     public static ushort[] GetAnimationFrames(TRModel model, List<TRModel> allModels, List<ushort> allFrames)
     {
-        int modelIndex = allModels.ToList().IndexOf(model);
+        int modelIndex = allModels.IndexOf(model);
         uint endFrame = 0;
         if (modelIndex == allModels.Count - 1)
         {

--- a/TRModelTransporter/Handlers/ModelTransportHandler.cs
+++ b/TRModelTransporter/Handlers/ModelTransportHandler.cs
@@ -85,13 +85,10 @@ public class ModelTransportHandler
 
     public static void Import(TR3Level level, TR3ModelDefinition definition, Dictionary<TR3Type, TR3Type> aliasPriority, IEnumerable<TR3Type> laraDependants, IEnumerable<TR3Type> unsafeReplacements)
     {
-        List<TRModel> levelModels = level.Models.ToList();
-        int i = levelModels.FindIndex(m => m.ID == (short)definition.Entity);
+        int i = level.Models.FindIndex(m => m.ID == (short)definition.Entity);
         if (i == -1)
         {
-            levelModels.Add(definition.Model);
-            level.Models = levelModels.ToArray();
-            level.NumModels++;
+            level.Models.Add(definition.Model);
         }
         else if (!aliasPriority.ContainsKey(definition.Entity) || aliasPriority[definition.Entity] == definition.Alias)
         {
@@ -113,7 +110,7 @@ public class ModelTransportHandler
 
         if (definition.Entity == TR3Type.Lara && laraDependants != null)
         {
-            ReplaceLaraDependants(levelModels, definition.Model, laraDependants.Select(e => (short)e));
+            ReplaceLaraDependants(level.Models, definition.Model, laraDependants.Select(e => (short)e));
         }
     }
 

--- a/TRModelTransporter/Handlers/ModelTransportHandler.cs
+++ b/TRModelTransporter/Handlers/ModelTransportHandler.cs
@@ -60,13 +60,10 @@ public class ModelTransportHandler
 
     public static void Import(TR2Level level, TR2ModelDefinition definition, Dictionary<TR2Type, TR2Type> aliasPriority, IEnumerable<TR2Type> laraDependants)
     {
-        List<TRModel> levelModels = level.Models.ToList();
-        int i = levelModels.FindIndex(m => m.ID == (short)definition.Entity);
+        int i = level.Models.FindIndex(m => m.ID == (short)definition.Entity);
         if (i == -1)
         {
-            levelModels.Add(definition.Model);
-            level.Models = levelModels.ToArray();
-            level.NumModels++;
+            level.Models.Add(definition.Model);
         }
         else if (!aliasPriority.ContainsKey(definition.Entity) || aliasPriority[definition.Entity] == definition.Alias)
         {
@@ -82,7 +79,7 @@ public class ModelTransportHandler
         // their starting mesh and mesh tree indices are just remapped to Lara's.
         if (definition.Entity == TR2Type.Lara && laraDependants != null)
         {
-            ReplaceLaraDependants(levelModels, definition.Model, laraDependants.Select(e => (short)e));
+            ReplaceLaraDependants(level.Models, definition.Model, laraDependants.Select(e => (short)e));
         }
     }
 

--- a/TRModelTransporter/Handlers/ModelTransportHandler.cs
+++ b/TRModelTransporter/Handlers/ModelTransportHandler.cs
@@ -20,9 +20,9 @@ public class ModelTransportHandler
         definition.Model = GetTRModel(level.Models, (short)entity);
     }
 
-    private static TRModel GetTRModel(IEnumerable<TRModel> models, short entityID)
+    private static TRModel GetTRModel(List<TRModel> models, short entityID)
     {
-        TRModel model = models.ToList().Find(m => m.ID == entityID);
+        TRModel model = models.Find(m => m.ID == entityID);
         return model ?? throw new ArgumentException($"The model for {entityID} could not be found.");
     }
 

--- a/TRModelTransporter/Handlers/ModelTransportHandler.cs
+++ b/TRModelTransporter/Handlers/ModelTransportHandler.cs
@@ -28,13 +28,10 @@ public class ModelTransportHandler
 
     public static void Import(TR1Level level, TR1ModelDefinition definition, Dictionary<TR1Type, TR1Type> aliasPriority, IEnumerable<TR1Type> laraDependants)
     {
-        List<TRModel> levelModels = level.Models.ToList();
-        int i = levelModels.FindIndex(m => m.ID == (short)definition.Entity);
+        int i = level.Models.FindIndex(m => m.ID == (short)definition.Entity);
         if (i == -1)
         {
-            levelModels.Add(definition.Model);
-            level.Models = levelModels.ToArray();
-            level.NumModels++;
+            level.Models.Add(definition.Model);
         }
         else if (!aliasPriority.ContainsKey(definition.Entity) || aliasPriority[definition.Entity] == definition.Alias)
         {
@@ -52,11 +49,11 @@ public class ModelTransportHandler
         {
             if (definition.Entity == TR1Type.Lara)
             {
-                ReplaceLaraDependants(levelModels, definition.Model, laraDependants.Select(e => (short)e));
+                ReplaceLaraDependants(level.Models, definition.Model, laraDependants.Select(e => (short)e));
             }
             else if (laraDependants.Contains((TR1Type)definition.Model.ID))
             {
-                ReplaceLaraDependants(levelModels, levelModels.Find(m => m.ID == (uint)TR1Type.Lara), new short[] { (short)definition.Model.ID });
+                ReplaceLaraDependants(level.Models, level.Models.Find(m => m.ID == (uint)TR1Type.Lara), new short[] { (short)definition.Model.ID });
             }
         }
     }

--- a/TRModelTransporter/Handlers/Textures/TR2/TR2TextureImportHandler.cs
+++ b/TRModelTransporter/Handlers/Textures/TR2/TR2TextureImportHandler.cs
@@ -78,7 +78,7 @@ public class TR2TextureImportHandler : AbstractTextureImportHandler<TR2Type, TR2
         if
         (
             _definitions.ToList().FindIndex(d => flameEnemies.Contains(d.Entity)) != -1 ||
-            _level.Models.ToList().FindIndex(m => flameEnemies.Contains((TR2Type)m.ID)) != -1
+            _level.Models.FindIndex(m => flameEnemies.Contains((TR2Type)m.ID)) != -1
         )
         {
             List<TRSpriteSequence> sequences = _level.SpriteSequences.ToList();

--- a/TRModelTransporter/Transport/TR1/TR1ModelExporter.cs
+++ b/TRModelTransporter/Transport/TR1/TR1ModelExporter.cs
@@ -101,17 +101,13 @@ public class TR1ModelExporter : AbstractTRModelExporter<TR1Type, TR1Level, TR1Mo
         TRModel model = Array.Find(level.Models, m => m.ID == (uint)TR1Type.Pierre);
         // Get his shooting animation
         TRAnimation anim = level.Animations[model.Animation + 10];
-        List<TRAnimCommand> cmds = level.AnimCommands.ToList();
-        anim.AnimCommand = (ushort)cmds.Count;
+        anim.AnimCommand = (ushort)level.AnimCommands.Count;
         anim.NumAnimCommands = 1;
 
         // On the 2nd frame, play SFX 44 (magnums)
-        cmds.Add(new TRAnimCommand { Value = 5 });
-        cmds.Add(new TRAnimCommand { Value = (short)(anim.FrameStart + 1) });
-        cmds.Add(new TRAnimCommand { Value = 44 });
-
-        level.AnimCommands = cmds.ToArray();
-        level.NumAnimCommands = (uint)cmds.Count;
+        level.AnimCommands.Add(new() { Value = 5 });
+        level.AnimCommands.Add(new() { Value = (short)(anim.FrameStart + 1) });
+        level.AnimCommands.Add(new() { Value = 44 });
     }
 
     public static void AmendPierreDeath(TR1Level level)
@@ -121,17 +117,13 @@ public class TR1ModelExporter : AbstractTRModelExporter<TR1Type, TR1Level, TR1Mo
         TRAnimation anim = level.Animations[model.Animation + 12];
         anim.NumAnimCommands++;
 
-        List<TRAnimCommand> cmds = level.AnimCommands.ToList();
-        anim.AnimCommand = (ushort)cmds.Count;
-        cmds.Add(new TRAnimCommand { Value = 4 }); // Death
+        anim.AnimCommand = (ushort)level.AnimCommands.Count;
+        level.AnimCommands.Add(new() { Value = 4 }); // Death
 
         // On the 61st frame, play SFX 159 (death)
-        cmds.Add(new TRAnimCommand { Value = 5 });
-        cmds.Add(new TRAnimCommand { Value = (short)(anim.FrameStart + 60) });
-        cmds.Add(new TRAnimCommand { Value = 159 });
-
-        level.AnimCommands = cmds.ToArray();
-        level.NumAnimCommands = (uint)cmds.Count;
+        level.AnimCommands.Add(new() { Value = 5 });
+        level.AnimCommands.Add(new() { Value = (short)(anim.FrameStart + 60) });
+        level.AnimCommands.Add(new() { Value = 159 });
     }
 
     public static void AmendLarsonDeath(TR1Level level)
@@ -141,17 +133,13 @@ public class TR1ModelExporter : AbstractTRModelExporter<TR1Type, TR1Level, TR1Mo
         TRAnimation anim = level.Animations[model.Animation + 15];
         anim.NumAnimCommands++;
 
-        List<TRAnimCommand> cmds = level.AnimCommands.ToList();
-        anim.AnimCommand = (ushort)cmds.Count;
-        cmds.Add(new TRAnimCommand { Value = 4 }); // Death
+        anim.AnimCommand = (ushort)level.AnimCommands.Count;
+        level.AnimCommands.Add(new() { Value = 4 }); // Death
 
         // On the 2nd frame, play SFX 158 (death)
-        cmds.Add(new TRAnimCommand { Value = 5 });
-        cmds.Add(new TRAnimCommand { Value = (short)(anim.FrameStart + 1) });
-        cmds.Add(new TRAnimCommand { Value = 158 });
-
-        level.AnimCommands = cmds.ToArray();
-        level.NumAnimCommands = (uint)cmds.Count;
+        level.AnimCommands.Add(new() { Value = 5 });
+        level.AnimCommands.Add(new() { Value = (short)(anim.FrameStart + 1) });
+        level.AnimCommands.Add(new() { Value = 158 });
     }
 
     public static void AmendSkaterBoyDeath(TR1Level level)
@@ -170,17 +158,13 @@ public class TR1ModelExporter : AbstractTRModelExporter<TR1Type, TR1Level, TR1Mo
         TRAnimation anim = level.Animations[model.Animation + 13];
         anim.NumAnimCommands++;
 
-        List<TRAnimCommand> cmds = level.AnimCommands.ToList();
-        anim.AnimCommand = (ushort)cmds.Count;
-        cmds.Add(new TRAnimCommand { Value = 4 }); // Death
+        anim.AnimCommand = (ushort)level.AnimCommands.Count;
+        level.AnimCommands.Add(new() { Value = 4 }); // Death
 
         // On the 5th frame, play SFX 160 (death)
-        cmds.Add(new TRAnimCommand { Value = 5 });
-        cmds.Add(new TRAnimCommand { Value = (short)(anim.FrameStart + 4) });
-        cmds.Add(new TRAnimCommand { Value = 160 });
-
-        level.AnimCommands = cmds.ToArray();
-        level.NumAnimCommands = (uint)cmds.Count;
+        level.AnimCommands.Add(new() { Value = 5 });
+        level.AnimCommands.Add(new() { Value = (short)(anim.FrameStart + 4) });
+        level.AnimCommands.Add(new() { Value = 160 });
     }
 
     public static void AddMovingBlockSFX(TR1Level level)
@@ -195,22 +179,18 @@ public class TR1ModelExporter : AbstractTRModelExporter<TR1Type, TR1Level, TR1Mo
         }
 
         TRModel model = Array.Find(level.Models, m => m.ID == (uint)TR1Type.MovingBlock);
-        List<TRAnimCommand> cmds = level.AnimCommands.ToList();
         for (int i = 2; i < 4; i++)
         {
             TRAnimation anim = level.Animations[model.Animation + i];
             anim.NumAnimCommands++;
 
-            anim.AnimCommand = (ushort)cmds.Count;
-            cmds.Add(new TRAnimCommand { Value = 4 }); // KillItem
+            anim.AnimCommand = (ushort)level.AnimCommands.Count;
+            level.AnimCommands.Add(new() { Value = 4 }); // KillItem
 
             // On the 1st frame, play SFX 162
-            cmds.Add(new TRAnimCommand { Value = 5 });
-            cmds.Add(new TRAnimCommand { Value = (short)(anim.FrameStart) });
-            cmds.Add(new TRAnimCommand { Value = 162 });
-        }            
-
-        level.AnimCommands = cmds.ToArray();
-        level.NumAnimCommands = (uint)cmds.Count;
+            level.AnimCommands.Add(new() { Value = 5 });
+            level.AnimCommands.Add(new() { Value = (short)anim.FrameStart });
+            level.AnimCommands.Add(new() { Value = 162 });
+        }
     }
 }

--- a/TRModelTransporter/Transport/TR1/TR1ModelExporter.cs
+++ b/TRModelTransporter/Transport/TR1/TR1ModelExporter.cs
@@ -98,7 +98,7 @@ public class TR1ModelExporter : AbstractTRModelExporter<TR1Type, TR1Level, TR1Mo
 
     public static void AmendPierreGunshot(TR1Level level)
     {
-        TRModel model = Array.Find(level.Models, m => m.ID == (uint)TR1Type.Pierre);
+        TRModel model = level.Models.Find(m => m.ID == (uint)TR1Type.Pierre);
         // Get his shooting animation
         TRAnimation anim = level.Animations[model.Animation + 10];
         anim.AnimCommand = (ushort)level.AnimCommands.Count;
@@ -112,7 +112,7 @@ public class TR1ModelExporter : AbstractTRModelExporter<TR1Type, TR1Level, TR1Mo
 
     public static void AmendPierreDeath(TR1Level level)
     {
-        TRModel model = Array.Find(level.Models, m => m.ID == (uint)TR1Type.Pierre);
+        TRModel model = level.Models.Find(m => m.ID == (uint)TR1Type.Pierre);
         // Get his death animation
         TRAnimation anim = level.Animations[model.Animation + 12];
         anim.NumAnimCommands++;
@@ -128,7 +128,7 @@ public class TR1ModelExporter : AbstractTRModelExporter<TR1Type, TR1Level, TR1Mo
 
     public static void AmendLarsonDeath(TR1Level level)
     {
-        TRModel model = Array.Find(level.Models, m => m.ID == (uint)TR1Type.Larson);
+        TRModel model = level.Models.Find(m => m.ID == (uint)TR1Type.Larson);
         // Get his death animation
         TRAnimation anim = level.Animations[model.Animation + 15];
         anim.NumAnimCommands++;
@@ -144,7 +144,7 @@ public class TR1ModelExporter : AbstractTRModelExporter<TR1Type, TR1Level, TR1Mo
 
     public static void AmendSkaterBoyDeath(TR1Level level)
     {
-        TRModel model = Array.Find(level.Models, m => m.ID == (uint)TR1Type.SkateboardKid);
+        TRModel model = level.Models.Find(m => m.ID == (uint)TR1Type.SkateboardKid);
         // Get his death animation
         TRAnimation anim = level.Animations[model.Animation + 13];
         // Play the death sound on the 2nd frame (doesn't work on the 1st, which is OG).
@@ -153,7 +153,7 @@ public class TR1ModelExporter : AbstractTRModelExporter<TR1Type, TR1Level, TR1Mo
 
     public static void AmendNatlaDeath(TR1Level level)
     {
-        TRModel model = Array.Find(level.Models, m => m.ID == (uint)TR1Type.Natla);
+        TRModel model = level.Models.Find(m => m.ID == (uint)TR1Type.Natla);
         // Get her death animation
         TRAnimation anim = level.Animations[model.Animation + 13];
         anim.NumAnimCommands++;
@@ -178,7 +178,7 @@ public class TR1ModelExporter : AbstractTRModelExporter<TR1Type, TR1Level, TR1Mo
             SoundUtilities.ImportLevelSound(level, vilcabamba, new short[] { 162 });
         }
 
-        TRModel model = Array.Find(level.Models, m => m.ID == (uint)TR1Type.MovingBlock);
+        TRModel model = level.Models.Find(m => m.ID == (uint)TR1Type.MovingBlock);
         for (int i = 2; i < 4; i++)
         {
             TRAnimation anim = level.Animations[model.Animation + i];

--- a/TRModelTransporter/Transport/TR1/TR1ModelImporter.cs
+++ b/TRModelTransporter/Transport/TR1/TR1ModelImporter.cs
@@ -33,9 +33,7 @@ public class TR1ModelImporter : AbstractTRModelImporter<TR1Type, TR1Level, TR1Mo
 
     protected override List<TR1Type> GetExistingModelTypes()
     {
-        List<TR1Type> existingEntities = new();
-        Level.Models.ToList().ForEach(m => existingEntities.Add((TR1Type)m.ID));
-        return existingEntities;
+        return Level.Models.Select(m => (TR1Type)m.ID).ToList();
     }
 
     protected override void Import(IEnumerable<TR1ModelDefinition> standardDefinitions, IEnumerable<TR1ModelDefinition> soundOnlyDefinitions)

--- a/TRModelTransporter/Transport/TR2/TR2ModelImporter.cs
+++ b/TRModelTransporter/Transport/TR2/TR2ModelImporter.cs
@@ -21,9 +21,7 @@ public class TR2ModelImporter : AbstractTRModelImporter<TR2Type, TR2Level, TR2Mo
 
     protected override List<TR2Type> GetExistingModelTypes()
     {
-        List<TR2Type> existingEntities = new();
-        Level.Models.ToList().ForEach(m => existingEntities.Add((TR2Type)m.ID));
-        return existingEntities;
+        return Level.Models.Select(m => (TR2Type)m.ID).ToList();
     }
 
     protected override void Import(IEnumerable<TR2ModelDefinition> standardDefinitions, IEnumerable<TR2ModelDefinition> soundOnlyDefinitions)

--- a/TRModelTransporter/Transport/TR3/TR3ModelImporter.cs
+++ b/TRModelTransporter/Transport/TR3/TR3ModelImporter.cs
@@ -22,9 +22,7 @@ public class TR3ModelImporter : AbstractTRModelImporter<TR3Type, TR3Level, TR3Mo
 
     protected override List<TR3Type> GetExistingModelTypes()
     {
-        List<TR3Type> existingEntities = new();
-        Level.Models.ToList().ForEach(m => existingEntities.Add((TR3Type)m.ID));
-        return existingEntities;
+        return Level.Models.Select(m => (TR3Type)m.ID).ToList();
     }
 
     protected override void Import(IEnumerable<TR3ModelDefinition> standardDefinitions, IEnumerable<TR3ModelDefinition> soundOnlyDefinitions)

--- a/TRRandomizerCore/Levels/TR1CombinedLevel.cs
+++ b/TRRandomizerCore/Levels/TR1CombinedLevel.cs
@@ -76,12 +76,6 @@ public class TR1CombinedLevel
 
     public void RemoveModel(TR1Type type)
     {
-        List<TRModel> models = Data.Models.ToList();
-        if (models.Find(m => m.ID == (uint)type) is TRModel model)
-        {
-            models.Remove(model);
-            Data.Models = models.ToArray();
-            Data.NumModels--;
-        }
+        Data.Models.RemoveAll(m => m.ID == (uint)type);
     }
 }

--- a/TRRandomizerCore/Levels/TR3CombinedLevel.cs
+++ b/TRRandomizerCore/Levels/TR3CombinedLevel.cs
@@ -129,12 +129,6 @@ public class TR3CombinedLevel
 
     public void RemoveModel(TR3Type type)
     {
-        List<TRModel> models = Data.Models.ToList();
-        if (models.Find(m => m.ID == (uint)type) is TRModel model)
-        {
-            models.Remove(model);
-            Data.Models = models.ToArray();
-            Data.NumModels--;
-        }
+        Data.Models.RemoveAll(m => m.ID == (uint)type);
     }
 }

--- a/TRRandomizerCore/Processors/TR3/TR3SequenceProcessor.cs
+++ b/TRRandomizerCore/Processors/TR3/TR3SequenceProcessor.cs
@@ -272,14 +272,12 @@ public class TR3SequenceProcessor : TR3LevelProcessor
 
     private void AmendWillardBoss(TR3CombinedLevel level)
     {
-        List<TRModel> models = level.Data.Models.ToList();
-
         // Add new duplicate models for keys, so secret rando doesn't replace the originals.
         foreach (TR3Type artefact in _artefactAssignment.Keys)
         {
             TR3Type replacement = _artefactAssignment[artefact];
-            TRModel artefactModel = models.Find(m => m.ID == (uint)artefact);
-            models.Add(new TRModel
+            TRModel artefactModel = level.Data.Models.Find(m => m.ID == (uint)artefact);
+            level.Data.Models.Add(new()
             {
                 Animation = artefactModel.Animation,
                 FrameOffset = artefactModel.FrameOffset,
@@ -299,9 +297,6 @@ public class TR3SequenceProcessor : TR3LevelProcessor
         {
             level.Script.Keys[i] = ScriptEditor.Script.GameStrings1[80 + i];
         }
-
-        level.Data.Models = models.ToArray();
-        level.Data.NumModels = (uint)models.Count;
 
         // Apply any changes needed for the boss fight
         AmendBossFight(level);

--- a/TRRandomizerCore/Randomizers/TR1/TR1EnemyRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/TR1EnemyRandomizer.cs
@@ -840,7 +840,7 @@ public class TR1EnemyRandomizer : BaseTR1Randomizer
             else if (type == TR1Type.AdamEgg || type == TR1Type.AtlanteanEgg)
             {
                 TR1Type eggType = TR1EnemyUtilities.CodeBitsToAtlantean(entity.CodeBits);
-                if (eggType == translatedType && Array.Find(level.Data.Models, m => m.ID == (uint)eggType) != null)
+                if (eggType == translatedType && level.Data.Models.Find(m => m.ID == (uint)eggType) != null)
                 {
                     count++;
                 }
@@ -871,7 +871,7 @@ public class TR1EnemyRandomizer : BaseTR1Randomizer
 
     private static void AmendToQLarson(TR1CombinedLevel level)
     {
-        TRModel larsonModel = Array.Find(level.Data.Models, m => m.ID == (uint)TR1Type.Larson);
+        TRModel larsonModel = level.Data.Models.Find(m => m.ID == (uint)TR1Type.Larson);
         if (larsonModel != null)
         {
             // Convert the Larson model into the Great Pyramid scion to allow ending the level. Larson will
@@ -944,12 +944,11 @@ public class TR1EnemyRandomizer : BaseTR1Randomizer
         // If non-shooting grounded Atlanteans are present, we can just duplicate the model to make shooting Atlanteans
         if (enemies.Available.Any(TR1TypeUtilities.GetFamily(TR1Type.ShootingAtlantean_N).Contains))
         {
-            List<TRModel> models = level.Data.Models.ToList();
-            TRModel shooter = models.Find(m => m.ID == (uint)TR1Type.ShootingAtlantean_N);
-            TRModel nonShooter = models.Find(m => m.ID == (uint)TR1Type.NonShootingAtlantean_N);
+            TRModel shooter = level.Data.Models.Find(m => m.ID == (uint)TR1Type.ShootingAtlantean_N);
+            TRModel nonShooter = level.Data.Models.Find(m => m.ID == (uint)TR1Type.NonShootingAtlantean_N);
             if (shooter == null && nonShooter != null)
             {
-                models.Add(new TRModel
+                level.Data.Models.Add(new()
                 {
                     ID = (uint)TR1Type.ShootingAtlantean_N,
                     Animation = nonShooter.Animation,
@@ -958,9 +957,6 @@ public class TR1EnemyRandomizer : BaseTR1Randomizer
                     NumMeshes = nonShooter.NumMeshes,
                     StartingMesh = nonShooter.StartingMesh
                 });
-
-                level.Data.Models = models.ToArray();
-                level.Data.NumModels++;
 
                 enemies.Available.Add(TR1Type.ShootingAtlantean_N);
             }
@@ -1071,7 +1067,7 @@ public class TR1EnemyRandomizer : BaseTR1Randomizer
                 };
 
                 // Only include it if the model is present i.e. it's not an empty egg.
-                if (Array.Find(level.Data.Models, m => (TR1Type)m.ID == resultantEnemy.TypeID) != null)
+                if (level.Data.Models.Find(m => (TR1Type)m.ID == resultantEnemy.TypeID) != null)
                 {
                     levelEnemies.Add(resultantEnemy);
                 }
@@ -1329,7 +1325,7 @@ public class TR1EnemyRandomizer : BaseTR1Randomizer
         TR1Entity adamEgg = level.Data.Entities.Find(e => e.TypeID == TR1Type.AdamEgg);
         if (adamEgg != null
             && TR1EnemyUtilities.CodeBitsToAtlantean(adamEgg.CodeBits) == TR1Type.Adam
-            && Array.Find(level.Data.Models, m => m.ID == (uint)TR1Type.Adam) != null)
+            && level.Data.Models.Find(m => m.ID == (uint)TR1Type.Adam) != null)
         {
             enemies.Add(adamEgg);
         }

--- a/TRRandomizerCore/Randomizers/TR1/TR1EnemyRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/TR1EnemyRandomizer.cs
@@ -691,11 +691,7 @@ public class TR1EnemyRandomizer : BaseTR1Randomizer
                     if (Settings.AllowEmptyEggs)
                     {
                         // Add 1/4 chance of an empty egg, provided at least one spawn model is not available
-                        List<TR1Type> allModels = new();
-                        foreach (TRModel model in level.Data.Models)
-                        {
-                            allModels.Add((TR1Type)model.ID);
-                        }
+                        IEnumerable<TR1Type> allModels = level.Data.Models.Select(m => (TR1Type)m.ID);
 
                         // We can add Adam to make it possible for a dud spawn - he's not normally available for eggs because
                         // of his own restrictions.

--- a/TRRandomizerCore/Randomizers/TR1/TR1OutfitRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/TR1OutfitRandomizer.cs
@@ -379,7 +379,7 @@ public class TR1OutfitRandomizer : BaseTR1Randomizer
             TRMesh goldenHips = TRMeshUtilities.GetModelFirstMesh(level.Data, TR1Type.LaraMiscAnim_H);
             ushort goldPalette = goldenHips.ColouredRectangles[0].Texture;
 
-            TRModel ponytail = Array.Find(level.Data.Models, m => m.ID == (uint)TR1Type.LaraPonytail_H_U);
+            TRModel ponytail = level.Data.Models.Find(m => m.ID == (uint)TR1Type.LaraPonytail_H_U);
             TRMesh[] ponytailMeshes = TRMeshUtilities.GetModelMeshes(level.Data, ponytail);
             MeshEditor editor = new();
             foreach (TRMesh mesh in ponytailMeshes)
@@ -717,7 +717,7 @@ public class TR1OutfitRandomizer : BaseTR1Randomizer
                 return false;
             }
 
-            TRModel existingModel = Array.Find(level.Data.Models, m => m.ID == (uint)TR1Type.LaraMiscAnim_H);
+            TRModel existingModel = level.Data.Models.Find(m => m.ID == (uint)TR1Type.LaraMiscAnim_H);
             if (existingModel != null)
             {
                 // If we already have the gym outfit available, we're done.
@@ -750,7 +750,7 @@ public class TR1OutfitRandomizer : BaseTR1Randomizer
                 // e.g. for Adam death animation and scion pickups.
                 if (existingModel != null)
                 {
-                    TRModel newModel = Array.Find(level.Data.Models, m => m.ID == (uint)TR1Type.LaraMiscAnim_H);
+                    TRModel newModel = level.Data.Models.Find(m => m.ID == (uint)TR1Type.LaraMiscAnim_H);
                     newModel.Animation = existingModel.Animation;
                     newModel.FrameOffset = existingModel.FrameOffset;
                 }

--- a/TRRandomizerCore/Randomizers/TR1/TR1OutfitRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/TR1OutfitRandomizer.cs
@@ -388,10 +388,7 @@ public class TR1OutfitRandomizer : BaseTR1Randomizer
                 TRMeshUtilities.InsertMesh(level.Data, clonedMesh);
             }
 
-            List<TRMeshTreeNode> nodes = level.Data.MeshTrees.ToList();
-            nodes.AddRange(TRMeshUtilities.GetModelMeshTrees(level.Data, ponytail));
-            level.Data.MeshTrees = nodes.ToArray();
-            level.Data.NumMeshTrees += ponytail.NumMeshes;
+            level.Data.MeshTrees.AddRange(TRMeshUtilities.GetModelMeshTrees(level.Data, ponytail));
             ponytail.NumMeshes *= 2;
         }
 

--- a/TRRandomizerCore/Randomizers/TR1/TR1SecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/TR1SecretRandomizer.cs
@@ -873,7 +873,6 @@ public class TR1SecretRandomizer : BaseTR1Randomizer, ISecretRandomizer
 
                     importer.Import();
 
-                    List<TRModel> models = level.Data.Models.ToList();
                     List<TRSpriteSequence> sequences = level.Data.SpriteSequences.ToList();
 
                     // Redefine the artefacts as puzzle models
@@ -884,7 +883,7 @@ public class TR1SecretRandomizer : BaseTR1Randomizer, ISecretRandomizer
                         TR1Type puzzleModelType = allocation.AvailablePickupModels.First();
                         TR1Type puzzlePickupType = _modelReplacements[puzzleModelType];
 
-                        models.Find(m => m.ID == (uint)secretModelType).ID = (uint)puzzleModelType;
+                        level.Data.Models.Find(m => m.ID == (uint)secretModelType).ID = (uint)puzzleModelType;
                         sequences.Find(s => s.SpriteID == (int)secretPickupType).SpriteID = (int)puzzlePickupType;
 
                         if (secretModelType == TR1Type.SecretScion_M_H && _outer.Are3DPickupsEnabled())
@@ -907,9 +906,6 @@ public class TR1SecretRandomizer : BaseTR1Randomizer, ISecretRandomizer
                         // Assign a name for the script
                         SetPuzzleTypeName(level, puzzlePickupType, _pickupNames[secretModelType]);
                     }
-
-                    level.Data.Models = models.ToArray();
-                    level.Data.NumModels = (uint)models.Count;
                 }
 
                 if (!_outer.TriggerProgress())

--- a/TRRandomizerCore/Randomizers/TR1/TR1SecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/TR1SecretRandomizer.cs
@@ -837,11 +837,9 @@ public class TR1SecretRandomizer : BaseTR1Randomizer, ISecretRandomizer
 
                 // Work out which models are available to replace as secret pickups.
                 // We exclude current puzzle/key items from the available switching pool.
-                List<TRModel> models = level.Data.Models.ToList();
-
                 foreach (TR1Type puzzleType in _modelReplacements.Keys)
                 {
-                    if (models.Find(m => m.ID == (uint)puzzleType) == null)
+                    if (level.Data.Models.Find(m => m.ID == (uint)puzzleType) == null)
                     {
                         allocation.AvailablePickupModels.Add(puzzleType);
                     }

--- a/TRRandomizerCore/Randomizers/TR2/TR2EnemyRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR2/TR2EnemyRandomizer.cs
@@ -489,19 +489,18 @@ public class TR2EnemyRandomizer : BaseTR2Randomizer
 
     private static void DisguiseEntity(TR2CombinedLevel level, TR2Type guiser, TR2Type targetEntity)
     {
-        List<TRModel> models = level.Data.Models.ToList();
-        int existingIndex = models.FindIndex(m => m.ID == (short)guiser);
+        int existingIndex = level.Data.Models.FindIndex(m => m.ID == (short)guiser);
         if (existingIndex != -1)
         {
-            models.RemoveAt(existingIndex);
+            level.Data.Models.RemoveAt(existingIndex);
         }
 
-        TRModel disguiseAsModel = models[models.FindIndex(m => m.ID == (short)targetEntity)];
+        TRModel disguiseAsModel = level.Data.Models.Find(m => m.ID == (short)targetEntity);
         if (targetEntity == TR2Type.BirdMonster && level.Is(TR2LevelNames.CHICKEN))
         {
             // We have to keep the original model for the boss, so in
             // this instance we just clone the model for the guiser
-            models.Add(new TRModel
+            level.Data.Models.Add(new()
             {
                 Animation = disguiseAsModel.Animation,
                 FrameOffset = disguiseAsModel.FrameOffset,
@@ -515,9 +514,6 @@ public class TR2EnemyRandomizer : BaseTR2Randomizer
         {
             disguiseAsModel.ID = (uint)guiser;
         }
-
-        level.Data.Models = models.ToArray();
-        level.Data.NumModels = (uint)models.Count;
     }
 
     private void RandomizeEnemies(TR2CombinedLevel level, EnemyRandomizationCollection enemies)
@@ -978,7 +974,7 @@ public class TR2EnemyRandomizer : BaseTR2Randomizer
         // #327 Trick the game into never reaching the final frame of the death animation.
         // This results in a very abrupt death but avoids the level ending. For Ice Palace,
         // environment modifications will be made to enforce an alternative ending.
-        TRModel model = Array.Find(level.Data.Models, m => m.ID == (uint)TR2Type.BirdMonster);
+        TRModel model = level.Data.Models.Find(m => m.ID == (uint)TR2Type.BirdMonster);
         if (model != null)
         {
             level.Data.Animations[model.Animation + 20].FrameEnd = level.Data.Animations[model.Animation + 19].FrameEnd;

--- a/TRRandomizerCore/Randomizers/TR3/TR3SecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/TR3SecretRandomizer.cs
@@ -449,7 +449,6 @@ public class TR3SecretRandomizer : BaseTR3Randomizer, ISecretRandomizer
         {
             // If we have a spare model slot, duplicate one of the artefacts into this so that
             // we can add a hint with the item name. Otherwise, just re-use a puzzle item.
-            List<TRModel> models = level.Data.Models.ToList();
             Dictionary<TR3Type, TR3Type> artefacts = TR3TypeUtilities.GetArtefactReplacements();
 
             TR3Type availablePickupType = default;
@@ -457,7 +456,7 @@ public class TR3SecretRandomizer : BaseTR3Randomizer, ISecretRandomizer
             foreach (TR3Type pickupType in artefacts.Keys)
             {
                 TR3Type menuType = artefacts[pickupType];
-                if (models.Find(m => m.ID == (uint)menuType) == null)
+                if (level.Data.Models.Find(m => m.ID == (uint)menuType) == null)
                 {
                     availablePickupType = pickupType;
                     availableMenuType = menuType;
@@ -469,8 +468,8 @@ public class TR3SecretRandomizer : BaseTR3Randomizer, ISecretRandomizer
             {
                 // We have a free slot, so duplicate a model
                 TR3Type baseArtefact = pickupTypes[_generator.Next(0, pickupTypes.Count)];
-                TRModel artefactMenuModel = models.Find(m => m.ID == (uint)artefacts[baseArtefact]);
-                models.Add(new TRModel
+                TRModel artefactMenuModel = level.Data.Models.Find(m => m.ID == (uint)artefacts[baseArtefact]);
+                level.Data.Models.Add(new()
                 {
                     Animation = artefactMenuModel.Animation,
                     FrameOffset = artefactMenuModel.FrameOffset,
@@ -479,9 +478,6 @@ public class TR3SecretRandomizer : BaseTR3Randomizer, ISecretRandomizer
                     NumMeshes = artefactMenuModel.NumMeshes,
                     StartingMesh = artefactMenuModel.StartingMesh
                 });
-
-                level.Data.Models = models.ToArray();
-                level.Data.NumModels++;
 
                 // Add a script name - pull from GamestringRando once translations completed
                 SetPuzzleTypeName(level, availablePickupType, "Infinite Medi Packs");
@@ -833,10 +829,7 @@ public class TR3SecretRandomizer : BaseTR3Randomizer, ISecretRandomizer
                         DataFolder = _outer.GetResourcePath(@"TR3\Models"),
                         TexturePositionMonitor = monitor
                     };
-
                     importer.Import();
-
-                    List<TRModel> models = level.Data.Models.ToList();
 
                     // Redefine the artefacts as puzzle models otherwise the level ends on pickup
                     foreach (TR3Type artefactPickupType in allocation.ImportModels)
@@ -846,13 +839,13 @@ public class TR3SecretRandomizer : BaseTR3Randomizer, ISecretRandomizer
                         TR3Type puzzlePickupType = allocation.AvailablePickupModels.First();
                         TR3Type puzzleMenuType = _artefactReplacements[puzzlePickupType];
 
-                        models.Find(m => m.ID == (uint)artefactPickupType).ID = (uint)puzzlePickupType;
+                        level.Data.Models.Find(m => m.ID == (uint)artefactPickupType).ID = (uint)puzzlePickupType;
 
                         // #277 Most levels (beyond India) have the artefacts as menu models so we need
                         // to duplicate the models instead of replacing them, otherwise the carried-over
                         // artefacts from previous levels are invisible.
-                        TRModel menuModel = models.Find(m => m.ID == (uint)artefactMenuType);
-                        models.Add(new TRModel
+                        TRModel menuModel = level.Data.Models.Find(m => m.ID == (uint)artefactMenuType);
+                        level.Data.Models.Add(new()
                         {
                             Animation = menuModel.Animation,
                             FrameOffset = menuModel.FrameOffset,
@@ -875,9 +868,6 @@ public class TR3SecretRandomizer : BaseTR3Randomizer, ISecretRandomizer
                         monitor.EntityMap[artefactPickupType] = puzzlePickupType;
                         monitor.EntityMap[artefactMenuType] = puzzleMenuType;
                     }
-
-                    level.Data.Models = models.ToArray();
-                    level.Data.NumModels = (uint)models.Count;
                 }
 
                 if (!_outer.TriggerProgress())

--- a/TRRandomizerCore/Textures/DynamicTextureBuilder.cs
+++ b/TRRandomizerCore/Textures/DynamicTextureBuilder.cs
@@ -136,7 +136,7 @@ public class DynamicTextureBuilder
         // Lara will be partially re-textured.
         foreach (TR1Type modelID in modelIDs)
         {
-            TRModel model = Array.Find(level.Data.Models, m => m.ID == (uint)modelID);
+            TRModel model = level.Data.Models.Find(m => m.ID == (uint)modelID);
             if (model != null)
             {
                 AddModelTextures(level.Data, model, hips, defaultObjectTextures, modelMeshes);
@@ -145,7 +145,7 @@ public class DynamicTextureBuilder
 
         foreach (TR1Type modelID in _enemyIDs)
         {
-            TRModel model = Array.Find(level.Data.Models, m => m.ID == (uint)modelID);
+            TRModel model = level.Data.Models.Find(m => m.ID == (uint)modelID);
             if (model != null)
             {
                 AddModelTextures(level.Data, model, hips, enemyObjectTextures, modelMeshes);
@@ -173,7 +173,7 @@ public class DynamicTextureBuilder
         Dictionary<TR1Type, TR1Type> keyItems = TR1TypeUtilities.GetKeyItemMap();
         foreach (TR1Type pickupType in keyItems.Keys)
         {
-            TRModel model = Array.Find(level.Data.Models, m => m.ID == (uint)keyItems[pickupType]);
+            TRModel model = level.Data.Models.Find(m => m.ID == (uint)keyItems[pickupType]);
             if (model == null)
             {
                 continue;

--- a/TRRandomizerCore/Textures/Wireframing/AbstractTRWireframer.cs
+++ b/TRRandomizerCore/Textures/Wireframing/AbstractTRWireframer.cs
@@ -727,7 +727,7 @@ public abstract class AbstractTRWireframer<E, L>
     protected abstract Dictionary<E, TRMesh[]> GetModelMeshes(L level);
     protected abstract int GetBlackPaletteIndex(L level);
     protected abstract int ImportColour(L level, Color c);
-    protected abstract TRModel[] GetModels(L level);
+    protected abstract List<TRModel> GetModels(L level);
     protected abstract TRMesh[] GetModelMeshes(L level, TRModel model);
     protected abstract TRMesh[] GetLevelMeshes(L level);
     protected abstract TRStaticMesh[] GetStaticMeshes(L level);

--- a/TRRandomizerCore/Textures/Wireframing/TR1Wireframer.cs
+++ b/TRRandomizerCore/Textures/Wireframing/TR1Wireframer.cs
@@ -110,7 +110,7 @@ public class TR1Wireframer : AbstractTRWireframer<TR1Type, TR1Level>
         return TRMeshUtilities.GetModelMeshes(level, model);
     }
 
-    protected override TRModel[] GetModels(TR1Level level)
+    protected override List<TRModel> GetModels(TR1Level level)
     {
         return level.Models;
     }

--- a/TRRandomizerCore/Textures/Wireframing/TR2Wireframer.cs
+++ b/TRRandomizerCore/Textures/Wireframing/TR2Wireframer.cs
@@ -82,9 +82,9 @@ public class TR2Wireframer : AbstractTRWireframer<TR2Type, TR2Level>
         return TRMeshUtilities.GetModelMeshes(level, model);
     }
 
-    protected override TRModel[] GetModels(TR2Level level)
+    protected override List<TRModel> GetModels(TR2Level level)
     {
-        return level.Models;
+        return level.Models.ToList();
     }
 
     protected override TRObjectTexture[] GetObjectTextures(TR2Level level)

--- a/TRRandomizerCore/Textures/Wireframing/TR3Wireframer.cs
+++ b/TRRandomizerCore/Textures/Wireframing/TR3Wireframer.cs
@@ -77,9 +77,9 @@ public class TR3Wireframer : AbstractTRWireframer<TR3Type, TR3Level>
         return TRMeshUtilities.GetModelMeshes(level, model);
     }
 
-    protected override TRModel[] GetModels(TR3Level level)
+    protected override List<TRModel> GetModels(TR3Level level)
     {
-        return level.Models;
+        return level.Models.ToList();
     }
 
     protected override TRObjectTexture[] GetObjectTextures(TR3Level level)

--- a/TRRandomizerCore/Utilities/TR1EnemyUtilities.cs
+++ b/TRRandomizerCore/Utilities/TR1EnemyUtilities.cs
@@ -583,7 +583,7 @@ public static class TR1EnemyUtilities
         }
 
         TR1Type type = CodeBitsToAtlantean(entity.CodeBits);
-        return Array.Find(level.Data.Models, m => m.ID == (uint)type) == null;
+        return level.Data.Models.Find(m => m.ID == (uint)type) == null;
     }
 
     public static bool CanDropItems(TR1Entity entity, TR1CombinedLevel level, FDControl floorData)


### PR DESCRIPTION
Part of #468.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Animations, state changes, dispatches, commands, mesh trees, frames and models are now all lists. I've hopefully caught all the unnecessary `list.ToList()` calls.

All OG IO tests are running fine.
