### PR TITLE
Parse demo data

### DIFF
--- a/TRLevelControl/Build/TRDemoBuilder.cs
+++ b/TRLevelControl/Build/TRDemoBuilder.cs
@@ -1,0 +1,76 @@
+﻿using TRLevelControl.Model;
+
+namespace TRLevelControl.Build;
+
+public class TRDemoBuilder<G, I>
+    where G : Enum
+    where I : Enum
+{
+    private readonly TRGameVersion _version;
+
+    public TRDemoBuilder(TRGameVersion version)
+    {
+        _version = version;
+    }
+
+    public TRDemoData<G, I> Read(TRLevelReader reader)
+    {
+        ushort numDemoData = reader.ReadUInt16();
+        if (numDemoData == 0)
+        {
+            return null;
+        }
+
+        TRDemoData<G, I> demoData = new()
+        {
+            LaraPos = reader.ReadVertex32(),
+            LaraRot = reader.ReadVertex32(),
+            LaraRoom = reader.ReadInt32(),
+        };
+
+        if (_version > TRGameVersion.TR1)
+        {
+            demoData.LaraLastGun = (G)(object)reader.ReadInt32();
+        }
+
+        int inputData;
+        while ((inputData = reader.ReadInt32()) != -1)
+        {
+            demoData.Inputs.Add((I)(object)inputData);
+        }
+
+        return demoData;
+    }
+
+    public void Write(TRDemoData<G, I> demoData, TRLevelWriter writer)
+    {
+        if (demoData == null)
+        {
+            writer.Write((ushort)0);
+            return;
+        }
+
+        byte[] data;
+        {
+            using MemoryStream ms = new();
+            using TRLevelWriter demoWriter = new(ms);
+
+            demoWriter.Write(demoData.LaraPos);
+            demoWriter.Write(demoData.LaraRot);
+            demoWriter.Write(demoData.LaraRoom);
+
+            if (_version > TRGameVersion.TR1)
+            {
+                demoWriter.Write((int)(object)demoData.LaraLastGun);
+            }
+
+            demoWriter.Write(demoData.Inputs.Select(i => (int)(object)i));
+            demoWriter.Write(-1);
+
+            data = ms.ToArray();
+        }
+
+        writer.Write((ushort)data.Length);
+        writer.Write(data);
+    }
+}

--- a/TRLevelControl/Control/TR1LevelControl.cs
+++ b/TRLevelControl/Control/TR1LevelControl.cs
@@ -67,8 +67,7 @@ public class TR1LevelControl : TRLevelControlBase<TR1Level>
 
         ReadCinematicFrames(reader);
 
-        ushort numDemoData = reader.ReadUInt16();
-        _level.DemoData = reader.ReadBytes(numDemoData);
+        ReadDemoData(reader);
 
         ReadSoundEffects(reader);
     }
@@ -103,8 +102,7 @@ public class TR1LevelControl : TRLevelControlBase<TR1Level>
 
         WriteCinematicFrames(writer);
 
-        writer.Write((ushort)_level.DemoData.Length);
-        writer.Write(_level.DemoData);
+        WriteDemoData(writer);
 
         WriteSoundEffects(writer);
     }
@@ -288,6 +286,18 @@ public class TR1LevelControl : TRLevelControlBase<TR1Level>
     {
         writer.Write((ushort)_level.CinematicFrames.Count);
         writer.Write(_level.CinematicFrames);
+    }
+
+    private void ReadDemoData(TRLevelReader reader)
+    {
+        TRDemoBuilder<TR1DemoGun, TR1InputState> builder = new(TRGameVersion.TR1);
+        _level.DemoData = builder.Read(reader);
+    }
+
+    private void WriteDemoData(TRLevelWriter writer)
+    {
+        TRDemoBuilder<TR1DemoGun, TR1InputState> builder = new(TRGameVersion.TR1);
+        builder.Write(_level.DemoData, writer);
     }
 
     private void ReadSoundEffects(TRLevelReader reader)

