### PR TITLE
Organise TR4/5 SFX data hierarchically

### DIFF
--- a/TRLevelControl/Control/TR4LevelControl.cs
+++ b/TRLevelControl/Control/TR4LevelControl.cs
@@ -401,54 +401,121 @@ public class TR4LevelControl : TRLevelControlBase<TR4Level>
 
     private void ReadSoundEffects(TRLevelReader reader)
     {
-        TR4FileReadUtilities.PopulateDemoSoundSampleIndices(reader, _level);
+        _level.SoundEffects = new();
+        short[] soundMap = reader.ReadInt16s(Enum.GetValues<TR4SFX>().Length);
+
+        uint numSoundDetails = reader.ReadUInt32();
+        List<TR4SoundEffect> sfx = new();
+
+        Dictionary<int, ushort> sampleMap = new();
+        for (int i = 0; i < numSoundDetails; i++)
+        {
+            sampleMap[i] = reader.ReadUInt16();
+            sfx.Add(new()
+            {
+                Volume = reader.ReadByte(),
+                Range = reader.ReadByte(),
+                Chance = reader.ReadByte(),
+                Pitch = reader.ReadByte(),
+                Samples = new()
+            });
+
+            sfx[i].SetFlags(reader.ReadUInt16());
+        }
+
+        // Sample indices are discarded in game. The details point to the samples
+        // directly per ReadWAVData.
+        uint numSampleIndices = reader.ReadUInt32();
+        reader.ReadUInt32s(numSampleIndices);
+
+        for (int i = 0; i < soundMap.Length; i++)
+        {
+            if (soundMap[i] < 0 || soundMap[i] >= sfx.Count)
+            {
+                continue;
+            }
+
+            _level.SoundEffects[(TR4SFX)i] = sfx[soundMap[i]];
+        }
     }
 
     private void WriteSoundEffects(TRLevelWriter writer)
     {
-        foreach (short sound in _level.SoundMap)
+        short detailsIndex = 0;
+        List<uint> sampleIndices = new();
+        List<TR4Sample> samples = new();
+
+        foreach (TR4SFX id in Enum.GetValues<TR4SFX>())
         {
-            writer.Write(sound);
+            writer.Write(_level.SoundEffects.ContainsKey(id) ? detailsIndex++ : (short)-1);
         }
 
-        writer.Write((uint)_level.SoundDetails.Count);
-        foreach (TR4SoundDetails snd in _level.SoundDetails)
+        writer.Write((uint)_level.SoundEffects.Count);
+        foreach (TR4SoundEffect details in _level.SoundEffects.Values)
         {
-            writer.Write(snd.Serialize());
+            TR4Sample firstSample = details.Samples.First();
+            int sampleIndex = samples.IndexOf(firstSample);
+            if (sampleIndex == -1)
+            {
+                sampleIndex = samples.Count;
+                samples.AddRange(details.Samples);
+            }
+
+            writer.Write((ushort)sampleIndex);
+            writer.Write(details.Volume);
+            writer.Write(details.Range);
+            writer.Write(details.Chance);
+            writer.Write(details.Pitch);
+            writer.Write(details.GetFlags());
+
+            sampleIndices.Add((uint)sampleIndex);
         }
 
-        writer.Write((uint)_level.SampleIndices.Count);
-        foreach (uint sampleindex in _level.SampleIndices)
-        {
-            writer.Write(sampleindex);
-        }
+        // Sample indices are not required, but write them anyway to match OG
+        writer.Write((uint)sampleIndices.Count);
+        writer.Write(sampleIndices);
     }
 
     private void ReadWAVData(TRLevelReader reader)
     {
         uint numSamples = reader.ReadUInt32();
-        _level.Samples = new();
+        List<TR4Sample> samples = new();
 
         for (int i = 0; i < numSamples; i++)
         {
-            _level.Samples.Add(new()
+            TR4Sample sample = new()
             {
-                UncompSize = reader.ReadUInt32(),
-                CompSize = reader.ReadUInt32(),
-            });
+                InflatedLength = reader.ReadUInt32()
+            };
+            samples.Add(sample);
 
-            _level.Samples[i].CompressedChunk = reader.ReadBytes((int)_level.Samples[i].CompSize);
+            uint compressedSize = reader.ReadUInt32();
+            sample.Data = reader.ReadUInt8s(compressedSize);
+        }
+
+        int pos = 0;
+        foreach (TR4SoundEffect sfx in _level.SoundEffects.Values)
+        {
+            for (int i = 0; i < sfx.Samples.Capacity; i++)
+            {
+                sfx.Samples.Add(samples[pos++]);
+            }
         }
     }
 
     private void WriteWAVData(TRLevelWriter writer)
     {
-        writer.Write((uint)_level.Samples.Count);
-        foreach (TR4Sample sample in _level.Samples)
+        List<TR4Sample> samples = _level.SoundEffects.Values
+            .SelectMany(s => s.Samples)
+            .Distinct()
+            .ToList();
+
+        writer.Write((uint)samples.Count);
+        foreach (TR4Sample sample in samples)
         {
-            writer.Write(sample.UncompSize);
-            writer.Write(sample.CompSize);
-            writer.Write(sample.CompressedChunk);
+            writer.Write(sample.InflatedLength);
+            writer.Write((uint)sample.Data.Length);
+            writer.Write(sample.Data);
         }
     }
 }

