### PR TITLE
Convert model storage to dictionaries

### DIFF
--- a/TREnvironmentEditor/Model/Conditions/Models/EMModelExistsCondition.cs
+++ b/TREnvironmentEditor/Model/Conditions/Models/EMModelExistsCondition.cs
@@ -8,19 +8,16 @@ public class EMModelExistsCondition : BaseEMCondition
 
     protected override bool Evaluate(TR1Level level)
     {
-        TRModel model = level.Models.Find(m => m.ID == ModelID);
-        return model != null;
+        return level.Models.ContainsKey((TR1Type)ModelID);
     }
 
     protected override bool Evaluate(TR2Level level)
     {
-        TRModel model = level.Models.Find(m => m.ID == ModelID);
-        return model != null;
+        return level.Models.ContainsKey((TR2Type)ModelID);
     }
 
     protected override bool Evaluate(TR3Level level)
     {
-        TRModel model = level.Models.Find(m => m.ID == ModelID);
-        return model != null;
+        return level.Models.ContainsKey((TR3Type)ModelID);
     }
 }

--- a/TREnvironmentEditor/Model/Conditions/Models/EMUnconditionalBirdCheck.cs
+++ b/TREnvironmentEditor/Model/Conditions/Models/EMUnconditionalBirdCheck.cs
@@ -11,12 +11,8 @@ public class EMUnconditionalBirdCheck : BaseEMCondition
 
     protected override bool Evaluate(TR2Level level)
     {
-        TRModel model = level.Models.Find(m => m.ID == (uint)TR2Type.BirdMonster);
-        if (model != null)
-        {
-            return model.Animations[20].FrameEnd == model.Animations[19].FrameEnd;
-        }
-        return false;
+        TRModel model = level.Models[TR2Type.BirdMonster];
+        return model != null && model.Animations[20].FrameEnd == model.Animations[19].FrameEnd;
     }
 
     protected override bool Evaluate(TR3Level level)

--- a/TREnvironmentEditor/Model/Types/Mirroring/EMMirrorFunction.cs
+++ b/TREnvironmentEditor/Model/Types/Mirroring/EMMirrorFunction.cs
@@ -1078,7 +1078,7 @@ public class EMMirrorFunction : BaseEMFunction
         // Models such as doors may use textures also used on walls, but
         // these models aren't mirrored so the texture will end up being
         // upside down. Rotate the relevant mesh faces.
-        MirrorDependentFaces(level.Models, textureReferences);
+        MirrorDependentFaces(level.Models.Values, textureReferences);
     }
 
     private static void MirrorTextures(TR2Level level)
@@ -1247,19 +1247,14 @@ public class EMMirrorFunction : BaseEMFunction
 
     private static void MirrorDependentFaces(IEnumerable<TRModel> models, ISet<ushort> textureReferences)
     {
-        foreach (TRModel model in models)
+        IEnumerable<TRMeshFace> faces = models.SelectMany(m => m.Meshes)
+            .SelectMany(m => m.TexturedRectangles)
+            .Where(f => textureReferences.Contains(f.Texture))
+            .Distinct();
+        foreach (TRMeshFace face in faces)
         {
-            foreach (TRMesh mesh in model.Meshes)
-            {
-                foreach (TRMeshFace face in mesh.TexturedRectangles)
-                {
-                    if (textureReferences.Contains(face.Texture))
-                    {
-                        face.SwapVertices(0, 2);
-                        face.SwapVertices(1, 3);
-                    }
-                }
-            }
+            face.SwapVertices(0, 2);
+            face.SwapVertices(1, 3);
         }
     }
 }

--- a/TREnvironmentEditor/Model/Types/Mirroring/EMMirrorModelFunction.cs
+++ b/TREnvironmentEditor/Model/Types/Mirroring/EMMirrorModelFunction.cs
@@ -10,21 +10,24 @@ public class EMMirrorModelFunction : BaseEMFunction
     public override void ApplyToLevel(TR1Level level)
     {
         IEnumerable<TRModel> models = level.Models
-            .Where(m => ModelIDs.Contains(m.ID) && m.Meshes.Count == 1);
+            .Where(kvp => ModelIDs.Contains((uint)kvp.Key) && kvp.Value.Meshes.Count == 1)
+            .Select(kvp => kvp.Value);
         MirrorObjectTextures(MirrorMeshes(models), level.ObjectTextures);
     }
 
     public override void ApplyToLevel(TR2Level level)
     {
         IEnumerable<TRModel> models = level.Models
-            .Where(m => ModelIDs.Contains(m.ID) && m.Meshes.Count == 1);
+            .Where(kvp => ModelIDs.Contains((uint)kvp.Key) && kvp.Value.Meshes.Count == 1)
+            .Select(kvp => kvp.Value);
         MirrorObjectTextures(MirrorMeshes(models), level.ObjectTextures);
     }
 
     public override void ApplyToLevel(TR3Level level)
     {
         IEnumerable<TRModel> models = level.Models
-            .Where(m => ModelIDs.Contains(m.ID) && m.Meshes.Count == 1);
+            .Where(kvp => ModelIDs.Contains((uint)kvp.Key) && kvp.Value.Meshes.Count == 1)
+            .Select(kvp => kvp.Value);
         MirrorObjectTextures(MirrorMeshes(models), level.ObjectTextures);
     }
 

--- a/TREnvironmentEditor/Model/Types/Models/EMConvertModelFunction.cs
+++ b/TREnvironmentEditor/Model/Types/Models/EMConvertModelFunction.cs
@@ -9,63 +9,35 @@ public class EMConvertModelFunction : BaseEMFunction
 
     public override void ApplyToLevel(TR1Level level)
     {
-        ConvertModel(level.Models);
-        UpdateModelEntities(level.Entities);
+        ConvertModel(level.Models, level.Entities);
     }
 
     public override void ApplyToLevel(TR2Level level)
     {
-        ConvertModel(level.Models);
-        UpdateModelEntities(level.Entities);
+        ConvertModel(level.Models, level.Entities);
     }
 
     public override void ApplyToLevel(TR3Level level)
     {
-        ConvertModel(level.Models);
-        UpdateModelEntities(level.Entities);
+        ConvertModel(level.Models, level.Entities);
     }
 
-    private void ConvertModel(List<TRModel> models)
+    private void ConvertModel<T, E>(TRDictionary<T, TRModel> models, List<E> entities)
+        where T : Enum
+        where E : TREntity<T>
     {
-        if (models.Find(m => m.ID == NewModelID) == null)
+        T oldID = (T)(object)OldModelID;
+        T newID = (T)(object)NewModelID;
+        if (!models.ChangeKey(oldID, newID))
         {
-            TRModel oldModel = models.Find(m => m.ID == OldModelID);
-            if (oldModel != null)
-            {
-                oldModel.ID = NewModelID;
-            }
+            return;
         }
-    }
 
-    private void UpdateModelEntities(List<TR1Entity> entities)
-    {
-        foreach (TR1Entity entity in entities)
+        foreach (E entity in entities)
         {
-            if (entity.TypeID == (TR1Type)OldModelID)
+            if (EqualityComparer<T>.Default.Equals(entity.TypeID, oldID))
             {
-                entity.TypeID = (TR1Type)NewModelID;
-            }
-        }
-    }
-
-    private void UpdateModelEntities(IEnumerable<TR2Entity> entities)
-    {
-        foreach (TR2Entity entity in entities)
-        {
-            if (entity.TypeID == (TR2Type)OldModelID)
-            {
-                entity.TypeID = (TR2Type)NewModelID;
-            }
-        }
-    }
-
-    private void UpdateModelEntities(IEnumerable<TR3Entity> entities)
-    {
-        foreach (TR3Entity entity in entities)
-        {
-            if (entity.TypeID == (TR3Type)OldModelID)
-            {
-                entity.TypeID = (TR3Type)NewModelID;
+                entity.TypeID = newID;
             }
         }
     }

--- a/TREnvironmentEditor/Model/Types/Models/EMImportNonGraphicsModelFunction.cs
+++ b/TREnvironmentEditor/Model/Types/Models/EMImportNonGraphicsModelFunction.cs
@@ -10,8 +10,8 @@ public class EMImportNonGraphicsModelFunction : BaseEMFunction
 
     public override void ApplyToLevel(TR1Level level)
     {
-        List<EMMeshTextureData> data = PrepareImportData(level.Models);
-        if (data.Count == 0)
+        IEnumerable<EMMeshTextureData> data = PrepareImportData(level.Models);
+        if (!data.Any())
         {
             return;
         }
@@ -26,13 +26,13 @@ public class EMImportNonGraphicsModelFunction : BaseEMFunction
         };
         importer.Import();
 
-        RemapFaces(data, level.ObjectTextures.Count - 1, modelID => level.Models.Find(m => m.ID == modelID));
+        RemapFaces(data, level.ObjectTextures.Count - 1, level.Models);
     }
 
     public override void ApplyToLevel(TR2Level level)
     {
-        List<EMMeshTextureData> data = PrepareImportData(level.Models);
-        if (data.Count == 0)
+        IEnumerable<EMMeshTextureData> data = PrepareImportData(level.Models);
+        if (!data.Any())
         {
             return;
         }
@@ -47,13 +47,13 @@ public class EMImportNonGraphicsModelFunction : BaseEMFunction
         };
         importer.Import();
 
-        RemapFaces(data, level.ObjectTextures.Count - 1, modelID => level.Models.Find(m => m.ID == modelID));
+        RemapFaces(data, level.ObjectTextures.Count - 1, level.Models);
     }
 
     public override void ApplyToLevel(TR3Level level)
     {
-        List<EMMeshTextureData> data = PrepareImportData(level.Models);
-        if (data.Count == 0)
+        IEnumerable<EMMeshTextureData> data = PrepareImportData(level.Models);
+        if (!data.Any())
         {
             return;
         }
@@ -68,27 +68,21 @@ public class EMImportNonGraphicsModelFunction : BaseEMFunction
         };
         importer.Import();
 
-        RemapFaces(data, level.ObjectTextures.Count - 1, modelID => level.Models.Find(m => m.ID == modelID));
+        RemapFaces(data, level.ObjectTextures.Count - 1, level.Models);
     }
 
-    private List<EMMeshTextureData> PrepareImportData(List<TRModel> existingModels)
+    private IEnumerable<EMMeshTextureData> PrepareImportData<T>(SortedDictionary<T, TRModel> existingModels)
+        where T : Enum
     {
-        List<EMMeshTextureData> importData = new();
-        foreach (EMMeshTextureData data in Data)
-        {
-            if (existingModels.Find(m => m.ID == data.ModelID) == null)
-            {
-                importData.Add(data);
-            }
-        }
-        return importData;
+        return Data.Where(d => !existingModels.ContainsKey((T)(object)d.ModelID));
     }
 