--- a/TRLevelControl/Control/TR2LevelControl.cs
+++ b/TRLevelControl/Control/TR2LevelControl.cs
@@ -67,8 +67,7 @@ public class TR2LevelControl : TRLevelControlBase<TR2Level>
 
         ReadCinematicFrames(reader);
 
-        ushort numDemoData = reader.ReadUInt16();
-        _level.DemoData = reader.ReadBytes(numDemoData);
+        ReadDemoData(reader);
 
         ReadSoundEffects(reader);
     }
@@ -103,8 +102,7 @@ public class TR2LevelControl : TRLevelControlBase<TR2Level>
 
         WriteCinematicFrames(writer);
 
-        writer.Write((ushort)_level.DemoData.Length);
-        writer.Write(_level.DemoData);
+        WriteDemoData(writer);
 
         WriteSoundEffects(writer);
     }
@@ -294,6 +292,18 @@ public class TR2LevelControl : TRLevelControlBase<TR2Level>
     {
         writer.Write((ushort)_level.CinematicFrames.Count);
         writer.Write(_level.CinematicFrames);
+    }
+
+    private void ReadDemoData(TRLevelReader reader)
+    {
+        TRDemoBuilder<TR2DemoGun, TR2InputState> builder = new(TRGameVersion.TR2);
+        _level.DemoData = builder.Read(reader);
+    }
+
+    private void WriteDemoData(TRLevelWriter writer)
+    {
+        TRDemoBuilder<TR2DemoGun, TR2InputState> builder = new(TRGameVersion.TR2);
+        builder.Write(_level.DemoData, writer);
     }
 
     private void ReadSoundEffects(TRLevelReader reader)

--- a/TRLevelControl/Control/TR3LevelControl.cs
+++ b/TRLevelControl/Control/TR3LevelControl.cs
@@ -67,8 +67,7 @@ public class TR3LevelControl : TRLevelControlBase<TR3Level>
 
         ReadCinematicFrames(reader);
 
-        ushort numDemoData = reader.ReadUInt16();
-        _level.DemoData = reader.ReadBytes(numDemoData);
+        ReadDemoData(reader);
 
         ReadSoundEffects(reader);
     }
@@ -103,8 +102,7 @@ public class TR3LevelControl : TRLevelControlBase<TR3Level>
 
         WriteCinematicFrames(writer);
 
-        writer.Write((ushort)_level.DemoData.Length);
-        writer.Write(_level.DemoData);
+        WriteDemoData(writer);
 
         WriteSoundEffects(writer);
     }
@@ -294,6 +292,18 @@ public class TR3LevelControl : TRLevelControlBase<TR3Level>
     {
         writer.Write((ushort)_level.CinematicFrames.Count);
         writer.Write(_level.CinematicFrames);
+    }
+
+    private void ReadDemoData(TRLevelReader reader)
+    {
+        TRDemoBuilder<TR3DemoGun, TR3InputState> builder = new(TRGameVersion.TR3);
+        _level.DemoData = builder.Read(reader);
+    }
+
+    private void WriteDemoData(TRLevelWriter writer)
+    {
+        TRDemoBuilder<TR3DemoGun, TR3InputState> builder = new(TRGameVersion.TR3);
+        builder.Write(_level.DemoData, writer);
     }
 
     private void ReadSoundEffects(TRLevelReader reader)

--- a/TRLevelControl/Control/TR4LevelControl.cs
+++ b/TRLevelControl/Control/TR4LevelControl.cs
@@ -315,16 +315,15 @@ public class TR4LevelControl : TRLevelControlBase<TR4Level>
         writer.Write(_level.AIEntities);
     }
 