--- a/TRLevelControl/Control/TR4LevelControl.cs
+++ b/TRLevelControl/Control/TR4LevelControl.cs
@@ -113,6 +113,8 @@ public class TR4LevelControl : TRLevelControlBase<TR4Level>
 
         ReadEntities(reader);
 
+        ReadDemoData(reader);
+
         ReadSoundEffects(reader);
 
         reader.ReadUInt16s(3); // Always 0s
@@ -143,6 +145,8 @@ public class TR4LevelControl : TRLevelControlBase<TR4Level>
         WriteObjectTextures(writer);
 
         WriteEntities(writer);
+
+        WriteDemoData(writer);
 
         WriteSoundEffects(writer);
 
@@ -383,6 +387,18 @@ public class TR4LevelControl : TRLevelControlBase<TR4Level>
         writer.Write(_level.AIEntities);
     }
 
+    private void ReadDemoData(TRLevelReader reader)
+    {
+        ushort numDemoData = reader.ReadUInt16();
+        _level.DemoData = reader.ReadBytes(numDemoData);
+    }
+
+    private void WriteDemoData(TRLevelWriter writer)
+    {
+        writer.Write((ushort)_level.DemoData.Length);
+        writer.Write(_level.DemoData);
+    }
+
     private void ReadSoundEffects(TRLevelReader reader)
     {
         TR4FileReadUtilities.PopulateDemoSoundSampleIndices(reader, _level);
@@ -390,9 +406,6 @@ public class TR4LevelControl : TRLevelControlBase<TR4Level>
 
     private void WriteSoundEffects(TRLevelWriter writer)
     {
-        writer.Write((ushort)_level.DemoData.Length);
-        writer.Write(_level.DemoData);
-
         foreach (short sound in _level.SoundMap)
         {
             writer.Write(sound);

--- a/TRLevelControl/Control/TR4LevelControl.cs
+++ b/TRLevelControl/Control/TR4LevelControl.cs
@@ -424,9 +424,10 @@ public class TR4LevelControl : TRLevelControlBase<TR4Level>
         }
 
         // Sample indices are discarded in game. The details point to the samples
-        // directly per ReadWAVData.
+        // directly per ReadWAVData. Observe the reads here only.
         uint numSampleIndices = reader.ReadUInt32();
-        reader.ReadUInt32s(numSampleIndices);
+        uint[] sampleIndices = reader.ReadUInt32s(numSampleIndices);
+        _observer?.OnSampleIndicesRead(sampleIndices);
 
         for (int i = 0; i < soundMap.Length; i++)
         {
@@ -472,8 +473,9 @@ public class TR4LevelControl : TRLevelControlBase<TR4Level>
         }
 
         // Sample indices are not required, but write them anyway to match OG
-        writer.Write((uint)sampleIndices.Count);
-        writer.Write(sampleIndices);
+        IEnumerable<uint> outputIndices = _observer?.GetSampleIndices() ?? sampleIndices;
+        writer.Write((uint)outputIndices.Count());
+        writer.Write(outputIndices);
     }
 
     private void ReadWAVData(TRLevelReader reader)

--- a/TRLevelControl/Control/TR5LevelControl.cs
+++ b/TRLevelControl/Control/TR5LevelControl.cs
@@ -443,9 +443,10 @@ public class TR5LevelControl : TRLevelControlBase<TR5Level>
         }
 
         // Sample indices are discarded in game. The details point to the samples