-    private static void RemapFaces(List<EMMeshTextureData> data, int maximumTexture, Func<short, TRModel> modelAction)
+    private static void RemapFaces<T>(IEnumerable<EMMeshTextureData> data, int maximumTexture, SortedDictionary<T, TRModel> models)
+        where T : Enum
     {
         foreach (EMMeshTextureData textureData in data)
         {
-            TRModel model= modelAction.Invoke(textureData.ModelID);
+            TRModel model = models[(T)(object)textureData.ModelID];
             foreach (TRMesh mesh in model.Meshes)
             {
                 foreach (TRMeshFace face in mesh.ColouredTriangles)

--- a/TRLevelControl/Control/TR1LevelControl.cs
+++ b/TRLevelControl/Control/TR1LevelControl.cs
@@ -259,18 +259,18 @@ public class TR1LevelControl : TRLevelControlBase<TR1Level>
 
     private void WriteMeshData(TRLevelWriter writer)
     {
-        _meshBuilder.WriteObjectMeshes(writer, _level.Models.SelectMany(m => m.Meshes), _level.StaticMeshes);
+        _meshBuilder.WriteObjectMeshes(writer, _level.Models.Values.SelectMany(m => m.Meshes), _level.StaticMeshes);
     }
 
     private void ReadModelData(TRLevelReader reader)
     {
-        TRModelBuilder builder = new(TRGameVersion.TR1, _observer);
+        TRModelBuilder<TR1Type> builder = new(TRGameVersion.TR1, _observer);
         _level.Models = builder.ReadModelData(reader, _meshBuilder);
     }
 
     private void WriteModelData(TRLevelWriter writer)
     {
-        TRModelBuilder builder = new(TRGameVersion.TR1, _observer);
+        TRModelBuilder<TR1Type> builder = new(TRGameVersion.TR1, _observer);
         builder.WriteModelData(writer, _level.Models);
     }
 

--- a/TRLevelControl/Control/TR2LevelControl.cs
+++ b/TRLevelControl/Control/TR2LevelControl.cs
@@ -270,18 +270,18 @@ public class TR2LevelControl : TRLevelControlBase<TR2Level>
 
     private void WriteMeshData(TRLevelWriter writer)
     {
-        _meshBuilder.WriteObjectMeshes(writer, _level.Models.SelectMany(m => m.Meshes), _level.StaticMeshes);
+        _meshBuilder.WriteObjectMeshes(writer, _level.Models.Values.SelectMany(m => m.Meshes), _level.StaticMeshes);
     }
 
     private void ReadModelData(TRLevelReader reader)
     {
-        TRModelBuilder builder = new(TRGameVersion.TR2, _observer);
+        TRModelBuilder<TR2Type> builder = new(TRGameVersion.TR2, _observer);
         _level.Models = builder.ReadModelData(reader, _meshBuilder);
     }
 
     private void WriteModelData(TRLevelWriter writer)
     {
-        TRModelBuilder builder = new(TRGameVersion.TR2, _observer);
+        TRModelBuilder<TR2Type> builder = new(TRGameVersion.TR2, _observer);
         builder.WriteModelData(writer, _level.Models);
     }
 

--- a/TRLevelControl/Control/TR3LevelControl.cs
+++ b/TRLevelControl/Control/TR3LevelControl.cs
@@ -276,18 +276,18 @@ public class TR3LevelControl : TRLevelControlBase<TR3Level>
 
     private void WriteMeshData(TRLevelWriter writer)
     {
-        _meshBuilder.WriteObjectMeshes(writer, _level.Models.SelectMany(m => m.Meshes), _level.StaticMeshes);
+        _meshBuilder.WriteObjectMeshes(writer, _level.Models.Values.SelectMany(m => m.Meshes), _level.StaticMeshes);
     }
 
     private void ReadModelData(TRLevelReader reader)
     {
-        TRModelBuilder builder = new(TRGameVersion.TR3, _observer);
+        TRModelBuilder<TR3Type> builder = new(TRGameVersion.TR3, _observer);
         _level.Models = builder.ReadModelData(reader, _meshBuilder);
     }
 
     private void WriteModelData(TRLevelWriter writer)
     {
-        TRModelBuilder builder = new(TRGameVersion.TR3, _observer);
+        TRModelBuilder<TR3Type> builder = new(TRGameVersion.TR3, _observer);
         builder.WriteModelData(writer, _level.Models);
     }
 

--- a/TRLevelControl/Control/TR4LevelControl.cs
+++ b/TRLevelControl/Control/TR4LevelControl.cs
@@ -185,18 +185,18 @@ public class TR4LevelControl : TRLevelControlBase<TR4Level>
 
     private void WriteMeshData(TRLevelWriter writer)
     {
-        _meshBuilder.WriteObjectMeshes(writer, _level.Models.SelectMany(m => m.Meshes), _level.StaticMeshes);
+        _meshBuilder.WriteObjectMeshes(writer, _level.Models.Values.SelectMany(m => m.Meshes), _level.StaticMeshes);
     }
 
     private void ReadModelData(TRLevelReader reader)
     {
-        TRModelBuilder builder = new(TRGameVersion.TR4, _observer);
+        TRModelBuilder<TR4Type> builder = new(TRGameVersion.TR4, _observer);
         _level.Models = builder.ReadModelData(reader, _meshBuilder);
     }
 
     private void WriteModelData(TRLevelWriter writer)
     {
-        TRModelBuilder builder = new(TRGameVersion.TR4, _observer);
+        TRModelBuilder<TR4Type> builder = new(TRGameVersion.TR4, _observer);
         builder.WriteModelData(writer, _level.Models);
     }
 

--- a/TRLevelControl/Control/TR5LevelControl.cs
+++ b/TRLevelControl/Control/TR5LevelControl.cs
@@ -202,18 +202,18 @@ public class TR5LevelControl : TRLevelControlBase<TR5Level>
 
     private void WriteMeshData(TRLevelWriter writer)
     {
-        _meshBuilder.WriteObjectMeshes(writer, _level.Models.SelectMany(m => m.Meshes), _level.StaticMeshes);
+        _meshBuilder.WriteObjectMeshes(writer, _level.Models.Values.SelectMany(m => m.Meshes), _level.StaticMeshes);
     }
 
     private void ReadModelData(TRLevelReader reader)
     {
-        TRModelBuilder builder = new(TRGameVersion.TR5, _observer);
+        TRModelBuilder<TR5Type> builder = new(TRGameVersion.TR5, _observer);
         _level.Models = builder.ReadModelData(reader, _meshBuilder);
     }
 
     private void WriteModelData(TRLevelWriter writer)
     {
-        TRModelBuilder builder = new(TRGameVersion.TR5, _observer);
+        TRModelBuilder<TR5Type> builder = new(TRGameVersion.TR5, _observer);
         builder.WriteModelData(writer, _level.Models);
     }
 

--- a/TRLevelControl/Model/Common/TRDictionary.cs
+++ b/TRLevelControl/Model/Common/TRDictionary.cs
@@ -1,0 +1,23 @@
+﻿namespace TRLevelControl.Model;
+
+public class TRDictionary<TKey, TValue> : SortedDictionary<TKey, TValue>
+    where TValue : class
+{
+    public new TValue this[TKey key]
+    {
+        get => ContainsKey(key) ? base[key] : null;
+        set => base[key] = value;
+    }
+
+    public bool ChangeKey(TKey oldKey, TKey newKey)
+    {
+        if (!TryGetValue(oldKey, out TValue value))
+        {
+            return false;
+        }
+
+        Remove(oldKey);
+        base[newKey] = value;
+        return true;
+    }
+}

--- a/TRLevelControl/Model/Common/TRModel.cs
+++ b/TRLevelControl/Model/Common/TRModel.cs
@@ -5,7 +5,6 @@ public class TRModel : ICloneable
     public List<TRAnimation> Animations { get; set; } = new();
     public List<TRMeshTreeNode> MeshTrees { get; set; } = new();
     public List<TRMesh> Meshes { get; set; } = new();
-    public uint ID { get; set; }
 
     public TRModel Clone()
     {
@@ -14,7 +13,6 @@ public class TRModel : ICloneable
             Animations = new(Animations.Select(a => a.Clone())),
             MeshTrees = new(MeshTrees.Select(m => m.Clone())),
             Meshes = new(Meshes.Select(m => m.Clone())),
-            ID = ID,
         };
     }
 

--- a/TRLevelControl/Model/TR1/Enums/TR1Type.cs
+++ b/TRLevelControl/Model/TR1/Enums/TR1Type.cs
@@ -7,7 +7,7 @@
 //_N are nullmeshes (no render/collision)
 //_H are helper entities (not placed)
 //_U are unused entities
-public enum TR1Type
+public enum TR1Type : uint
 {
     Lara                   = 0,
     LaraPistolAnim_H       = 1,

--- a/TRLevelControl/Model/TR1/TR1Level.cs
+++ b/TRLevelControl/Model/TR1/TR1Level.cs
@@ -5,7 +5,7 @@ public class TR1Level : TRLevelBase
     public List<TRTexImage8> Images8 { get; set; }
     public List<TR1Room> Rooms { get; set; }
     public List<ushort> FloorData { get; set; }
-    public List<TRModel> Models { get; set; }
+    public TRDictionary<TR1Type, TRModel> Models { get; set; }
     public List<TRStaticMesh> StaticMeshes { get; set; }
     public List<TRObjectTexture> ObjectTextures { get; set; }
     public List<TRSpriteTexture> SpriteTextures { get; set; }
@@ -22,4 +22,8 @@ public class TR1Level : TRLevelBase
     public List<TRCinematicFrame> CinematicFrames { get; set; }
     public byte[] DemoData { get; set; }
     public SortedDictionary<TR1SFX, TR1SoundEffect> SoundEffects { get; set; }
+
+    public override IEnumerable<TRMesh> DistinctMeshes => Models.Values.SelectMany(m => m.Meshes)
+        .Concat(StaticMeshes.Select(s => s.Mesh))
+        .Distinct();
 }

--- a/TRLevelControl/Model/TR2/Enums/TR2Type.cs
+++ b/TRLevelControl/Model/TR2/Enums/TR2Type.cs
@@ -7,7 +7,7 @@
 //_N are nullmeshes (no render/collision)
 //_H are helper entities (not placed)
 //_U are unused entities
-public enum TR2Type
+public enum TR2Type : uint
 {
     Lara                     = 0,
     LaraPistolAnim_H         = 1,

--- a/TRLevelControl/Model/TR2/TR2Level.cs
+++ b/TRLevelControl/Model/TR2/TR2Level.cs
@@ -8,7 +8,7 @@ public class TR2Level : TRLevelBase
     public List<TRTexImage16> Images16 { get; set; }
     public List<TR2Room> Rooms { get; set; }
     public List<ushort> FloorData { get; set; }
-    public List<TRModel> Models { get; set; }
+    public TRDictionary<TR2Type, TRModel> Models { get; set; }
     public List<TRStaticMesh> StaticMeshes { get; set; }
     public List<TRObjectTexture> ObjectTextures { get; set; }
     public List<TRSpriteTexture> SpriteTextures { get; set; }
@@ -24,4 +24,8 @@ public class TR2Level : TRLevelBase
     public List<TRCinematicFrame> CinematicFrames { get; set; }
     public byte[] DemoData { get; set; }
     public SortedDictionary<TR2SFX, TR2SoundEffect> SoundEffects { get; set; }
+
+    public override IEnumerable<TRMesh> DistinctMeshes => Models.Values.SelectMany(m => m.Meshes)
+        .Concat(StaticMeshes.Select(s => s.Mesh))
+        .Distinct();
 }

--- a/TRLevelControl/Model/TR3/Enums/TR3Type.cs
+++ b/TRLevelControl/Model/TR3/Enums/TR3Type.cs
@@ -7,7 +7,7 @@
 //_N are nullmeshes (no render/collision) - RED
 //_H are helper entities (not placed) - GREEN
 //_U are unused entities - PURPLE
-public enum TR3Type
+public enum TR3Type : uint
 {
     Lara                       = 0,
     LaraPistolAnimation_H      = 1,

--- a/TRLevelControl/Model/TR3/TR3Level.cs
+++ b/TRLevelControl/Model/TR3/TR3Level.cs
@@ -8,7 +8,7 @@ public class TR3Level : TRLevelBase
     public List<TRTexImage16> Images16 { get; set; }
     public List<TR3Room> Rooms { get; set; }
     public List<ushort> FloorData { get; set; }
-    public List<TRModel> Models { get; set; }
+    public TRDictionary<TR3Type, TRModel> Models { get; set; }
     public List<TRStaticMesh> StaticMeshes { get; set; }
     public List<TRSpriteTexture> SpriteTextures { get; set; }
     public List<TRSpriteSequence> SpriteSequences { get; set; }
@@ -24,4 +24,8 @@ public class TR3Level : TRLevelBase
     public List<TRCinematicFrame> CinematicFrames { get; set; }
     public byte[] DemoData { get; set; }
     public SortedDictionary<TR3SFX, TR3SoundEffect> SoundEffects { get; set; }
+
+    public override IEnumerable<TRMesh> DistinctMeshes => Models.Values.SelectMany(m => m.Meshes)
+        .Concat(StaticMeshes.Select(s => s.Mesh))
+        .Distinct();
 }

--- a/TRLevelControl/Model/TR4/Enums/TR4Type.cs
+++ b/TRLevelControl/Model/TR4/Enums/TR4Type.cs
@@ -1,6 +1,6 @@
 ﻿namespace TRLevelControl.Model;
 
-public enum TR4Type
+public enum TR4Type : uint
 {
     Lara                   = 0,
     LaraPistolAnim         = 1,

--- a/TRLevelControl/Model/TR4/TR4Level.cs
+++ b/TRLevelControl/Model/TR4/TR4Level.cs
@@ -5,7 +5,7 @@ public class TR4Level : TRLevelBase
     public TR4Textiles Images { get; set; }
     public List<TR4Room> Rooms { get; set; }
     public List<ushort> FloorData { get; set; }
-    public List<TRModel> Models { get; set; }
+    public TRDictionary<TR4Type, TRModel> Models { get; set; }
     public List<TRStaticMesh> StaticMeshes { get; set; }
     public List<TRSpriteTexture> SpriteTextures { get; set; }
     public List<TRSpriteSequence> SpriteSequences { get; set; }
@@ -22,4 +22,8 @@ public class TR4Level : TRLevelBase
     public List<TR4AIEntity> AIEntities { get; set; }
     public byte[] DemoData { get; set; }
     public SortedDictionary<TR4SFX, TR4SoundEffect> SoundEffects { get; set; }
+
+    public override IEnumerable<TRMesh> DistinctMeshes => Models.Values.SelectMany(m => m.Meshes)
+        .Concat(StaticMeshes.Select(s => s.Mesh))
+        .Distinct();
 }

--- a/TRLevelControl/Model/TR5/Enums/TR5Type.cs
+++ b/TRLevelControl/Model/TR5/Enums/TR5Type.cs
@@ -1,6 +1,6 @@
 ﻿namespace TRLevelControl.Model;
 
-public enum TR5Type
+public enum TR5Type : uint
 {
     Lara                 = 0,
     LaraPistolAnim       = 1,

--- a/TRLevelControl/Model/TR5/TR5Level.cs
+++ b/TRLevelControl/Model/TR5/TR5Level.cs
@@ -7,7 +7,7 @@ public class TR5Level : TRLevelBase
     public ushort WeatherType { get; set; }
     public List<TR5Room> Rooms { get; set; }
     public List<ushort> FloorData { get; set; }
-    public List<TRModel> Models { get; set; }
+    public TRDictionary<TR5Type, TRModel> Models { get; set; }
     public List<TRStaticMesh> StaticMeshes { get; set; }
     public List<TRSpriteTexture> SpriteTextures { get; set; }
     public List<TRSpriteSequence> SpriteSequences { get; set; }
@@ -24,4 +24,8 @@ public class TR5Level : TRLevelBase
     public List<TR5AIEntity> AIEntities { get; set; }
     public byte[] DemoData { get; set; }
     public SortedDictionary<TR5SFX, TR4SoundEffect> SoundEffects { get; set; }
+
+    public override IEnumerable<TRMesh> DistinctMeshes => Models.Values.SelectMany(m => m.Meshes)
+        .Concat(StaticMeshes.Select(s => s.Mesh))
+        .Distinct();
 }

--- a/TRLevelControl/Model/TRLevelBase.cs
+++ b/TRLevelControl/Model/TRLevelBase.cs
@@ -3,4 +3,5 @@
 public abstract class TRLevelBase
 {
     public TRVersion Version { get; set; }
+    public abstract IEnumerable<TRMesh> DistinctMeshes { get; }
 }

--- a/TRLevelToolset/Controls/DataControls/TR/TRAnimationControl.cs
+++ b/TRLevelToolset/Controls/DataControls/TR/TRAnimationControl.cs
@@ -10,12 +10,12 @@ internal class TRANimationControl : IDrawable
     {
         if (ImGui.TreeNodeEx("Animations Data", ImGuiTreeNodeFlags.OpenOnArrow))
         {
-            ImGui.Text("Animations count: " + IOManager.CurrentLevelAsTR1?.Models.Sum(m => m.Animations.Count));
-            ImGui.Text("State change count: " + IOManager.CurrentLevelAsTR1?.Models.Sum(m => m.Animations.Sum(a => a.Changes.Count)));
-            ImGui.Text("Animation dispatch count: " + IOManager.CurrentLevelAsTR1?.Models.Sum(m => m.Animations.Sum(a => a.Changes.Sum(c => c.Dispatches.Count))));
-            ImGui.Text("Animation command count: " + IOManager.CurrentLevelAsTR1?.Models.Sum(m => m.Animations.Sum(a => a.Commands.Count)));
-            ImGui.Text("Mesh tree count: " + IOManager.CurrentLevelAsTR1?.Models.Sum(m => m.MeshTrees.Count));
-            ImGui.Text("Total frames count: " + IOManager.CurrentLevelAsTR1?.Models.Sum(m => m.Animations.Sum(a => a.Frames.Count)));
+            ImGui.Text("Animations count: " + IOManager.CurrentLevelAsTR1?.Models.Values.Sum(m => m.Animations.Count));
+            ImGui.Text("State change count: " + IOManager.CurrentLevelAsTR1?.Models.Values.Sum(m => m.Animations.Sum(a => a.Changes.Count)));
+            ImGui.Text("Animation dispatch count: " + IOManager.CurrentLevelAsTR1?.Models.Values.Sum(m => m.Animations.Sum(a => a.Changes.Sum(c => c.Dispatches.Count))));
+            ImGui.Text("Animation command count: " + IOManager.CurrentLevelAsTR1?.Models.Values.Sum(m => m.Animations.Sum(a => a.Commands.Count)));
+            ImGui.Text("Mesh tree count: " + IOManager.CurrentLevelAsTR1?.Models.Values.Sum(m => m.MeshTrees.Count));
+            ImGui.Text("Total frames count: " + IOManager.CurrentLevelAsTR1?.Models.Values.Sum(m => m.Animations.Sum(a => a.Frames.Count)));
 
             ImGui.TreePop();
         }

--- a/TRLevelToolset/Controls/DataControls/TR/TRMeshControl.cs
+++ b/TRLevelToolset/Controls/DataControls/TR/TRMeshControl.cs
@@ -10,8 +10,7 @@ internal class TRMeshControl : IDrawable
     {
         if (ImGui.TreeNodeEx("Mesh Data", ImGuiTreeNodeFlags.OpenOnArrow))
         {
-            ImGui.Text("Mesh count: " + IOManager.CurrentLevelAsTR1?.Models.SelectMany(m => m.Meshes)
-                .Concat(IOManager.CurrentLevelAsTR1.StaticMeshes.Select(s => s.Mesh)).Count());
+            ImGui.Text("Mesh count: " + IOManager.CurrentLevelAsTR1?.DistinctMeshes.Count());
 
             ImGui.TreePop();
         }

--- a/TRModelTransporter/Handlers/Textures/TR2/TR2TextureImportHandler.cs
+++ b/TRModelTransporter/Handlers/Textures/TR2/TR2TextureImportHandler.cs
@@ -66,7 +66,7 @@ public class TR2TextureImportHandler : AbstractTextureImportHandler<TR2Type, TR2
         if
         (
             _definitions.ToList().FindIndex(d => flameEnemies.Contains(d.Entity)) != -1 ||
-            _level.Models.FindIndex(m => flameEnemies.Contains((TR2Type)m.ID)) != -1
+            _level.Models.Keys.Any(flameEnemies.Contains)
         )
         {
             int blastSequence = _level.SpriteSequences.FindIndex(s => s.SpriteID == (int)TR2Type.FireBlast_S_H);

--- a/TRModelTransporter/Helpers/TRModelExtensions.cs
+++ b/TRModelTransporter/Helpers/TRModelExtensions.cs
@@ -132,7 +132,7 @@ public static class TRModelExtensions
             return;
         }
 
-        foreach (TRMesh mesh in level.Models.SelectMany(m => m.Meshes).Concat(level.StaticMeshes.Select(s => s.Mesh)))
+        foreach (TRMesh mesh in level.DistinctMeshes)
         {
             foreach (TRMeshFace face in mesh.TexturedFaces)
             {
@@ -190,7 +190,7 @@ public static class TRModelExtensions
             return;
         }
 
-        foreach (TRMesh mesh in level.Models.SelectMany(m => m.Meshes).Concat(level.StaticMeshes.Select(s => s.Mesh)))
+        foreach (TRMesh mesh in level.DistinctMeshes)
         {
             foreach (TRMeshFace face in mesh.TexturedFaces)
             {

--- a/TRModelTransporter/Model/AbstractTRModelDefinition.cs
+++ b/TRModelTransporter/Model/AbstractTRModelDefinition.cs
@@ -8,7 +8,7 @@ namespace TRModelTransporter.Model;
 public abstract class AbstractTRModelDefinition<E> : IDisposable where E : Enum
 {
     [JsonIgnore]
-    public abstract E Entity { get; }
+    public E Entity { get; set; }
     [JsonIgnore]
     public E Alias { get; set; }
     [JsonIgnore]

--- a/TRModelTransporter/Model/Definitions/TR1ModelDefinition.cs
+++ b/TRModelTransporter/Model/Definitions/TR1ModelDefinition.cs
@@ -4,7 +4,6 @@ namespace TRModelTransporter.Model.Definitions;
 
 public class TR1ModelDefinition : AbstractTRModelDefinition<TR1Type>
 {
-    public override TR1Type Entity => (TR1Type)Model.ID;
     public TRCinematicFrame[] CinematicFrames { get; set; }
     public Dictionary<int, TRColour> Colours { get; set; }
     public List<TRMesh> Meshes { get; set; }

--- a/TRModelTransporter/Model/Definitions/TR2ModelDefinition.cs
+++ b/TRModelTransporter/Model/Definitions/TR2ModelDefinition.cs
@@ -4,7 +4,6 @@ namespace TRModelTransporter.Model.Definitions;
 
 public class TR2ModelDefinition : AbstractTRModelDefinition<TR2Type>
 {
-    public override TR2Type Entity => (TR2Type)Model.ID;
     public TRCinematicFrame[] CinematicFrames { get; set; }
     public Dictionary<int, TRColour4> Colours { get; set; }
     public List<TRMesh> Meshes { get; set; }

--- a/TRModelTransporter/Model/Definitions/TR3ModelDefinition.cs
+++ b/TRModelTransporter/Model/Definitions/TR3ModelDefinition.cs
@@ -4,7 +4,6 @@ namespace TRModelTransporter.Model.Definitions;
 
 public class TR3ModelDefinition : AbstractTRModelDefinition<TR3Type>
 {
-    public override TR3Type Entity => (TR3Type)Model.ID;
     public TRCinematicFrame[] CinematicFrames { get; set; }
     public Dictionary<int, TRColour4> Colours { get; set; }
     public List<TRMesh> Meshes { get; set; }

--- a/TRModelTransporter/Model/Textures/RemapTypes/TR1TextureRemapGroup.cs
+++ b/TRModelTransporter/Model/Textures/RemapTypes/TR1TextureRemapGroup.cs
@@ -7,12 +7,7 @@ public class TR1TextureRemapGroup : AbstractTextureRemapGroup<TR1Type, TR1Level>
 {
     protected override IEnumerable<TR1Type> GetModelTypes(TR1Level level)
     {
-        List<TR1Type> types = new();
-        foreach (TRModel model in level.Models)
-        {
-            types.Add((TR1Type)model.ID);
-        }
-        return types;
+        return level.Models.Keys.ToList();
     }
 
     protected override AbstractTexturePacker<TR1Type, TR1Level> CreatePacker(TR1Level level)

--- a/TRModelTransporter/Model/Textures/RemapTypes/TR2TextureRemapGroup.cs
+++ b/TRModelTransporter/Model/Textures/RemapTypes/TR2TextureRemapGroup.cs
@@ -7,12 +7,7 @@ public class TR2TextureRemapGroup : AbstractTextureRemapGroup<TR2Type, TR2Level>
 {
     protected override IEnumerable<TR2Type> GetModelTypes(TR2Level level)
     {
-        List<TR2Type> types = new();
-        foreach (TRModel model in level.Models)
-        {
-            types.Add((TR2Type)model.ID);
-        }
-        return types;
+        return level.Models.Keys.ToList();
     }
 
     protected override AbstractTexturePacker<TR2Type, TR2Level> CreatePacker(TR2Level level)

--- a/TRModelTransporter/Model/Textures/RemapTypes/TR3TextureRemapGroup.cs
+++ b/TRModelTransporter/Model/Textures/RemapTypes/TR3TextureRemapGroup.cs
@@ -7,12 +7,7 @@ public class TR3TextureRemapGroup : AbstractTextureRemapGroup<TR3Type, TR3Level>
 {
     protected override IEnumerable<TR3Type> GetModelTypes(TR3Level level)
     {
-        List<TR3Type> types = new();
-        foreach (TRModel model in level.Models)
-        {
-            types.Add((TR3Type)model.ID);
-        }
-        return types;
+        return level.Models.Keys.ToList();
     }
 
     protected override AbstractTexturePacker<TR3Type, TR3Level> CreatePacker(TR3Level level)

--- a/TRModelTransporter/Packing/Types/TR1TexturePacker.cs
+++ b/TRModelTransporter/Packing/Types/TR1TexturePacker.cs
@@ -59,7 +59,7 @@ public class TR1TexturePacker : AbstractTexturePacker<TR1Type, TR1Level>
 
     protected override List<TRMesh> GetModelMeshes(TR1Type modelEntity)
     {
-        return Level.Models.Find(m => m.ID == (uint)modelEntity)?.Meshes;
+        return Level.Models[modelEntity]?.Meshes;
     }
 
     protected override TRSpriteSequence GetSpriteSequence(TR1Type entity)
@@ -69,12 +69,7 @@ public class TR1TexturePacker : AbstractTexturePacker<TR1Type, TR1Level>
 
     protected override IEnumerable<TR1Type> GetAllModelTypes()
     {
-        List<TR1Type> modelIDs = new();
-        foreach (TRModel model in Level.Models)
-        {
-            modelIDs.Add((TR1Type)model.ID);
-        }
-        return modelIDs;
+        return Level.Models.Keys.ToList();
     }
 
     protected override void CreateImageSpace(int count)

--- a/TRModelTransporter/Packing/Types/TR2TexturePacker.cs
+++ b/TRModelTransporter/Packing/Types/TR2TexturePacker.cs
@@ -56,7 +56,7 @@ public class TR2TexturePacker : AbstractTexturePacker<TR2Type, TR2Level>
 
     protected override List<TRMesh> GetModelMeshes(TR2Type modelEntity)
     {
-        return Level.Models.Find(m => m.ID == (uint)modelEntity)?.Meshes;
+        return Level.Models[modelEntity]?.Meshes;
     }
 
     protected override TRSpriteSequence GetSpriteSequence(TR2Type entity)
@@ -66,12 +66,7 @@ public class TR2TexturePacker : AbstractTexturePacker<TR2Type, TR2Level>
 
     protected override IEnumerable<TR2Type> GetAllModelTypes()
     {
-        List<TR2Type> modelIDs = new();
-        foreach (TRModel model in Level.Models)
-        {
-            modelIDs.Add((TR2Type)model.ID);
-        }
-        return modelIDs;
+        return Level.Models.Keys.ToList();
     }
 
     protected override void CreateImageSpace(int count)

--- a/TRModelTransporter/Packing/Types/TR3TexturePacker.cs
+++ b/TRModelTransporter/Packing/Types/TR3TexturePacker.cs
@@ -56,7 +56,7 @@ public class TR3TexturePacker : AbstractTexturePacker<TR3Type, TR3Level>
 
     protected override List<TRMesh> GetModelMeshes(TR3Type modelEntity)
     {
-        return Level.Models.Find(m => m.ID == (uint)modelEntity)?.Meshes;
+        return Level.Models[modelEntity]?.Meshes;
     }
 
     protected override TRSpriteSequence GetSpriteSequence(TR3Type entity)
@@ -66,12 +66,7 @@ public class TR3TexturePacker : AbstractTexturePacker<TR3Type, TR3Level>
 
     protected override IEnumerable<TR3Type> GetAllModelTypes()
     {
-        List<TR3Type> modelIDs = new();
-        foreach (TRModel model in Level.Models)
-        {
-            modelIDs.Add((TR3Type)model.ID);
-        }
-        return modelIDs;
+        return Level.Models.Keys.ToList();
     }
 
     protected override void CreateImageSpace(int count)

--- a/TRModelTransporter/Transport/TR1/TR1ModelExporter.cs
+++ b/TRModelTransporter/Transport/TR1/TR1ModelExporter.cs
@@ -96,7 +96,7 @@ public class TR1ModelExporter : AbstractTRModelExporter<TR1Type, TR1Level, TR1Mo
 
     public static void AmendPierreGunshot(TR1Level level)
     {
-        TRModel model = level.Models.Find(m => m.ID == (uint)TR1Type.Pierre);
+        TRModel model = level.Models[TR1Type.Pierre];
         // Get his shooting animation
         TRAnimation anim = model.Animations[10];
 
@@ -110,7 +110,7 @@ public class TR1ModelExporter : AbstractTRModelExporter<TR1Type, TR1Level, TR1Mo
 
     public static void AmendPierreDeath(TR1Level level)
     {
-        TRModel model = level.Models.Find(m => m.ID == (uint)TR1Type.Pierre);
+        TRModel model = level.Models[TR1Type.Pierre];
         // Get his death animation
         TRAnimation anim = model.Animations[12];
 
@@ -124,7 +124,7 @@ public class TR1ModelExporter : AbstractTRModelExporter<TR1Type, TR1Level, TR1Mo
 
     public static void AmendLarsonDeath(TR1Level level)
     {
-        TRModel model = level.Models.Find(m => m.ID == (uint)TR1Type.Larson);
+        TRModel model = level.Models[TR1Type.Larson];
         // Get his death animation
         TRAnimation anim = model.Animations[15];
 
@@ -138,7 +138,7 @@ public class TR1ModelExporter : AbstractTRModelExporter<TR1Type, TR1Level, TR1Mo
 
     public static void AmendSkaterBoyDeath(TR1Level level)
     {
-        TRModel model = level.Models.Find(m => m.ID == (uint)TR1Type.SkateboardKid);
+        TRModel model = level.Models[TR1Type.SkateboardKid];
         // Get his death animation
         TRAnimation anim = model.Animations[13];
         // Play the death sound on the 2nd frame (doesn't work on the 1st, which is OG).
@@ -147,7 +147,7 @@ public class TR1ModelExporter : AbstractTRModelExporter<TR1Type, TR1Level, TR1Mo
 
     public static void AmendNatlaDeath(TR1Level level)
     {
-        TRModel model = level.Models.Find(m => m.ID == (uint)TR1Type.Natla);
+        TRModel model = level.Models[TR1Type.Natla];
         // Get her death animation
         TRAnimation anim = model.Animations[13];
 
@@ -170,7 +170,7 @@ public class TR1ModelExporter : AbstractTRModelExporter<TR1Type, TR1Level, TR1Mo
             level.SoundEffects[TR1SFX.TrapdoorClose] = vilcabamba.SoundEffects[TR1SFX.TrapdoorClose];
         }
 
-        TRModel model = level.Models.Find(m => m.ID == (uint)TR1Type.MovingBlock);
+        TRModel model = level.Models[TR1Type.MovingBlock];
         for (int i = 2; i < 4; i++)
         {
             TRAnimation anim = model.Animations[i];

--- a/TRModelTransporter/Transport/TR1/TR1ModelImporter.cs
+++ b/TRModelTransporter/Transport/TR1/TR1ModelImporter.cs
@@ -33,7 +33,7 @@ public class TR1ModelImporter : AbstractTRModelImporter<TR1Type, TR1Level, TR1Mo
 
     protected override List<TR1Type> GetExistingModelTypes()
     {
-        return Level.Models.Select(m => (TR1Type)m.ID).ToList();
+        return Level.Models.Keys.ToList();
     }
 
     protected override void Import(IEnumerable<TR1ModelDefinition> standardDefinitions, IEnumerable<TR1ModelDefinition> soundOnlyDefinitions)

--- a/TRModelTransporter/Transport/TR2/TR2ModelImporter.cs
+++ b/TRModelTransporter/Transport/TR2/TR2ModelImporter.cs
@@ -21,7 +21,7 @@ public class TR2ModelImporter : AbstractTRModelImporter<TR2Type, TR2Level, TR2Mo
 
     protected override List<TR2Type> GetExistingModelTypes()
     {
-        return Level.Models.Select(m => (TR2Type)m.ID).ToList();
+        return Level.Models.Keys.ToList();
     }
 
     protected override void Import(IEnumerable<TR2ModelDefinition> standardDefinitions, IEnumerable<TR2ModelDefinition> soundOnlyDefinitions)

--- a/TRModelTransporter/Transport/TR3/TR3ModelImporter.cs
+++ b/TRModelTransporter/Transport/TR3/TR3ModelImporter.cs
@@ -22,7 +22,7 @@ public class TR3ModelImporter : AbstractTRModelImporter<TR3Type, TR3Level, TR3Mo
 
     protected override List<TR3Type> GetExistingModelTypes()
     {
-        return Level.Models.Select(m => (TR3Type)m.ID).ToList();
+        return Level.Models.Keys.ToList();
     }
 
     protected override void Import(IEnumerable<TR3ModelDefinition> standardDefinitions, IEnumerable<TR3ModelDefinition> soundOnlyDefinitions)

--- a/TRRandomizerCore/Levels/TR1CombinedLevel.cs
+++ b/TRRandomizerCore/Levels/TR1CombinedLevel.cs
@@ -73,9 +73,4 @@ public class TR1CombinedLevel
     /// Returns {Name}-Steam if IsSteamPyramid, otherwise just {Name}.
     /// </summary>
     public string JsonID => IsSteamPyramid ? Name + "-Steam" : Name;
-
-    public void RemoveModel(TR1Type type)
-    {
-        Data.Models.RemoveAll(m => m.ID == (uint)type);
-    }
 }

--- a/TRRandomizerCore/Levels/TR3CombinedLevel.cs
+++ b/TRRandomizerCore/Levels/TR3CombinedLevel.cs
@@ -126,9 +126,4 @@ public class TR3CombinedLevel
             return TR3Adventure.India;
         }
     }
-
-    public void RemoveModel(TR3Type type)
-    {
-        Data.Models.RemoveAll(m => m.ID == (uint)type);
-    }
 }

--- a/TRRandomizerCore/Processors/TR2/TR2ModelAdjuster.cs
+++ b/TRRandomizerCore/Processors/TR2/TR2ModelAdjuster.cs
@@ -46,11 +46,8 @@ public class TR2ModelAdjuster : TR2LevelProcessor
         // of the old model, should also point to the new model type.
         foreach (TR2Type oldEntity in _modelRemap.Keys)
         {
-            TRModel model = _levelInstance.Data.Models.Find(m => m.ID == (short)oldEntity);
-            if (model != null)
+            if (_levelInstance.Data.Models.ChangeKey(oldEntity, _modelRemap[oldEntity]))
             {
-                model.ID = (uint)_modelRemap[oldEntity];
-
                 List<TR2Entity> modelEntities = _levelInstance.Data.Entities.FindAll(e => e.TypeID == oldEntity);
                 foreach (TR2Entity entity in modelEntities)
                 {

--- a/TRRandomizerCore/Processors/TR3/TR3SequenceProcessor.cs
+++ b/TRRandomizerCore/Processors/TR3/TR3SequenceProcessor.cs
@@ -194,9 +194,8 @@ public class TR3SequenceProcessor : TR3LevelProcessor
         // test here for the likes of Jungle.
         if (!Settings.RandomizeEnemies
             && level.Data.Entities.Any(e => e.TypeID == TR3Type.Monkey)
-            && level.Data.Models.Any(m => (TR3Type)m.ID == TR3Type.Tiger))
+            && level.Data.Models.Remove(TR3Type.Tiger))
         {
-            level.RemoveModel(TR3Type.Tiger);
             level.Data.Entities.Where(e => e.TypeID == TR3Type.Tiger)
                 .ToList()
                 .ForEach(e => e.TypeID = TR3Type.Monkey);
@@ -249,7 +248,7 @@ public class TR3SequenceProcessor : TR3LevelProcessor
         List<TR3Type> imports = new();
         foreach (TR3Type artefactMenuModel in TR3TypeUtilities.GetArtefactMenuModels())
         {
-            if (level.Data.Models.Find(m => m.ID == (uint)artefactMenuModel) == null)
+            if (!level.Data.Models.ContainsKey(artefactMenuModel))
             {
                 imports.Add(artefactMenuModel);
             }
@@ -275,10 +274,8 @@ public class TR3SequenceProcessor : TR3LevelProcessor
         foreach (TR3Type artefact in _artefactAssignment.Keys)
         {
             TR3Type replacement = _artefactAssignment[artefact];
-            TRModel artefactModel = level.Data.Models.Find(m => m.ID == (uint)artefact);
-            TRModel replacementModel = artefactModel.Clone();
-            replacementModel.ID = (uint)replacement;
-            level.Data.Models.Add(replacementModel);
+            TRModel artefactModel = level.Data.Models[artefact];
+            level.Data.Models[replacement] = artefactModel.Clone();
 
             level.Data.Entities
                 .FindAll(e => e.TypeID == artefact)

--- a/TRRandomizerCore/Randomizers/TR1/TR1OutfitRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/TR1OutfitRandomizer.cs
@@ -324,7 +324,7 @@ public class TR1OutfitRandomizer : BaseTR1Randomizer
             }
 
             // Find the texture references for the plain parts of imported hair
-            List<TRMesh> ponytailMeshes = level.Data.Models.Find(m => m.ID == (uint)TR1Type.LaraPonytail_H_U).Meshes;
+            List<TRMesh> ponytailMeshes = level.Data.Models[TR1Type.LaraPonytail_H_U].Meshes;
 
             ushort plainHairQuad = ponytailMeshes[0].TexturedRectangles[0].Texture;
             ushort plainHairTri = ponytailMeshes[5].TexturedTriangles[0].Texture;
@@ -340,7 +340,7 @@ public class TR1OutfitRandomizer : BaseTR1Randomizer
 
             foreach (TR1Type laraType in headAmendments.Keys)
             {
-                List<TRMesh> meshes = level.Data.Models.Find(m => m.ID == (uint)laraType)?.Meshes;
+                List<TRMesh> meshes = level.Data.Models[laraType]?.Meshes;
                 if (meshes == null || meshes.Count < 15)
                 {
                     continue;
@@ -373,11 +373,11 @@ public class TR1OutfitRandomizer : BaseTR1Randomizer
         
         private static void CreateGoldenBraid(TR1CombinedLevel level)
         {
-            TRModel model = level.Data.Models.Find(m => m.ID == (uint)TR1Type.LaraMiscAnim_H);
+            TRModel model = level.Data.Models[TR1Type.LaraMiscAnim_H];
             TRMesh goldenHips = model.Meshes[0];
             ushort goldPalette = goldenHips.ColouredRectangles[0].Texture;
 
-            TRModel ponytail = level.Data.Models.Find(m => m.ID == (uint)TR1Type.LaraPonytail_H_U);
+            TRModel ponytail = level.Data.Models[TR1Type.LaraPonytail_H_U];
             ponytail.Meshes.AddRange(ponytail.Meshes.Select(m => MeshEditor.CloneMeshAsColoured(m, goldPalette)));
             ponytail.MeshTrees.AddRange(ponytail.MeshTrees);
         }
@@ -387,7 +387,7 @@ public class TR1OutfitRandomizer : BaseTR1Randomizer
             MeshEditor editor = new();
             foreach (TR1Type ent in entities)
             {
-                List<TRMesh> meshes = level.Data.Models.Find(m => m.ID == (uint)ent)?.Meshes;
+                List<TRMesh> meshes = level.Data.Models[ent]?.Meshes;
                 if (meshes != null)
                 {
                     foreach (TRMesh mesh in meshes)
@@ -438,7 +438,7 @@ public class TR1OutfitRandomizer : BaseTR1Randomizer
             // Make the backpack shallower so the braid doesn't smash into it
             foreach (TR1Type ent in laraEntities)
             {
-                TRMesh mesh = level.Data.Models.Find(m => m.ID == (uint)ent).Meshes[7];
+                TRMesh mesh = level.Data.Models[ent].Meshes[7];
                 for (int i = 26; i < 30; i++)
                 {
                     mesh.Vertices[i].Z += 12;
@@ -469,7 +469,7 @@ public class TR1OutfitRandomizer : BaseTR1Randomizer
             {
                 // Lara's head may be Natla's or Pierre's, so only support the braid if
                 // the mesh is the original.
-                TRMesh larasHead = parentLevel.CutSceneLevel.Data.Models.Find(m => m.ID == (uint)TR1Type.CutsceneActor1).Meshes[14];
+                TRMesh larasHead = parentLevel.CutSceneLevel.Data.Models[TR1Type.CutsceneActor1].Meshes[14];
                 return larasHead.CollRadius == 68;
             }
 
@@ -483,12 +483,12 @@ public class TR1OutfitRandomizer : BaseTR1Randomizer
                 return;
             }
 
-            List<TRMesh> lara = level.Data.Models.Find(m => m.ID == (uint)(level.IsCutScene ? TR1Type.CutsceneActor1 : TR1Type.Lara)).Meshes;
-            List<TRMesh> laraPistol = level.Data.Models.Find(m => m.ID == (uint)TR1Type.LaraPistolAnim_H).Meshes;
-            List<TRMesh> laraShotgun = level.Data.Models.Find(m => m.ID == (uint)TR1Type.LaraShotgunAnim_H).Meshes;
-            List<TRMesh> laraMagnums = level.Data.Models.Find(m => m.ID == (uint)TR1Type.LaraMagnumAnim_H).Meshes;
-            List<TRMesh> laraUzis = level.Data.Models.Find(m => m.ID == (uint)TR1Type.LaraUziAnimation_H).Meshes;
-            List<TRMesh> laraMisc = level.Data.Models.Find(m => m.ID == (uint)TR1Type.LaraMiscAnim_H).Meshes;
+            List<TRMesh> lara = level.Data.Models[(level.IsCutScene ? TR1Type.CutsceneActor1 : TR1Type.Lara)].Meshes;
+            List<TRMesh> laraPistol = level.Data.Models[TR1Type.LaraPistolAnim_H].Meshes;
+            List<TRMesh> laraShotgun = level.Data.Models[TR1Type.LaraShotgunAnim_H].Meshes;
+            List<TRMesh> laraMagnums = level.Data.Models[TR1Type.LaraMagnumAnim_H].Meshes;
+            List<TRMesh> laraUzis = level.Data.Models[TR1Type.LaraUziAnimation_H].Meshes;
+            List<TRMesh> laraMisc = level.Data.Models[TR1Type.LaraMiscAnim_H].Meshes;
 
             // Basic meshes to take from LaraMiscAnim. We don't replace Lara's gloves
             // or thighs (at this stage - handled below with gun swaps).
@@ -587,9 +587,9 @@ public class TR1OutfitRandomizer : BaseTR1Randomizer
                 return;
             }
 
-            List<TRMesh> lara = level.Data.Models.Find(m => m.ID == (uint)(level.IsCutScene ? TR1Type.CutsceneActor1 : TR1Type.Lara)).Meshes;
-            List<TRMesh> laraShotgun = level.Data.Models.Find(m => m.ID == (uint)TR1Type.LaraShotgunAnim_H).Meshes;
-            List<TRMesh> laraMisc = level.Data.Models.Find(m => m.ID == (uint)TR1Type.LaraMiscAnim_H).Meshes;
+            List<TRMesh> lara = level.Data.Models[(level.IsCutScene ? TR1Type.CutsceneActor1 : TR1Type.Lara)].Meshes;
+            List<TRMesh> laraShotgun = level.Data.Models[TR1Type.LaraShotgunAnim_H].Meshes;
+            List<TRMesh> laraMisc = level.Data.Models[TR1Type.LaraMiscAnim_H].Meshes;
 
             // Just the torso
             laraMisc[7].CopyInto(lara[7]);
@@ -686,7 +686,7 @@ public class TR1OutfitRandomizer : BaseTR1Randomizer
                 return false;
             }
 
-            TRModel existingModel = level.Data.Models.Find(m => m.ID == (uint)TR1Type.LaraMiscAnim_H);
+            TRModel existingModel = level.Data.Models[TR1Type.LaraMiscAnim_H];
             if (existingModel != null)
             {
                 // If we already have the gym outfit available, we're done.
@@ -718,7 +718,7 @@ public class TR1OutfitRandomizer : BaseTR1Randomizer
                 // e.g. for Adam death animation and scion pickups.
                 if (existingModel != null)
                 {
-                    TRModel newModel = level.Data.Models.Find(m => m.ID == (uint)TR1Type.LaraMiscAnim_H);
+                    TRModel newModel = level.Data.Models[TR1Type.LaraMiscAnim_H];
                     newModel.Animations = existingModel.Animations;
                 }
 
@@ -804,9 +804,9 @@ public class TR1OutfitRandomizer : BaseTR1Randomizer
 
         private void ConvertToMauledOutfit(TR1CombinedLevel level)
         {
-            List<TRMesh> lara = level.Data.Models.Find(m => m.ID == (uint)(level.IsCutScene ? TR1Type.CutsceneActor1 : TR1Type.Lara)).Meshes;
-            List<TRMesh> laraShotgun = level.Data.Models.Find(m => m.ID == (uint)TR1Type.LaraShotgunAnim_H).Meshes;
-            List<TRMesh> laraMisc = level.Data.Models.Find(m => m.ID == (uint)TR1Type.LaraMiscAnim_H).Meshes;
+            List<TRMesh> lara = level.Data.Models[(level.IsCutScene ? TR1Type.CutsceneActor1 : TR1Type.Lara)].Meshes;
+            List<TRMesh> laraShotgun = level.Data.Models[TR1Type.LaraShotgunAnim_H].Meshes;
+            List<TRMesh> laraMisc = level.Data.Models[TR1Type.LaraMiscAnim_H].Meshes;
 
             if (level.Is(TR1LevelNames.QUALOPEC_CUT))
             {
@@ -862,7 +862,7 @@ public class TR1OutfitRandomizer : BaseTR1Randomizer
             };
             foreach (TR1Type gunAnimType in gunAnims)
             {
-                List<TRMesh> meshes = level.Data.Models.Find(m => m.ID == (uint)gunAnimType)?.Meshes;
+                List<TRMesh> meshes = level.Data.Models[gunAnimType]?.Meshes;
                 if (meshes == null)
                     continue;
 

--- a/TRRandomizerCore/Randomizers/TR1/TR1SecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/TR1SecretRandomizer.cs
@@ -506,17 +506,17 @@ public class TR1SecretRandomizer : BaseTR1Randomizer, ISecretRandomizer
     {
         if (TR1TypeUtilities.IsKeyType(itemType))
         {
-            PopulateScriptStrings(itemType - TR1Type.Key1_S_P, level.Script.Keys, "K");
+            PopulateScriptStrings((int)(itemType - TR1Type.Key1_S_P), level.Script.Keys, "K");
             level.Script.Keys.Add(name);
         }
         else if (TR1TypeUtilities.IsPuzzleType(itemType))
         {
-            PopulateScriptStrings(itemType - TR1Type.Puzzle1_S_P, level.Script.Puzzles, "P");
+            PopulateScriptStrings((int)(itemType - TR1Type.Puzzle1_S_P), level.Script.Puzzles, "P");
             level.Script.Puzzles.Add(name);
         }
         else if (TR1TypeUtilities.IsQuestType(itemType))
         {
-            PopulateScriptStrings(itemType - TR1Type.Quest1_S_P, level.Script.Pickups, "Q");
+            PopulateScriptStrings((int)(itemType - TR1Type.Quest1_S_P), level.Script.Pickups, "Q");
             level.Script.Pickups.Add(name);
         }
     }
@@ -835,7 +835,7 @@ public class TR1SecretRandomizer : BaseTR1Randomizer, ISecretRandomizer
                 // We exclude current puzzle/key items from the available switching pool.
                 foreach (TR1Type puzzleType in _modelReplacements.Keys)
                 {
-                    if (level.Data.Models.Find(m => m.ID == (uint)puzzleType) == null)
+                    if (!level.Data.Models.ContainsKey(puzzleType))
                     {
                         allocation.AvailablePickupModels.Add(puzzleType);
                     }
@@ -875,15 +875,14 @@ public class TR1SecretRandomizer : BaseTR1Randomizer, ISecretRandomizer
                         TR1Type puzzleModelType = allocation.AvailablePickupModels.First();
                         TR1Type puzzlePickupType = _modelReplacements[puzzleModelType];
 
-                        TRModel puzzleModel = level.Data.Models.Find(m => m.ID == (uint)secretModelType);
-                        puzzleModel.ID = (uint)puzzleModelType;
+                        level.Data.Models.ChangeKey(secretModelType, puzzleModelType);
                         level.Data.SpriteSequences.Find(s => s.SpriteID == (int)secretPickupType).SpriteID = (int)puzzlePickupType;
 
                         if (secretModelType == TR1Type.SecretScion_M_H && _outer.Are3DPickupsEnabled())
                         {
                             // TR1X embeds scions into the ground when they are puzzle/key types in 3D mode,
                             // so we counteract that here to avoid uncollectable items.
-                            TRMesh scionMesh = puzzleModel.Meshes[0];
+                            TRMesh scionMesh = level.Data.Models[puzzleModelType].Meshes[0];
                             foreach (TRVertex vertex in scionMesh.Vertices)
                             {
                                 vertex.Y -= 90;

--- a/TRRandomizerCore/Randomizers/TR2/TR2EnemyRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR2/TR2EnemyRandomizer.cs
@@ -487,26 +487,17 @@ public class TR2EnemyRandomizer : BaseTR2Randomizer
         });
     }
 
-    private static void DisguiseEntity(TR2CombinedLevel level, TR2Type guiser, TR2Type targetEntity)
+    private static void DisguiseEntity(TR2CombinedLevel level, TR2Type guiser, TR2Type targetType)
     {
-        int existingIndex = level.Data.Models.FindIndex(m => m.ID == (short)guiser);
-        if (existingIndex != -1)
-        {
-            level.Data.Models.RemoveAt(existingIndex);
-        }
-
-        TRModel disguiseAsModel = level.Data.Models.Find(m => m.ID == (short)targetEntity);
-        if (targetEntity == TR2Type.BirdMonster && level.Is(TR2LevelNames.CHICKEN))
+        if (targetType == TR2Type.BirdMonster && level.Is(TR2LevelNames.CHICKEN))
         {
             // We have to keep the original model for the boss, so in
             // this instance we just clone the model for the guiser
-            TRModel guiserModel = disguiseAsModel.Clone();
-            guiserModel.ID = (uint)guiser;
-            level.Data.Models.Add(guiserModel);
+            level.Data.Models[guiser] = level.Data.Models[targetType].Clone();
         }
         else
         {
-            disguiseAsModel.ID = (uint)guiser;
+            level.Data.Models.ChangeKey(targetType, guiser);
         }
     }
 
@@ -926,10 +917,10 @@ public class TR2EnemyRandomizer : BaseTR2Randomizer
 
         if (laraClones.Count > 0)
         {
-            TRModel laraModel = level.Data.Models.Find(m => m.ID == (uint)TR2Type.Lara);
+            TRModel laraModel = level.Data.Models[TR2Type.Lara];
             foreach (TR2Type enemyType in laraClones)
             {
-                TRModel enemyModel = level.Data.Models.Find(m => m.ID == (uint)enemyType);
+                TRModel enemyModel = level.Data.Models[enemyType];
                 enemyModel.MeshTrees = laraModel.MeshTrees;
                 enemyModel.Meshes = laraModel.Meshes;
             }
@@ -943,8 +934,8 @@ public class TR2EnemyRandomizer : BaseTR2Randomizer
             && _generator.Next(0, chance) == 0)
         {
             // Make Marco look and behave like Winston, until Lara gets too close
-            TRModel marcoModel = level.Data.Models.Find(m => m.ID == (uint)TR2Type.MarcoBartoli);
-            TRModel winnieModel = level.Data.Models.Find(m => m.ID == (uint)TR2Type.Winston);
+            TRModel marcoModel = level.Data.Models[TR2Type.MarcoBartoli];
+            TRModel winnieModel = level.Data.Models[TR2Type.Winston];
             marcoModel.Animations = winnieModel.Animations;
             marcoModel.MeshTrees = winnieModel.MeshTrees;
             marcoModel.Meshes = winnieModel.Meshes;
@@ -964,7 +955,7 @@ public class TR2EnemyRandomizer : BaseTR2Randomizer
         // #327 Trick the game into never reaching the final frame of the death animation.
         // This results in a very abrupt death but avoids the level ending. For Ice Palace,
         // environment modifications will be made to enforce an alternative ending.
-        TRModel model = level.Data.Models.Find(m => m.ID == (uint)TR2Type.BirdMonster);
+        TRModel model = level.Data.Models[TR2Type.BirdMonster];
         if (model != null)
         {
             model.Animations[20].FrameEnd = model.Animations[19].FrameEnd;

--- a/TRRandomizerCore/Randomizers/TR2/TR2OutfitRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR2/TR2OutfitRandomizer.cs
@@ -229,8 +229,10 @@ public class TR2OutfitRandomizer : BaseTR2Randomizer
 
         private bool Import(TR2CombinedLevel level, TR2Type lara)
         {
-            TRModel laraModel = level.Data.Models.Find(m => m.ID == (uint)TR2Type.Lara);
-            List<TRModel> laraClones = level.Data.Models.FindAll(m => m.MeshTrees.FirstOrDefault() == laraModel.MeshTrees.FirstOrDefault() && m != laraModel);
+            TRModel laraModel = level.Data.Models[TR2Type.Lara];
+            List<TRModel> laraClones = level.Data.Models.Values
+                .Where(m => m.MeshTrees.FirstOrDefault() == laraModel.MeshTrees.FirstOrDefault() && m != laraModel)
+                .ToList();
 
             if (lara == TR2Type.LaraInvisible)
             {
@@ -275,7 +277,7 @@ public class TR2OutfitRandomizer : BaseTR2Randomizer
                 // #314 Any clones of Lara should copy her new style
                 if (laraClones.Count > 0)
                 {
-                    laraModel = level.Data.Models.Find(m => m.ID == (uint)TR2Type.Lara);
+                    laraModel = level.Data.Models[TR2Type.Lara];
                     foreach (TRModel model in laraClones)
                     {
                         model.MeshTrees = laraModel.MeshTrees;
@@ -318,7 +320,7 @@ public class TR2OutfitRandomizer : BaseTR2Randomizer
             MeshEditor editor = new();
             foreach (TR2Type ent in entities)
             {
-                List<TRMesh> meshes = level.Data.Models.Find(m => m.ID == (uint)ent)?.Meshes;
+                List<TRMesh> meshes = level.Data.Models[ent]?.Meshes;
                 if (meshes != null)
                 {
                     foreach (TRMesh mesh in meshes)
@@ -338,13 +340,13 @@ public class TR2OutfitRandomizer : BaseTR2Randomizer
 
         private void AdjustOutfit(TR2CombinedLevel level, TR2Type lara)
         {
-            TRModel laraModel = level.Data.Models.Find(m => m.ID == (uint)TR2Type.Lara);
+            TRModel laraModel = level.Data.Models[TR2Type.Lara];
             if (level.Is(TR2LevelNames.HOME) && lara != TR2Type.LaraHome)
             {
                 // This ensures that Lara's hips match the new outfit for the starting animation and shower cutscene,
                 // otherwise the dressing gown hips are rendered, but the mesh is completely different for this, plus
                 // its textures will have been removed.
-                TRModel laraMiscModel = level.Data.Models.Find(m => m.ID == (uint)TR2Type.LaraMiscAnim_H);
+                TRModel laraMiscModel = level.Data.Models[TR2Type.LaraMiscAnim_H];
                 laraModel.Meshes[0].CopyInto(laraMiscModel.Meshes[0]);
             }
 
@@ -377,14 +379,14 @@ public class TR2OutfitRandomizer : BaseTR2Randomizer
                         // so we basically just retain the hand.
                         MeshEditor editor = new()
                         {
-                            Mesh = level.Data.Models.Find(m => m.ID == (uint)TR2Type.LaraMiscAnim_H).Meshes[10]
+                            Mesh = level.Data.Models[TR2Type.LaraMiscAnim_H].Meshes[10]
                         };
 
                         editor.RemoveTexturedRectangleRange(6, 20);
                         editor.ClearTexturedTriangles();
 
                         // And hide it from the inventory
-                        foreach (TRMesh mesh in level.Data.Models.Find(m => m.ID == (uint)TR2Type.Puzzle1_M_H).Meshes)
+                        foreach (TRMesh mesh in level.Data.Models[TR2Type.Puzzle1_M_H].Meshes)
                         {
                             editor.Mesh = mesh;
                             editor.ClearTexturedRectangles();
@@ -400,8 +402,8 @@ public class TR2OutfitRandomizer : BaseTR2Randomizer
                 // into the diving suit, but model ID 99 is the one before. We always want the cutscene actor to
                 // match DA, but this unfortunately means she'll leave the cutscene in the same outfit. She just
                 // didn't like the look of any of the alternatives...
-                TRModel actorLara = level.Data.Models.Find(m => m.ID == (short)TR2Type.CutsceneActor3);
-                TRModel realLara = level.Data.Models.Find(m => m.ID == (short)TR2Type.Lara);
+                TRModel actorLara = level.Data.Models[TR2Type.CutsceneActor3];
+                TRModel realLara = level.Data.Models[TR2Type.Lara];
 
                 actorLara.MeshTrees = realLara.MeshTrees;
                 actorLara.Meshes = realLara.Meshes;

--- a/TRRandomizerCore/Randomizers/TR3/TR3EnemyRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/TR3EnemyRandomizer.cs
@@ -360,7 +360,7 @@ public class TR3EnemyRandomizer : BaseTR3Randomizer
         {
             TR3Type banishedType = _generator.NextDouble() < 0.5 ? TR3Type.Tiger : TR3Type.Monkey;
             availableEnemyTypes.Remove(banishedType);
-            level.RemoveModel(banishedType);
+            level.Data.Models.Remove(banishedType);
         }
 
         List<TR3Type> droppableEnemies = TR3TypeUtilities.FilterDroppableEnemies(availableEnemyTypes, Settings.ProtectMonks);
@@ -747,10 +747,9 @@ public class TR3EnemyRandomizer : BaseTR3Randomizer
 
                     // Remove stale tiger model if present to avoid friendly monkeys causing vehicle crashes.
                     if (level.HasVehicle
-                        && enemies.EntitiesToImport.Contains(TR3Type.Monkey)
-                        && level.Data.Models.Any(m => m.ID == (uint)TR3Type.Tiger))
+                        && enemies.EntitiesToImport.Contains(TR3Type.Monkey))
                     {
-                        level.RemoveModel(TR3Type.Tiger);
+                        level.Data.Models.Remove(TR3Type.Tiger);
                     }
                 }
 

--- a/TRRandomizerCore/Randomizers/TR3/TR3OutfitRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/TR3OutfitRandomizer.cs
@@ -271,7 +271,7 @@ public class TR3OutfitRandomizer : BaseTR3Randomizer
             MeshEditor editor = new();
             foreach (TR3Type ent in entities)
             {
-                List<TRMesh> meshes = level.Data.Models.Find(m => m.ID == (uint)ent)?.Meshes;
+                List<TRMesh> meshes = level.Data.Models[ent]?.Meshes;
                 if (meshes != null)
                 {
                     foreach (TRMesh mesh in meshes)

--- a/TRRandomizerCore/Randomizers/TR3/TR3TextureRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/TR3TextureRandomizer.cs
@@ -17,7 +17,7 @@ public class TR3TextureRandomizer : BaseTR3Randomizer, ITextureVariantHandler
     private static readonly Color[] _wireframeColours = ColorUtilities.GetWireframeColours();
 
     private readonly Dictionary<AbstractTextureSource, string> _persistentVariants;
-    private readonly Dictionary<string, WireframeData> _wireframeData;
+    private readonly Dictionary<string, WireframeData<TR3Type>> _wireframeData;
     private readonly object _drawLock;
     private TR3TextureDatabase _textureDatabase;
     private Dictionary<TextureCategory, bool> _textureOptions;
@@ -31,7 +31,7 @@ public class TR3TextureRandomizer : BaseTR3Randomizer, ITextureVariantHandler
     public TR3TextureRandomizer()
     {
         _persistentVariants = new Dictionary<AbstractTextureSource, string>();
-        _wireframeData = JsonConvert.DeserializeObject<Dictionary<string, WireframeData>>(ReadResource(@"TR3\Textures\wireframing.json"));
+        _wireframeData = JsonConvert.DeserializeObject<Dictionary<string, WireframeData<TR3Type>>>(ReadResource(@"TR3\Textures\wireframing.json"));
         _drawLock = new object();
     }
 
@@ -170,14 +170,14 @@ public class TR3TextureRandomizer : BaseTR3Randomizer, ITextureVariantHandler
             _persistentWireColour = _wireframeColours[_generator.Next(0, _wireframeColours.Length)];
         }
 
-        foreach (WireframeData data in _wireframeData.Values.ToList())
+        foreach (WireframeData<TR3Type> data in _wireframeData.Values)
         {
             data.HighlightLadders = Settings.UseWireframeLadders;
             data.HighlightTriggers = data.HighlightDeathTiles = Settings.ShowWireframeTriggers;
             data.SolidInteractables = Settings.UseSolidInteractableWireframing;
             foreach (SpecialTextureHandling special in data.SpecialTextures)
             {
-                List<SpecialTextureMode> modes = WireframeData.GetDrawModes(special.Type);
+                List<SpecialTextureMode> modes = WireframeData<TR3Type>.GetDrawModes(special.Type);
                 special.Mode = modes[_generator.Next(0, modes.Count)];
             }
         }
@@ -253,7 +253,7 @@ public class TR3TextureRandomizer : BaseTR3Randomizer, ITextureVariantHandler
             (_solidLaraLevels.Contains(lvl.Script) || (lvl.IsCutScene && _solidLaraLevels.Contains(lvl.ParentLevel.Script)));
     }
 
-    private WireframeData GetWireframeData(TR3CombinedLevel lvl)
+    private WireframeData<TR3Type> GetWireframeData(TR3CombinedLevel lvl)
     {
         if (IsWireframeLevel(lvl))
         {
@@ -320,11 +320,11 @@ public class TR3TextureRandomizer : BaseTR3Randomizer, ITextureVariantHandler
 
                     if (_outer.IsWireframeLevel(level))
                     {
-                        WireframeData data = _outer.GetWireframeData(level);
+                        WireframeData<TR3Type> data = _outer.GetWireframeData(level);
                         data.SolidEnemies = _outer.Settings.UseSolidEnemyWireframing;
                         if (level.IsCutScene)
                         {
-                            WireframeData parentData = _outer.GetWireframeData(level.ParentLevel);
+                            WireframeData<TR3Type> parentData = _outer.GetWireframeData(level.ParentLevel);
                             data.HighlightColour = parentData.HighlightColour;
                             data.SolidLara = parentData.SolidLara;
                         }
@@ -356,9 +356,9 @@ public class TR3TextureRandomizer : BaseTR3Randomizer, ITextureVariantHandler
 
                         if (_outer.Settings.UseDifferentWireframeColours)
                         {
-                            foreach (TRModel model in level.Data.Models)
+                            foreach (TR3Type type in level.Data.Models.Keys)
                             {
-                                data.ModelColours[model.ID] = _outer.GetWireframeVariant();
+                                data.ModelColours[type] = _outer.GetWireframeVariant();
                             }
                         }
                     }

--- a/TRRandomizerCore/Textures/DynamicTextureBuilder.cs
+++ b/TRRandomizerCore/Textures/DynamicTextureBuilder.cs
@@ -123,7 +123,7 @@ public class DynamicTextureBuilder
         }
         else
         {
-            hips = level.Data.Models.Find(m => m.ID == (uint)TR1Type.Lara).Meshes[0];
+            hips = level.Data.Models[TR1Type.Lara].Meshes[0];
             if (level.Data.Entities.Any(e => e.TypeID == TR1Type.MidasHand_N))
             {
                 modelIDs.Add(TR1Type.LaraMiscAnim_H);
@@ -135,19 +135,19 @@ public class DynamicTextureBuilder
         // Lara will be partially re-textured.
         foreach (TR1Type modelID in modelIDs)
         {
-            TRModel model = level.Data.Models.Find(m => m.ID == (uint)modelID);
+            TRModel model = level.Data.Models[modelID];
             if (model != null)
             {
-                AddModelTextures(level.Data, model, hips, defaultObjectTextures, modelMeshes);
+                AddModelTextures(level.Data, modelID, model, hips, defaultObjectTextures, modelMeshes);
             }
         }
 
         foreach (TR1Type modelID in _enemyIDs)
         {
-            TRModel model = level.Data.Models.Find(m => m.ID == (uint)modelID);
+            TRModel model = level.Data.Models[modelID];
             if (model != null)
             {
-                AddModelTextures(level.Data, model, hips, enemyObjectTextures, modelMeshes);
+                AddModelTextures(level.Data, modelID, model, hips, enemyObjectTextures, modelMeshes);
             }
         }
 
@@ -172,7 +172,7 @@ public class DynamicTextureBuilder
         Dictionary<TR1Type, TR1Type> keyItems = TR1TypeUtilities.GetKeyItemMap();
         foreach (TR1Type pickupType in keyItems.Keys)
         {
-            TRModel model = level.Data.Models.Find(m => m.ID == (uint)keyItems[pickupType]);
+            TRModel model = level.Data.Models[keyItems[pickupType]];
             if (model == null)
             {
                 continue;
@@ -185,14 +185,14 @@ public class DynamicTextureBuilder
                 TRRoomSector sector = FDUtilities.GetRoomSector(keyInstance.X, keyInstance.Y, keyInstance.Z, keyInstance.Room, level.Data, floorData);
                 if (LocationUtilities.SectorContainsSecret(sector, floorData))
                 {
-                    AddModelTextures(level.Data, model, hips, secretObjectTextures, modelMeshes);
+                    AddModelTextures(level.Data, pickupType, model, hips, secretObjectTextures, modelMeshes);
                     AddSpriteTextures(level.Data, pickupType, secretSpriteTextures);
                     continue;
                 }
             }
                 
             // Otherwise it's a regular key item
-            AddModelTextures(level.Data, model, hips, keyItemObjectTextures, modelMeshes);
+            AddModelTextures(level.Data, pickupType, model, hips, keyItemObjectTextures, modelMeshes);
             AddSpriteTextures(level.Data, pickupType, keyItemSpriteTextures);
         }
 
@@ -222,9 +222,8 @@ public class DynamicTextureBuilder
         };
     }
 
-    private void AddModelTextures(TR1Level level, TRModel model, TRMesh dummyMesh, ISet<int> textures, ISet<TRMesh> meshCollection)
+    private void AddModelTextures(TR1Level level, TR1Type modelID, TRModel model, TRMesh dummyMesh, ISet<int> textures, ISet<TRMesh> meshCollection)
     {
-        TR1Type modelID = (TR1Type)model.ID;
         if (TextureMonitor?.RemovedTextures?.Contains(modelID) ?? false)
         {
             // Don't include textures that may have been re-assigned to other imported models (e.g. enemies).
@@ -238,7 +237,7 @@ public class DynamicTextureBuilder
             return;
         }
 
-        if (modelID == TR1Type.Cowboy && level.Models.Find(m => m.ID == (uint)TR1Type.Cowboy).Meshes[2].TexturedRectangles.Count > 0)
+        if (modelID == TR1Type.Cowboy && level.Models[TR1Type.Cowboy].Meshes[2].TexturedRectangles.Count > 0)
         {
             // We only want to target LeoC's headless cowboy - in this case the cowboy is OG.
             return;

--- a/TRRandomizerCore/Textures/Wireframing/TR2Wireframer.cs
+++ b/TRRandomizerCore/Textures/Wireframing/TR2Wireframer.cs
@@ -34,14 +34,13 @@ public class TR2Wireframer : AbstractTRWireframer<TR2Type, TR2Level>
         return new TR2TexturePacker(level);
     }
 
-    protected override bool IsSkybox(TRModel model)
+    protected override bool IsSkybox(TR2Type type)
     {
-        return (TR2Type)model.ID == TR2Type.Skybox_H;
+        return type == TR2Type.Skybox_H;
     }
 
-    protected override bool IsInteractableModel(TRModel model)
+    protected override bool IsInteractableModel(TR2Type type)
     {
-        TR2Type type = (TR2Type)model.ID;
         return TR2TypeUtilities.IsSwitchType(type)
             || TR2TypeUtilities.IsKeyholeType(type)
             || TR2TypeUtilities.IsSlotType(type)
@@ -58,12 +57,7 @@ public class TR2Wireframer : AbstractTRWireframer<TR2Type, TR2Level>
         return level.GetInvalidObjectTextureIndices();
     }
 
-    protected override IEnumerable<TRMesh> GetLevelMeshes(TR2Level level)
-    {
-        return level.Models.SelectMany(m => m.Meshes).Concat(level.StaticMeshes.Select(s => s.Mesh));
-    }
-
-    protected override List<TRModel> GetModels(TR2Level level)
+    protected override TRDictionary<TR2Type, TRModel> GetModels(TR2Level level)
     {
         return level.Models;
     }
@@ -99,15 +93,14 @@ public class TR2Wireframer : AbstractTRWireframer<TR2Type, TR2Level>
         return _paletteTracker.Import(c);
     }
 
-    protected override bool IsLaraModel(TRModel model)
+    protected override bool IsLaraModel(TR2Type type)
     {
-        return _laraEntities.Contains((TR2Type)model.ID);
+        return _laraEntities.Contains(type);
     }
 
-    protected override bool IsEnemyModel(TRModel model)
+    protected override bool IsEnemyModel(TR2Type type)
     {
-        TR2Type id = (TR2Type)model.ID;
-        return TR2TypeUtilities.IsEnemyType(id) || _additionalEnemyEntities.Contains(id);
+        return TR2TypeUtilities.IsEnemyType(type) || _additionalEnemyEntities.Contains(type);
     }
 
     protected override void ResetUnusedTextures(TR2Level level)

--- a/TRRandomizerCore/Textures/Wireframing/TR3Wireframer.cs
+++ b/TRRandomizerCore/Textures/Wireframing/TR3Wireframer.cs
@@ -34,9 +34,8 @@ public class TR3Wireframer : AbstractTRWireframer<TR3Type, TR3Level>
         return new TR3TexturePacker(level);
     }
 
-    protected override bool IsInteractableModel(TRModel model)
+    protected override bool IsInteractableModel(TR3Type type)
     {
-        TR3Type type = (TR3Type)model.ID;
         return TR3TypeUtilities.IsSwitchType(type)
             || TR3TypeUtilities.IsKeyholeType(type)
             || TR3TypeUtilities.IsSlotType(type)
@@ -53,12 +52,7 @@ public class TR3Wireframer : AbstractTRWireframer<TR3Type, TR3Level>
         return level.GetInvalidObjectTextureIndices();
     }
 
-    protected override IEnumerable<TRMesh> GetLevelMeshes(TR3Level level)
-    {
-        return level.Models.SelectMany(m => m.Meshes).Concat(level.StaticMeshes.Select(s => s.Mesh));
-    }
-
-    protected override List<TRModel> GetModels(TR3Level level)
+    protected override TRDictionary<TR3Type, TRModel> GetModels(TR3Level level)
     {
         return level.Models;
     }
@@ -94,25 +88,23 @@ public class TR3Wireframer : AbstractTRWireframer<TR3Type, TR3Level>
         return _paletteTracker.Import(c);
     }
 
-    protected override bool IsLaraModel(TRModel model)
+    protected override bool IsLaraModel(TR3Type type)
     {
-        return _laraEntities.Contains((TR3Type)model.ID);
+        return _laraEntities.Contains(type);
     }
 
-    protected override bool IsEnemyModel(TRModel model)
+    protected override bool IsEnemyModel(TR3Type type)
     {
-        TR3Type id = (TR3Type)model.ID;
-        return TR3TypeUtilities.IsEnemyType(id) || _additionalEnemyEntities.Contains(id);
+        return TR3TypeUtilities.IsEnemyType(type) || _additionalEnemyEntities.Contains(type);
     }
 
-    protected override bool IsSkybox(TRModel model)
+    protected override bool IsSkybox(TR3Type type)
     {
-        return (TR3Type)model.ID == TR3Type.Skybox_H;
+        return type == TR3Type.Skybox_H;
     }
 
-    protected override bool ShouldSolidifyModel(TRModel model)
+    protected override bool ShouldSolidifyModel(TR3Type type)
     {
-        TR3Type type = (TR3Type)model.ID;
         return TR3TypeUtilities.IsAnyPickupType(type) || TR3TypeUtilities.IsCrystalPickup(type);
     }
 

--- a/TRRandomizerCore/Textures/Wireframing/WireframeData.cs
+++ b/TRRandomizerCore/Textures/Wireframing/WireframeData.cs
@@ -2,7 +2,8 @@
 
 namespace TRRandomizerCore.Textures;
 
-public class WireframeData
+public class WireframeData<T>
+    where T : Enum
 {
     /// <summary>
     /// Textures that will be retained, such as water surfaces.
@@ -54,12 +55,12 @@ public class WireframeData
     /// <summary>
     /// Models that should also use solid textures if SolidEnemies is enabled (e.g. CutsceneActors)
     /// </summary>
-    public List<uint> SolidModels { get; set; }
+    public List<T> SolidModels { get; set; }
 
     /// <summary>
     /// Allows different solid colours to be allocated per model.
     /// </summary>
-    public Dictionary<uint, Color> ModelColours { get; set; }
+    public Dictionary<T, Color> ModelColours { get; set; }
 
     /// <summary>
     /// Where textures are shared within segments, and we want to exclude only parts, we "clip" out the rest.

--- a/TRRandomizerCore/Utilities/TR1EnemyUtilities.cs
+++ b/TRRandomizerCore/Utilities/TR1EnemyUtilities.cs
@@ -583,7 +583,7 @@ public static class TR1EnemyUtilities
         }
 
         TR1Type type = CodeBitsToAtlantean(entity.CodeBits);
-        return level.Data.Models.Find(m => m.ID == (uint)type) == null;
+        return !level.Data.Models.ContainsKey(type);
     }
 
     public static bool CanDropItems(TR1Entity entity, TR1CombinedLevel level, FDControl floorData)

--- a/TRTexture16Importer/Helpers/TRPalette16Control.cs
+++ b/TRTexture16Importer/Helpers/TRPalette16Control.cs
@@ -9,10 +9,10 @@ public class TRPalette16Control
     private readonly Queue<int> _freeIndices;
 
     public TRPalette16Control(TR2Level level)
-        : this(level.Palette16, level.Models.SelectMany(m => m.Meshes).Concat(level.StaticMeshes.Select(s => s.Mesh))) { }
+        : this(level.Palette16, level.DistinctMeshes) { }
 
     public TRPalette16Control(TR3Level level)
-        : this(level.Palette16, level.Models.SelectMany(m => m.Meshes).Concat(level.StaticMeshes.Select(s => s.Mesh))) { }
+        : this(level.Palette16, level.DistinctMeshes) { }
 
     public TRPalette16Control(List<TRColour4> palette16, IEnumerable<TRMesh> meshes)
     {

--- a/TRTexture16Importer/Helpers/TRPalette8Control.cs
+++ b/TRTexture16Importer/Helpers/TRPalette8Control.cs
@@ -63,24 +63,26 @@ public class TRPalette8Control : IDisposable
 
         // Grab meshes we aren't interested in - but don't remove Lara's hips e.g. Atlantean spawns
         List<TRMesh> ignoredMeshes = new();
-        List<TRMesh> laraMeshes = Level.Models.Find(m => m.ID == (uint)TR1Type.Lara)?.Meshes;
+        Level.Models.TryGetValue(TR1Type.Lara, out TRModel lara);
         foreach (TR1Type entity in ObsoleteModels)
         {
-            List<TRMesh> meshes = Level.Models.Find(m => m.ID == (uint)entity)?.Meshes;
-            if (meshes != null)
+            Level.Models.TryGetValue(entity, out TRModel model);
+            if (model == null)
             {
-                foreach (TRMesh mesh in meshes)
+                continue;
+            }
+
+            foreach (TRMesh mesh in model.Meshes)
+            {
+                if (lara == null || !lara.Meshes.Contains(mesh))
                 {
-                    if (laraMeshes == null || !laraMeshes.Contains(mesh))
-                    {
-                        ignoredMeshes.AddRange(meshes);
-                    }
+                    ignoredMeshes.AddRange(model.Meshes);
                 }
             }
         }
 
         // Update all colours used in all meshes
-        foreach (TRMesh mesh in Level.Models.SelectMany(m => m.Meshes).Concat(Level.StaticMeshes.Select(s => s.Mesh)))
+        foreach (TRMesh mesh in Level.DistinctMeshes)
         {
             if (ignoredMeshes.Contains(mesh))
             {
@@ -158,7 +160,7 @@ public class TRPalette8Control : IDisposable
             }
         }
 
-        foreach (TRMesh mesh in Level.Models.SelectMany(m => m.Meshes).Concat(Level.StaticMeshes.Select(s => s.Mesh)))
+        foreach (TRMesh mesh in Level.DistinctMeshes)
         {
             foreach (TRMeshFace face in mesh.ColouredFaces)
             {

--- a/TRTexture16Importer/Textures/Mapping/TR1TextureMapping.cs
+++ b/TRTexture16Importer/Textures/Mapping/TR1TextureMapping.cs
@@ -46,7 +46,7 @@ public class TR1TextureMapping : AbstractTextureMapping<TR1Type, TR1Level>
 
     protected override List<TRMesh> GetModelMeshes(TR1Type entity)
     {
-        return _level.Models.Find(m => m.ID == (uint)entity)?.Meshes;
+        return _level.Models.ContainsKey(entity) ? _level.Models[entity].Meshes : null;
     }
 
     protected override List<TRSpriteSequence> GetSpriteSequences()

--- a/TRTexture16Importer/Textures/Mapping/TR2TextureMapping.cs
+++ b/TRTexture16Importer/Textures/Mapping/TR2TextureMapping.cs
@@ -42,7 +42,7 @@ public class TR2TextureMapping : AbstractTextureMapping<TR2Type, TR2Level>
 
     protected override List<TRMesh> GetModelMeshes(TR2Type entity)
     {
-        return _level.Models.Find(m => m.ID == (uint)entity).Meshes;
+        return _level.Models.ContainsKey(entity) ? _level.Models[entity].Meshes : null;
     }
 
     protected override List<TRSpriteSequence> GetSpriteSequences()

--- a/TRTexture16Importer/Textures/Mapping/TR3TextureMapping.cs
+++ b/TRTexture16Importer/Textures/Mapping/TR3TextureMapping.cs
@@ -43,7 +43,7 @@ public class TR3TextureMapping : AbstractTextureMapping<TR3Type, TR3Level>
 
     protected override List<TRMesh> GetModelMeshes(TR3Type entity)
     {
-        return _level.Models.Find(m => m.ID == (uint)entity).Meshes;
+        return _level.Models.ContainsKey(entity) ? _level.Models[entity].Meshes : null;
     }
 
     protected override List<TRSpriteSequence> GetSpriteSequences()

--- a/TextureExport/Types/DependencyExporter.cs
+++ b/TextureExport/Types/DependencyExporter.cs
@@ -9,9 +9,9 @@ public static class DependencyExporter
     public static void Export(TR1Level level, string lvl)
     {
         TR1TextureRemapGroup remapGroup = new();
-        foreach (TRModel model in level.Models)
+        foreach (TR1Type type in level.Models.Keys)
         {
-            remapGroup.CalculateDependencies(level, (TR1Type)model.ID);
+            remapGroup.CalculateDependencies(level, type);
         }
 
         foreach (TextureDependency<TR1Type> dependency in remapGroup.Dependencies)
@@ -46,9 +46,9 @@ public static class DependencyExporter
     public static void Export(TR2Level level, string lvl)
     {
         TR2TextureRemapGroup remapGroup = new();
-        foreach (TRModel model in level.Models)
+        foreach (TR2Type type in level.Models.Keys)
         {
-            remapGroup.CalculateDependencies(level, (TR2Type)model.ID);
+            remapGroup.CalculateDependencies(level, type);
         }
 
         string dir = @"TR2\Deduplication";
@@ -59,9 +59,9 @@ public static class DependencyExporter
     public static void Export(TR3Level level, string lvl)
     {
         TR3TextureRemapGroup remapGroup = new();
-        foreach (TRModel model in level.Models)
+        foreach (TR3Type type in level.Models.Keys)
         {
-            remapGroup.CalculateDependencies(level, (TR3Type)model.ID);
+            remapGroup.CalculateDependencies(level, type);
         }
 
         remapGroup.Dependencies.Sort(delegate (TextureDependency<TR3Type> d1, TextureDependency<TR3Type> d2)

--- a/TextureExport/Types/HtmlExporter.cs
+++ b/TextureExport/Types/HtmlExporter.cs
@@ -43,7 +43,7 @@ public static class HtmlExporter
         BuildLevelSelect(levelSel, lvlName, TR2LevelNames.AsOrderedList);
 
         StringBuilder skyboxInfo = new();
-        Dictionary<int, TRColour4> skyColours = GetSkyBoxColours(level.Models.Find(m => m.ID == (uint)TR2Type.Skybox_H)?.Meshes, level.Palette16);
+        Dictionary<int, TRColour4> skyColours = GetSkyBoxColours(level.Models[TR2Type.Skybox_H]?.Meshes, level.Palette16);
         BuildSkyBox(skyboxInfo, skyColours);
 
         Write("TR2", lvlName, tiles, levelSel, skyboxInfo);
@@ -59,7 +59,7 @@ public static class HtmlExporter
         BuildLevelSelect(levelSel, lvlName, TR3LevelNames.AsOrderedList);
 
         StringBuilder skyboxInfo = new();
-        Dictionary<int, TRColour4> skyColours = GetSkyBoxColours(level.Models.Find(m => m.ID == (uint)TR3Type.Skybox_H)?.Meshes, level.Palette16);
+        Dictionary<int, TRColour4> skyColours = GetSkyBoxColours(level.Models[TR3Type.Skybox_H]?.Meshes, level.Palette16);
         BuildSkyBox(skyboxInfo, skyColours);
 
         Write("TR3", lvlName, tiles, levelSel, skyboxInfo);


### PR DESCRIPTION
Part of #619.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Models are now stored in dictionaries in levels. These are sorted, so this means when changing available models we automatically write back in order of model type. Previously, writing back was based on the order in which new models were added - although the engines support this, it's not how the original levels are compiled.

Added a utility property to each level to retrieve each distinct mesh because some are shared between models and we generally want to perform actions on them only once.