-    private void ReadDemoData(TRLevelReader reader)
+    private static void ReadDemoData(TRLevelReader reader)
     {
         ushort numDemoData = reader.ReadUInt16();
-        _level.DemoData = reader.ReadBytes(numDemoData);
+        Debug.Assert(numDemoData == 0);
     }
 
     private void WriteDemoData(TRLevelWriter writer)
     {
-        writer.Write((ushort)_level.DemoData.Length);
-        writer.Write(_level.DemoData);
+        writer.Write((ushort)0);
     }
 
     private void ReadSoundEffects(TRLevelReader reader)

--- a/TRLevelControl/Control/TR5LevelControl.cs
+++ b/TRLevelControl/Control/TR5LevelControl.cs
@@ -367,16 +367,15 @@ public class TR5LevelControl : TRLevelControlBase<TR5Level>
         writer.Write(_level.AIEntities);
     }
 
-    private void ReadDemoData(TRLevelReader reader)
+    private static void ReadDemoData(TRLevelReader reader)
     {
         ushort numDemoData = reader.ReadUInt16();
-        _level.DemoData = reader.ReadBytes(numDemoData);
+        Debug.Assert(numDemoData == 0);
     }
 
     private void WriteDemoData(TRLevelWriter writer)
     {
-        writer.Write((ushort)_level.DemoData.Length);
-        writer.Write(_level.DemoData);
+        writer.Write((ushort)0);
     }
 
     private void ReadSoundEffects(TRLevelReader reader)

--- a/TRLevelControl/Model/Common/TRDemoData.cs
+++ b/TRLevelControl/Model/Common/TRDemoData.cs
@@ -1,0 +1,12 @@
+﻿namespace TRLevelControl.Model;
+
+public class TRDemoData<G, I>
+    where G : Enum
+    where I : Enum
+{
+    public TRVertex32 LaraPos { get; set; }
+    public TRVertex32 LaraRot { get; set; }
+    public int LaraRoom { get; set; }
+    public G LaraLastGun { get; set; }
+    public List<I> Inputs { get; set; } = new();
+}

--- a/TRLevelControl/Model/TR1/Enums/TR1DemoGun.cs
+++ b/TRLevelControl/Model/TR1/Enums/TR1DemoGun.cs
@@ -1,0 +1,6 @@
+﻿namespace TRLevelControl.Model;
+
+public enum TR1DemoGun
+{
+    None = 0,
+}

--- a/TRLevelControl/Model/TR1/Enums/TR1InputState.cs
+++ b/TRLevelControl/Model/TR1/Enums/TR1InputState.cs
@@ -1,0 +1,24 @@
+﻿namespace TRLevelControl.Model;
+
+[Flags]
+public enum TR1InputState
+{
+    None        = 0,
+    Forward     = 1 << 0,
+    Back        = 1 << 1,
+    Left        = 1 << 2,
+    Right       = 1 << 3,
+    Jump        = 1 << 4,
+    Draw        = 1 << 5,
+    Action      = 1 << 6,
+    Walk        = 1 << 7,
+    Option      = 1 << 8,
+    Look        = 1 << 9,
+    StepLeft    = 1 << 10,
+    StepRight   = 1 << 11,
+    Roll        = 1 << 12,
+    MenuConfirm = 1 << 20,
+    MenuBack    = 1 << 21,
+    Save        = 1 << 22,
+    Load        = 1 << 23,
+}

--- a/TRLevelControl/Model/TR1/TR1Level.cs
+++ b/TRLevelControl/Model/TR1/TR1Level.cs
@@ -12,7 +12,7 @@ public class TR1Level : TRLevelBase
     public List<byte> LightMap { get; set; }
     public List<TRColour> Palette { get; set; }
     public List<TRCinematicFrame> CinematicFrames { get; set; }
-    public byte[] DemoData { get; set; }
+    public TRDemoData<TR1DemoGun, TR1InputState> DemoData { get; set; }
     public SortedDictionary<TR1SFX, TR1SoundEffect> SoundEffects { get; set; }
 
     public override IEnumerable<TRMesh> DistinctMeshes => Models.Values.SelectMany(m => m.Meshes)