-        // directly per ReadWAVData.
+        // directly per ReadWAVData. Observe the reads here only.
         uint numSampleIndices = reader.ReadUInt32();
-        reader.ReadUInt32s(numSampleIndices);
+        uint[] sampleIndices = reader.ReadUInt32s(numSampleIndices);
+        _observer?.OnSampleIndicesRead(sampleIndices);
 
         for (int i = 0; i < soundMap.Length; i++)
         {
@@ -514,8 +515,9 @@ public class TR5LevelControl : TRLevelControlBase<TR5Level>
             sampleIndices.Add((uint)sampleIndex);
         }
 
-        writer.Write((uint)sampleIndices.Count);
-        writer.Write(sampleIndices);
+        IEnumerable<uint> outputIndices = _observer?.GetSampleIndices() ?? sampleIndices;
+        writer.Write((uint)outputIndices.Count());
+        writer.Write(outputIndices);
 
         writer.Write(Enumerable.Repeat((byte)0xCD, 6));
     }

--- a/TRLevelControl/Control/TR5LevelControl.cs
+++ b/TRLevelControl/Control/TR5LevelControl.cs
@@ -129,7 +129,7 @@ public class TR5LevelControl : TRLevelControlBase<TR5Level>
 
         ReadEntities(reader);
 
-        //reader.ReadUInt16(); // Unused, always 0 //IF we eliminate demodata
+        ReadDemoData(reader);
 
         ReadSoundEffects(reader);
         ReadWAVData(reader);
@@ -160,7 +160,7 @@ public class TR5LevelControl : TRLevelControlBase<TR5Level>
 
         WriteEntities(writer);
 
-        //writer.Write((ushort)0); //IF we eliminate demodata
+        WriteDemoData(writer);
 
         WriteSoundEffects(writer);
 
@@ -407,6 +407,18 @@ public class TR5LevelControl : TRLevelControlBase<TR5Level>
         writer.Write(_level.AIEntities);
     }
 
