### PR TITLE
Fix mirrored textures

### DIFF
--- a/TREnvironmentEditor/Model/Types/Mirroring/EMMirrorFunction.cs
+++ b/TREnvironmentEditor/Model/Types/Mirroring/EMMirrorFunction.cs
@@ -1035,7 +1035,7 @@ public class EMMirrorFunction : BaseEMFunction
     {
         foreach (ushort textureRef in textureReferences)
         {
-            objectTextures[textureRef].FlipHorizontal();
+            objectTextures[textureRef].FlipVertical();
         }
     }
 

--- a/TREnvironmentEditor/Model/Types/Mirroring/EMMirrorModelFunction.cs
+++ b/TREnvironmentEditor/Model/Types/Mirroring/EMMirrorModelFunction.cs
@@ -81,7 +81,7 @@ public class EMMirrorModelFunction : BaseEMFunction
     {
         foreach (ushort textureRef in textureReferences)
         {
-            objectTextures[textureRef].FlipHorizontal();
+            objectTextures[textureRef].FlipVertical();
         }
     }
 }

--- a/TREnvironmentEditor/Model/Types/Mirroring/EMMirrorObjectTexture.cs
+++ b/TREnvironmentEditor/Model/Types/Mirroring/EMMirrorObjectTexture.cs
@@ -25,7 +25,7 @@ public class EMMirrorObjectTexture : BaseEMFunction
     {
         foreach (ushort textureRef in Textures)
         {
-            levelTextures[textureRef].FlipHorizontal();
+            levelTextures[textureRef].FlipVertical();
         }
     }
 }

--- a/TREnvironmentEditor/Model/Types/Mirroring/EMMirrorStaticMeshFunction.cs
+++ b/TREnvironmentEditor/Model/Types/Mirroring/EMMirrorStaticMeshFunction.cs
@@ -8,33 +8,26 @@ public class EMMirrorStaticMeshFunction : BaseEMFunction
 
     public override void ApplyToLevel(TR1Level level)
     {
-        IEnumerable<TRMesh> meshes = level.StaticMeshes
-            .Where(kvp => MeshIDs.Contains(kvp.Key - TR1Type.SceneryBase))
-            .Select(kvp => kvp.Value.Mesh);
-
-        MirrorMeshes(meshes);
+        MirrorMeshes(level.StaticMeshes);
     }
 
     public override void ApplyToLevel(TR2Level level)
     {
-        IEnumerable<TRMesh> meshes = level.StaticMeshes
-            .Where(kvp => MeshIDs.Contains(kvp.Key - TR2Type.SceneryBase))
-            .Select(kvp => kvp.Value.Mesh);
-
-        MirrorMeshes(meshes);
+        MirrorMeshes(level.StaticMeshes);
     }
 
     public override void ApplyToLevel(TR3Level level)
     {
-        IEnumerable<TRMesh> meshes = level.StaticMeshes
-            .Where(kvp => MeshIDs.Contains(kvp.Key - TR3Type.SceneryBase))
-            .Select(kvp => kvp.Value.Mesh);
-
-        MirrorMeshes(meshes);
+        MirrorMeshes(level.StaticMeshes);
     }
 
-    private static void MirrorMeshes(IEnumerable<TRMesh> meshes)
+    private void MirrorMeshes<T>(TRDictionary<T, TRStaticMesh> staticMeshes)
+        where T : Enum
     {
+        IEnumerable<TRMesh> meshes = staticMeshes
+            .Where(kvp => MeshIDs.Contains((uint)(object)kvp.Key))
+            .Select(kvp => kvp.Value.Mesh);
+
         foreach (TRMesh mesh in meshes)
         {
             foreach (TRVertex vert in mesh.Vertices)


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Related to #648. Because face vertices are also flipped we need to (unintuitively) flip textures vertically rather than horizontally when mirroring.