--- a/TRLevelControl/Model/TR2/Enums/TR2DemoGun.cs
+++ b/TRLevelControl/Model/TR2/Enums/TR2DemoGun.cs
@@ -1,0 +1,13 @@
+﻿namespace TRLevelControl.Model;
+
+public enum TR2DemoGun
+{
+    None            = 0,
+    Pistols         = 1,
+    Autos           = 2,
+    Uzis            = 3,
+    Shotgun         = 4,
+    M16             = 5,
+    GrenadeLauncher = 6,
+    Harpoon         = 7,
+}

--- a/TRLevelControl/Model/TR2/Enums/TR2InputState.cs
+++ b/TRLevelControl/Model/TR2/Enums/TR2InputState.cs
@@ -1,0 +1,25 @@
+﻿namespace TRLevelControl.Model;
+
+[Flags]
+public enum TR2InputState
+{
+    None        = 0,
+    Forward     = 1 << 0,
+    Back        = 1 << 1,
+    Left        = 1 << 2,
+    Right       = 1 << 3,
+    Jump        = 1 << 4,
+    Draw        = 1 << 5,
+    Action      = 1 << 6,
+    Walk        = 1 << 7,
+    Option      = 1 << 8,
+    Look        = 1 << 9,
+    StepLeft    = 1 << 10,
+    StepRight   = 1 << 11,
+    Roll        = 1 << 12,
+    Flare       = 1 << 19,
+    MenuConfirm = 1 << 20,
+    MenuBack    = 1 << 21,
+    Save        = 1 << 22,
+    Load        = 1 << 23,
+}

--- a/TRLevelControl/Model/TR2/TR2Level.cs
+++ b/TRLevelControl/Model/TR2/TR2Level.cs
@@ -14,7 +14,7 @@ public class TR2Level : TRLevelBase
     public List<TR2Entity> Entities { get; set; }
     public List<byte> LightMap { get; set; }
     public List<TRCinematicFrame> CinematicFrames { get; set; }
-    public byte[] DemoData { get; set; }
+    public TRDemoData<TR2DemoGun, TR2InputState> DemoData { get; set; }
     public SortedDictionary<TR2SFX, TR2SoundEffect> SoundEffects { get; set; }
 
     public override IEnumerable<TRMesh> DistinctMeshes => Models.Values.SelectMany(m => m.Meshes)

--- a/TRLevelControl/Model/TR3/Enums/TR3DemoGun.cs
+++ b/TRLevelControl/Model/TR3/Enums/TR3DemoGun.cs
@@ -1,0 +1,14 @@
+﻿namespace TRLevelControl.Model;
+
+public enum TR3DemoGun
+{
+    None            = 0,
+    Pistols         = 1,
+    DEagle          = 2,
+    Uzis            = 3,
+    Shotgun         = 4,
+    MP5             = 5,
+    RocketLauncher  = 6,
+    GrenadeLauncher = 7,
+    Harpoon         = 8,
+}

--- a/TRLevelControl/Model/TR3/Enums/TR3InputState.cs
+++ b/TRLevelControl/Model/TR3/Enums/TR3InputState.cs
@@ -1,0 +1,27 @@
+﻿namespace TRLevelControl.Model;
+
+[Flags]
+public enum TR3InputState
+{
+    None        = 0,
+    Forward     = 1 << 0,
+    Back        = 1 << 1,
+    Left        = 1 << 2,
+    Right       = 1 << 3,
+    Jump        = 1 << 4,
+    Draw        = 1 << 5,
+    Action      = 1 << 6,
+    Walk        = 1 << 7,
+    Option      = 1 << 8,
+    Look        = 1 << 9,
+    StepLeft    = 1 << 10,
+    StepRight   = 1 << 11,
+    Roll        = 1 << 12,
+    Flare       = 1 << 19,
+    MenuConfirm = 1 << 20,
+    MenuBack    = 1 << 21,
+    Save        = 1 << 22,
+    Load        = 1 << 23,
+    Duck        = 1 << 30,
+    Sprint      = 1 << 31,
+}