+    private void ReadDemoData(TRLevelReader reader)
+    {
+        ushort numDemoData = reader.ReadUInt16();
+        _level.DemoData = reader.ReadBytes(numDemoData);
+    }
+
+    private void WriteDemoData(TRLevelWriter writer)
+    {
+        writer.Write((ushort)_level.DemoData.Length);
+        writer.Write(_level.DemoData);
+    }
+
     private void ReadSoundEffects(TRLevelReader reader)
     {
         TR5FileReadUtilities.PopulateDemoSoundSampleIndices(reader, _level);
@@ -415,9 +427,6 @@ public class TR5LevelControl : TRLevelControlBase<TR5Level>
 
     private void WriteSoundEffects(TRLevelWriter writer)
     {
-        writer.Write((ushort)_level.DemoData.Length);
-        writer.Write(_level.DemoData);
-
         foreach (short sound in _level.SoundMap)
         {
             writer.Write(sound);

--- a/TRLevelControl/ITRLevelObserver.cs
+++ b/TRLevelControl/ITRLevelObserver.cs
@@ -8,4 +8,6 @@ public interface ITRLevelObserver
     void OnChunkWritten(long startPosition, long endPosition, TRChunkType chunkType, byte[] data);
     void OnMeshPaddingRead(uint meshPointer, List<byte> values);
     List<byte> GetMeshPadding(uint meshPointer);
+    void OnSampleIndicesRead(uint[] sampleIndices);
+    IEnumerable<uint> GetSampleIndices();
 }

--- a/TRLevelControl/Model/TR4/TR4Level.cs
+++ b/TRLevelControl/Model/TR4/TR4Level.cs
@@ -29,8 +29,5 @@ public class TR4Level : TRLevelBase
     public List<TR4Entity> Entities { get; set; }
     public List<TR4AIEntity> AIEntities { get; set; }
     public byte[] DemoData { get; set; }
-    public short[] SoundMap { get; set; }
-    public List<TR4SoundDetails> SoundDetails { get; set; }
-    public List<uint> SampleIndices { get; set; }
-    public List<TR4Sample> Samples { get; set; }
+    public SortedDictionary<TR4SFX, TR4SoundEffect> SoundEffects { get; set; }
 }

--- a/TRLevelControl/Model/TR4/TR4Sample.cs
+++ b/TRLevelControl/Model/TR4/TR4Sample.cs
@@ -1,22 +1,7 @@
-﻿using TRLevelControl.Serialization;
+﻿namespace TRLevelControl.Model;
 
-namespace TRLevelControl.Model;
-
-public class TR4Sample : ISerializableCompact
+public class TR4Sample
 {
-    public uint UncompSize { get; set; }
-
-    public uint CompSize { get; set; }
-
-    public byte[] SoundData { get; set; }
-
-    //Optional - mainly just for testing, this is just to store the raw zlib compressed chunk.
-    public byte[] CompressedChunk { get; set; }
-
-    public byte[] Serialize()
-    {
-        //we cheat a bit here - sample is not actually zlib compressed, it is simply a WAV file.
-        //So in the TR4Level file we will write the sizes and compressed chunk straight.
-        throw new NotImplementedException();
-    }
+    public uint InflatedLength { get; set; }
+    public byte[] Data { get; set; }
 }

--- a/TRLevelControl/Model/TR4/TR4SoundEffect.cs
+++ b/TRLevelControl/Model/TR4/TR4SoundEffect.cs
@@ -1,0 +1,16 @@
+﻿namespace TRLevelControl.Model;
+
+public class TR4SoundEffect : TRSoundEffect<TR3SFXMode>
+{
+    public byte Volume { get; set; }
+    public byte Chance { get; set; }
+    public byte Range { get; set; }
+    public byte Pitch { get; set; }
+    public List<TR4Sample> Samples { get; set; }
+
+    protected override void SetSampleCount(int count)
+        => Samples.Capacity = count;
+
+    protected override int GetSampleCount()
+        => Samples.Count;
+}

--- a/TRLevelControl/Model/TR5/TR5Level.cs
+++ b/TRLevelControl/Model/TR5/TR5Level.cs
@@ -31,8 +31,5 @@ public class TR5Level : TRLevelBase
     public List<TR5Entity> Entities { get; set; }
     public List<TR5AIEntity> AIEntities { get; set; }
     public byte[] DemoData { get; set; }
-    public short[] SoundMap { get; set; }
-    public List<TR4SoundDetails> SoundDetails { get; set; }
-    public List<uint> SampleIndices { get; set; }
-    public List<TR4Sample> Samples { get; set; }
+    public SortedDictionary<TR5SFX, TR4SoundEffect> SoundEffects { get; set; }
 }

--- a/TRLevelControl/TR4FileReadUtilities.cs
+++ b/TRLevelControl/TR4FileReadUtilities.cs
@@ -292,9 +292,6 @@ internal static class TR4FileReadUtilities
 
     public static void PopulateDemoSoundSampleIndices(BinaryReader reader, TR4Level lvl)
     {
-        ushort numDemoData = reader.ReadUInt16();
-        lvl.DemoData = reader.ReadBytes(numDemoData);
-
         //Sound Map (370 shorts) & Sound Details
         lvl.SoundMap = new short[370];
 

--- a/TRLevelControl/TR4FileReadUtilities.cs
+++ b/TRLevelControl/TR4FileReadUtilities.cs
@@ -290,33 +290,6 @@ internal static class TR4FileReadUtilities
         lvl.AIEntities = reader.ReadTR4AIEntities(numEntities);
     }
 