--- a/TRLevelControl/Model/TR3/TR3Level.cs
+++ b/TRLevelControl/Model/TR3/TR3Level.cs
@@ -14,7 +14,7 @@ public class TR3Level : TRLevelBase
     public List<TR3Entity> Entities { get; set; }
     public List<byte> LightMap { get; set; }
     public List<TRCinematicFrame> CinematicFrames { get; set; }
-    public byte[] DemoData { get; set; }
+    public TRDemoData<TR3DemoGun, TR3InputState> DemoData { get; set; }
     public SortedDictionary<TR3SFX, TR3SoundEffect> SoundEffects { get; set; }
 
     public override IEnumerable<TRMesh> DistinctMeshes => Models.Values.SelectMany(m => m.Meshes)

--- a/TRLevelControl/Model/TR4/TR4Level.cs
+++ b/TRLevelControl/Model/TR4/TR4Level.cs
@@ -11,7 +11,6 @@ public class TR4Level : TRLevelBase
     public List<TRSoundSource<TR4SFX>> SoundSources { get; set; }
     public List<TR4Entity> Entities { get; set; }
     public List<TR4AIEntity> AIEntities { get; set; }
-    public byte[] DemoData { get; set; }
     public SortedDictionary<TR4SFX, TR4SoundEffect> SoundEffects { get; set; }
 
     public override IEnumerable<TRMesh> DistinctMeshes => Models.Values.SelectMany(m => m.Meshes)

--- a/TRLevelControl/Model/TR5/TR5Level.cs
+++ b/TRLevelControl/Model/TR5/TR5Level.cs
@@ -13,7 +13,6 @@ public class TR5Level : TRLevelBase
     public List<TRSoundSource<TR5SFX>> SoundSources { get; set; }
     public List<TR5Entity> Entities { get; set; }
     public List<TR5AIEntity> AIEntities { get; set; }
-    public byte[] DemoData { get; set; }
     public SortedDictionary<TR5SFX, TR4SoundEffect> SoundEffects { get; set; }
 
     public override IEnumerable<TRMesh> DistinctMeshes => Models.Values.SelectMany(m => m.Meshes)

--- a/TRLevelControlTests/TR1/DemoTests.cs
+++ b/TRLevelControlTests/TR1/DemoTests.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TRLevelControl.Model;
+
+namespace TRLevelControlTests.TR1;
+
+[TestClass]
+[TestCategory("DemoData")]
+public class DemoTests : TestBase
+{
+    [TestMethod]
+    public void AddDemoData()
+    {
+        TR1Level level = GetTR1TestLevel();
+        Assert.IsNull(level.DemoData);
+
+        TRDemoData<TR1DemoGun, TR1InputState> data = new()
+        {
+            LaraPos = new()
+            {
+                X = 2048,
+                Y = 1024,
+                Z = 4096,
+            },
+            LaraRot = new()
+            {
+                X = 10,
+                Y = 20,
+                Z = 30,
+            },
+            LaraRoom = 19,
+            LaraLastGun = TR1DemoGun.None,
+            Inputs = new()
+            {
+                TR1InputState.None,
+                TR1InputState.Forward,
+                TR1InputState.Forward | TR1InputState.Left,
+                TR1InputState.Forward | TR1InputState.Draw,
+                TR1InputState.Forward | TR1InputState.Action,
+                TR1InputState.Back,
+                TR1InputState.Right,
+                TR1InputState.Jump,
+                TR1InputState.Walk,
+                TR1InputState.Option,
+                TR1InputState.Look,
+                TR1InputState.StepLeft,
+                TR1InputState.StepRight,
+                TR1InputState.Roll,
+                TR1InputState.MenuConfirm,
+                TR1InputState.MenuBack,
+                TR1InputState.Save,
+                TR1InputState.Load,
+            }
+        };
+
+        level.DemoData = data;
+        level = WriteReadTempLevel(level);
+
+        Assert.IsNotNull(level.DemoData);
+        Assert.AreEqual(data.LaraPos.X, level.DemoData.LaraPos.X);
+        Assert.AreEqual(data.LaraPos.Y, level.DemoData.LaraPos.Y);
+        Assert.AreEqual(data.LaraPos.Z, level.DemoData.LaraPos.Z);
+        Assert.AreEqual(data.LaraRot.X, level.DemoData.LaraRot.X);
+        Assert.AreEqual(data.LaraRot.Y, level.DemoData.LaraRot.Y);
+        Assert.AreEqual(data.LaraRot.Z, level.DemoData.LaraRot.Z);
+        Assert.AreEqual(data.LaraRoom, level.DemoData.LaraRoom);
+        Assert.AreEqual(data.LaraLastGun, level.DemoData.LaraLastGun);
+
+        CollectionAssert.AreEqual(data.Inputs, level.DemoData.Inputs);
+    }
+}

--- a/TRLevelControlTests/TR2/DemoTests.cs
+++ b/TRLevelControlTests/TR2/DemoTests.cs
@@ -1,0 +1,71 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TRLevelControl.Model;
+
+namespace TRLevelControlTests.TR2;
+
+[TestClass]
+[TestCategory("DemoData")]
+public class DemoTests : TestBase
+{
+    [TestMethod]
+    public void AddDemoData()
+    {
+        TR2Level level = GetTR2TestLevel();
+        Assert.IsNull(level.DemoData);
+
+        TRDemoData<TR2DemoGun, TR2InputState> data = new()
+        {
+            LaraPos = new()
+            {
+                X = 2048,
+                Y = 1024,
+                Z = 4096,
+            },
+            LaraRot = new()
+            {
+                X = 10,
+                Y = 20,
+                Z = 30,
+            },
+            LaraRoom = 19,
+            LaraLastGun = TR2DemoGun.GrenadeLauncher,
+            Inputs = new()
+            {
+                TR2InputState.None,
+                TR2InputState.Forward,
+                TR2InputState.Forward | TR2InputState.Left,
+                TR2InputState.Forward | TR2InputState.Draw,
+                TR2InputState.Forward | TR2InputState.Action,
+                TR2InputState.Back,
+                TR2InputState.Right,
+                TR2InputState.Jump,
+                TR2InputState.Walk,
+                TR2InputState.Option,
+                TR2InputState.Look,
+                TR2InputState.StepLeft,
+                TR2InputState.StepRight,
+                TR2InputState.Roll,
+                TR2InputState.MenuConfirm,
+                TR2InputState.MenuBack,
+                TR2InputState.Save,
+                TR2InputState.Load,
+                TR2InputState.Flare,
+            }
+        };
+
+        level.DemoData = data;
+        level = WriteReadTempLevel(level);
+
+        Assert.IsNotNull(level.DemoData);
+        Assert.AreEqual(data.LaraPos.X, level.DemoData.LaraPos.X);
+        Assert.AreEqual(data.LaraPos.Y, level.DemoData.LaraPos.Y);
+        Assert.AreEqual(data.LaraPos.Z, level.DemoData.LaraPos.Z);
+        Assert.AreEqual(data.LaraRot.X, level.DemoData.LaraRot.X);
+        Assert.AreEqual(data.LaraRot.Y, level.DemoData.LaraRot.Y);
+        Assert.AreEqual(data.LaraRot.Z, level.DemoData.LaraRot.Z);
+        Assert.AreEqual(data.LaraRoom, level.DemoData.LaraRoom);
+        Assert.AreEqual(data.LaraLastGun, level.DemoData.LaraLastGun);
+
+        CollectionAssert.AreEqual(data.Inputs, level.DemoData.Inputs);
+    }
+}