-    public static void PopulateDemoSoundSampleIndices(BinaryReader reader, TR4Level lvl)
-    {
-        //Sound Map (370 shorts) & Sound Details
-        lvl.SoundMap = new short[370];
-
-        for (int i = 0; i < lvl.SoundMap.Length; i++)
-        {
-            lvl.SoundMap[i] = reader.ReadInt16();
-        }
-
-        uint numSoundDetails = reader.ReadUInt32();
-        lvl.SoundDetails = new();
-
-        for (int i = 0; i < numSoundDetails; i++)
-        {
-            lvl.SoundDetails.Add(ReadSoundDetails(reader));
-        }
-
-        uint numSampleIndices = reader.ReadUInt32();
-        lvl.SampleIndices = new();
-
-        for (int i = 0; i < numSampleIndices; i++)
-        {
-            lvl.SampleIndices.Add(reader.ReadUInt32());
-        }
-    }
-
     public static TR4SoundDetails ReadSoundDetails(BinaryReader reader)
     {
         return new()

--- a/TRLevelControl/TR5FileReadUtilities.cs
+++ b/TRLevelControl/TR5FileReadUtilities.cs
@@ -466,9 +466,6 @@ internal static class TR5FileReadUtilities
 
     public static void PopulateDemoSoundSampleIndices(BinaryReader reader, TR5Level lvl)
     {
-        ushort numDemoData = reader.ReadUInt16();
-        lvl.DemoData = reader.ReadBytes(numDemoData);
-
         //Sound Map (370 shorts) & Sound Details
         lvl.SoundMap = new short[450];
 

--- a/TRLevelControl/TR5FileReadUtilities.cs
+++ b/TRLevelControl/TR5FileReadUtilities.cs
@@ -463,31 +463,4 @@ internal static class TR5FileReadUtilities
         numEntities = reader.ReadUInt32();
         lvl.AIEntities = reader.ReadTR5AIEntities(numEntities);
     }
-
-    public static void PopulateDemoSoundSampleIndices(BinaryReader reader, TR5Level lvl)
-    {
-        //Sound Map (370 shorts) & Sound Details
-        lvl.SoundMap = new short[450];
-
-        for (int i = 0; i < lvl.SoundMap.Length; i++)
-        {
-            lvl.SoundMap[i] = reader.ReadInt16();
-        }
-
-        uint numSoundDetails = reader.ReadUInt32();
-        lvl.SoundDetails = new();
-
-        for (int i = 0; i < numSoundDetails; i++)
-        {
-            lvl.SoundDetails.Add(TR4FileReadUtilities.ReadSoundDetails(reader));
-        }
-
-        uint numSampleIndices = reader.ReadUInt32();
-        lvl.SampleIndices = new();
-
-        for (int i = 0; i < numSampleIndices; i++)
-        {
-            lvl.SampleIndices.Add(reader.ReadUInt32());
-        }
-    }
 }

--- a/TRLevelControlTests/Base/Observers/ObserverBase.cs
+++ b/TRLevelControlTests/Base/Observers/ObserverBase.cs
@@ -22,4 +22,10 @@ public class ObserverBase : ITRLevelObserver
 
     public virtual List<byte> GetMeshPadding(uint meshPointer)
         => null;
+
+    public virtual void OnSampleIndicesRead(uint[] sampleIndices)
+    { }
+
+    public virtual IEnumerable<uint> GetSampleIndices()
+        => null;
 }

--- a/TRLevelControlTests/Base/Observers/TR45Observer.cs
+++ b/TRLevelControlTests/Base/Observers/TR45Observer.cs
@@ -10,6 +10,8 @@ public class TR45Observer : ObserverBase
 
     private readonly Dictionary<uint, List<byte>> _meshPadding = new();
 
+    private uint[] _sampleIndices;
+
     public override void TestOutput(byte[] input, byte[] output)
     {
         CollectionAssert.AreEquivalent(_inflatedReads.Keys, _inflatedWrites.Keys);
@@ -69,6 +71,16 @@ public class TR45Observer : ObserverBase
     public override List<byte> GetMeshPadding(uint meshPointer)
     {
         return _meshPadding.ContainsKey(meshPointer) ? _meshPadding[meshPointer] : null;
+    }
+
+    public override void OnSampleIndicesRead(uint[] sampleIndices)
+    {
+        _sampleIndices = sampleIndices;
+    }
+
+    public override IEnumerable<uint> GetSampleIndices()
+    {
+        return _sampleIndices;
     }
 
     class ZipWrapper


### PR DESCRIPTION
Part of #619.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

TR4/5 catch-up with #620.

These levels store sample indices, but the engine ignores them (the count is read [here](https://github.com/Trxyebeep/TOMB4/blob/master/TOMB4/specific/file.cpp#L1227), and is then replaced with the number of WAV samples from the uncompressed data - nothing else is read from the compressed data). Writing back the ordered indices doesn't match the original, so we allow tests to restore. The generated levels play fine.