--- a/TRLevelControlTests/TR3/DemoTests.cs
+++ b/TRLevelControlTests/TR3/DemoTests.cs
@@ -1,0 +1,73 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TRLevelControl.Model;
+
+namespace TRLevelControlTests.TR3;
+
+[TestClass]
+[TestCategory("DemoData")]
+public class DemoTests : TestBase
+{
+    [TestMethod]
+    public void AddDemoData()
+    {
+        TR3Level level = GetTR3TestLevel();
+        Assert.IsNull(level.DemoData);
+
+        TRDemoData<TR3DemoGun, TR3InputState> data = new()
+        {
+            LaraPos = new()
+            {
+                X = 2048,
+                Y = 1024,
+                Z = 4096,
+            },
+            LaraRot = new()
+            {
+                X = 10,
+                Y = 20,
+                Z = 30,
+            },
+            LaraRoom = 19,
+            LaraLastGun = TR3DemoGun.Harpoon,
+            Inputs = new()
+            {
+                TR3InputState.None,
+                TR3InputState.Forward,
+                TR3InputState.Forward | TR3InputState.Left,
+                TR3InputState.Forward | TR3InputState.Draw,
+                TR3InputState.Forward | TR3InputState.Action,
+                TR3InputState.Back,
+                TR3InputState.Right,
+                TR3InputState.Jump,
+                TR3InputState.Walk,
+                TR3InputState.Option,
+                TR3InputState.Look,
+                TR3InputState.StepLeft,
+                TR3InputState.StepRight,
+                TR3InputState.Roll,
+                TR3InputState.MenuConfirm,
+                TR3InputState.MenuBack,
+                TR3InputState.Save,
+                TR3InputState.Load,
+                TR3InputState.Flare,
+                TR3InputState.Duck,
+                TR3InputState.Sprint,
+            }
+        };
+
+        level.DemoData = data;
+        level = WriteReadTempLevel(level);
+
+        Assert.IsNotNull(level.DemoData);
+        Assert.AreEqual(data.LaraPos.X, level.DemoData.LaraPos.X);
+        Assert.AreEqual(data.LaraPos.Y, level.DemoData.LaraPos.Y);
+        Assert.AreEqual(data.LaraPos.Z, level.DemoData.LaraPos.Z);
+        Assert.AreEqual(data.LaraRot.X, level.DemoData.LaraRot.X);
+        Assert.AreEqual(data.LaraRot.Y, level.DemoData.LaraRot.Y);
+        Assert.AreEqual(data.LaraRot.Z, level.DemoData.LaraRot.Z);
+        Assert.AreEqual(data.LaraRoom, level.DemoData.LaraRoom);
+        Assert.AreEqual(data.LaraLastGun, level.DemoData.LaraLastGun);
+
+        CollectionAssert.AreEqual(data.Inputs, level.DemoData.Inputs);
+    }
+}

--- a/TRLevelToolset/Controls/DataControls/TR/TRDemoDataControl.cs
+++ b/TRLevelToolset/Controls/DataControls/TR/TRDemoDataControl.cs
@@ -10,7 +10,7 @@ internal class TRDemoDataControl : IDrawable
     {
         if (ImGui.TreeNodeEx("Demo Data", ImGuiTreeNodeFlags.OpenOnArrow))
         {
-            ImGui.Text("Demo Data Size: " + IOManager.CurrentLevelAsTR1?.DemoData.Length);
+            ImGui.Text("Has Demo Data: " + IOManager.CurrentLevelAsTR1?.DemoData == null ? "No" : "Yes");
             ImGui.TreePop();
         }
     }


### PR DESCRIPTION
Resolves #470.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Demo data is now parsed for TR1-3. TR4 and TR5 do not support it, the engines just read `numDemoData` and do nothing else so we don't bother to reserve space in the levels for these. If this ever changes, we can easily adapt.