### PR TITLE
Redefine standard image class

### DIFF
--- a/TRDataControl/Environment/Model/Types/Textures/EMCreateTextureFunction.cs
+++ b/TRDataControl/Environment/Model/Types/Textures/EMCreateTextureFunction.cs
@@ -1,5 +1,5 @@
 ﻿using System.Drawing;
-using TRImageControl.Helpers;
+using TRImageControl;
 using TRImageControl.Packing;
 using TRLevelControl.Model;
 
@@ -58,8 +58,8 @@ public class EMCreateTextureFunction : BaseEMFunction
                 Index = data.Background,
                 Texture = textures[data.Background]
             };
-            BitmapGraphics tile = packer.Tiles[indexedTexture.Atlas].BitmapGraphics;
-            BitmapGraphics clip = new(tile.Extract(indexedTexture.Bounds));
+            TRImage tile = packer.Tiles[indexedTexture.Atlas].BitmapGraphics;
+            TRImage clip = new(tile.Extract(indexedTexture.Bounds));
             clip.Overlay(new Bitmap(data.Overlay));
 
             IndexedTRObjectTexture texture = CreateTexture(clip.Bitmap.Size);

--- a/TRDataControl/Environment/Model/Types/Textures/EMImportTextureFunction.cs
+++ b/TRDataControl/Environment/Model/Types/Textures/EMImportTextureFunction.cs
@@ -1,6 +1,5 @@
 ﻿using System.Drawing;
 using TRImageControl;
-using TRImageControl.Helpers;
 using TRLevelControl;
 using TRLevelControl.Model;
 

--- a/TRDataControl/Environment/Model/Types/Textures/EMImportTextureFunction.cs
+++ b/TRDataControl/Environment/Model/Types/Textures/EMImportTextureFunction.cs
@@ -15,7 +15,7 @@ public class EMImportTextureFunction : BaseEMFunction
 
     public override void ApplyToLevel(TR1Level level)
     {
-        using BitmapGraphics bg = new(new Bitmap(Bitmap));
+        using TRImage bg = new(new Bitmap(Bitmap));
         List<Color> palette = level.Palette.Select(c => c.ToTR1Color()).ToList();
         Rectangle size = new(0, 0, bg.Bitmap.Width, bg.Bitmap.Height);
         bg.Scan(size, (c, x, y) =>
@@ -38,7 +38,7 @@ public class EMImportTextureFunction : BaseEMFunction
 
     public override void ApplyToLevel(TR2Level level)
     {
-        using BitmapGraphics bg = new(level.Images16[Tile].ToBitmap());
+        using TRImage bg = new(level.Images16[Tile].ToBitmap());
         using Bitmap bmp = new(Bitmap);
         bg.Import(bmp, new Rectangle(X, Y, bmp.Width, bmp.Height));
         level.Images16[Tile].Pixels = TextureUtilities.ImportFromBitmap(bg.Bitmap);
@@ -46,7 +46,7 @@ public class EMImportTextureFunction : BaseEMFunction
 
     public override void ApplyToLevel(TR3Level level)
     {
-        using BitmapGraphics bg = new(level.Images16[Tile].ToBitmap());
+        using TRImage bg = new(level.Images16[Tile].ToBitmap());
         using Bitmap bmp = new(Bitmap);
         bg.Import(bmp, new Rectangle(X, Y, bmp.Width, bmp.Height));
         level.Images16[Tile].Pixels = TextureUtilities.ImportFromBitmap(bg.Bitmap);

--- a/TRDataControl/Environment/Model/Types/Textures/EMOverwriteTextureFunction.cs
+++ b/TRDataControl/Environment/Model/Types/Textures/EMOverwriteTextureFunction.cs
@@ -1,5 +1,5 @@
 ﻿using System.Drawing;
-using TRImageControl.Helpers;
+using TRImageControl;
 using TRImageControl.Packing;
 using TRLevelControl.Model;
 
@@ -73,7 +73,7 @@ public class EMOverwriteTextureFunction : BaseEMFunction, ITextureModifier
         foreach (TextureOverwrite overwrite in Overwrites)
         {
             Tuple<TexturedTile, TexturedTileSegment> segment = segmentAction(overwrite.Texture);
-            BitmapGraphics segmentBmp = new(segment.Item2.Bitmap);
+            TRImage segmentBmp = new(segment.Item2.Bitmap);
             Bitmap clipBmp = segmentBmp.Extract(overwrite.Clip);
 
             foreach (ushort targetTexture in overwrite.Targets.Keys)

--- a/TRDataControl/Handlers/ColourTransportHandler.cs
+++ b/TRDataControl/Handlers/ColourTransportHandler.cs
@@ -1,4 +1,4 @@
-﻿using TRImageControl.Helpers;
+﻿using TRImageControl;
 using TRLevelControl.Model;
 using TRModelTransporter.Model.Definitions;
 

--- a/TRDataControl/Handlers/Textures/AbstractTextureImportHandler.cs
+++ b/TRDataControl/Handlers/Textures/AbstractTextureImportHandler.cs
@@ -4,7 +4,7 @@ using TRImageControl.Packing;
 using TRLevelControl.Model;
 using TRModelTransporter.Data;
 using TRModelTransporter.Model;
-using TRImageControl.Helpers;
+using TRImageControl;
 
 namespace TRModelTransporter.Handlers;
 
@@ -79,7 +79,7 @@ public abstract class AbstractTextureImportHandler<E, L, D>
             }
 
             _importSegments[definition] = new List<TexturedTileSegment>();
-            using BitmapGraphics bg = new(definition.Bitmap);
+            using TRImage bg = new(definition.Bitmap);
             foreach (int segmentIndex in definition.ObjectTextures.Keys)
             {
                 Bitmap segmentClip = bg.Extract(definition.TextureSegments[segmentIndex]);

--- a/TRDataControl/Handlers/Textures/TR1/TR1TextureImportHandler.cs
+++ b/TRDataControl/Handlers/Textures/TR1/TR1TextureImportHandler.cs
@@ -1,4 +1,4 @@
-﻿using TRImageControl.Helpers;
+﻿using TRImageControl;
 using TRImageControl.Packing;
 using TRLevelControl.Model;
 using TRModelTransporter.Helpers;

--- a/TRDataControl/Transport/TR1/TR1DataImporter.cs
+++ b/TRDataControl/Transport/TR1/TR1DataImporter.cs
@@ -1,5 +1,5 @@
 ﻿using Newtonsoft.Json;
-using TRImageControl.Helpers;
+using TRImageControl;
 using TRImageControl.Packing;
 using TRLevelControl.Model;
 using TRModelTransporter.Data;

--- a/TRImageControl/Extensions/ColourExtensions.cs
+++ b/TRImageControl/Extensions/ColourExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using System.Drawing;
 using TRLevelControl.Model;
 
-namespace TRImageControl.Helpers;
+namespace TRImageControl;
 
 //https://www.codeproject.com/Articles/19045/Manipulating-colors-in-NET-Part-1
 public static class ColourExtensions

--- a/TRImageControl/Extensions/HSB.cs
+++ b/TRImageControl/Extensions/HSB.cs
@@ -1,4 +1,4 @@
-﻿namespace TRImageControl.Helpers;
+﻿namespace TRImageControl;
 
 public struct HSB
 {

--- a/TRImageControl/Extensions/HSBOperation.cs
+++ b/TRImageControl/Extensions/HSBOperation.cs
@@ -1,4 +1,4 @@
-﻿namespace TRImageControl.Helpers;
+﻿namespace TRImageControl;
 
 public class HSBOperation
 {

--- a/TRImageControl/Helpers/TRPalette8Control.cs
+++ b/TRImageControl/Helpers/TRPalette8Control.cs
@@ -40,7 +40,7 @@ public class TRPalette8Control : IDisposable
         for (int i = 0; i < Level.Images8.Count; i++)
         {
             Bitmap bmp = ChangedTiles.ContainsKey(i) ? ChangedTiles[i] : GetOriginalTile(i);
-            BitmapGraphics bg = new(bmp);
+            TRImage bg = new(bmp);
             bg.Scan(_defaultBounds, (c, x, y) =>
             {
                 int colIndex;

--- a/TRImageControl/Packing/TRTexturePacker.cs
+++ b/TRImageControl/Packing/TRTexturePacker.cs
@@ -3,7 +3,6 @@ using RectanglePacker.Events;
 using RectanglePacker.Organisation;
 using System.Collections.Immutable;
 using System.Drawing;
-using TRImageControl.Helpers;
 using TRLevelControl;
 using TRLevelControl.Model;
 
@@ -55,7 +54,7 @@ public abstract class TRTexturePacker<E, L> : AbstractPacker<TexturedTile, Textu
             for (int i = 0; i < NumLevelImages; i++)
             {
                 TexturedTile tile = AddTile();
-                tile.BitmapGraphics = new BitmapGraphics(GetTile(i));
+                tile.BitmapGraphics = new TRImage(GetTile(i));
                 tile.AllowOverlapping = true; // Allow initially for the likes of Opera House - see tile 3 [128, 128]
             }
 

--- a/TRImageControl/Packing/TexturedTile.cs
+++ b/TRImageControl/Packing/TexturedTile.cs
@@ -1,14 +1,13 @@
 ﻿using RectanglePacker.Defaults;
 using System.Drawing;
 using System.Drawing.Imaging;
-using TRImageControl.Helpers;
 
 namespace TRImageControl.Packing;
 
 public class TexturedTile : DefaultTile<TexturedTileSegment>, IDisposable
 {
-    private BitmapGraphics _graphics;
-    public BitmapGraphics BitmapGraphics
+    private TRImage _graphics;
+    public TRImage BitmapGraphics
     {
         get => _graphics;
         set

--- a/TRImageControl/Packing/Types/TR1TexturePacker.cs
+++ b/TRImageControl/Packing/Types/TR1TexturePacker.cs
@@ -1,5 +1,4 @@
 ﻿using System.Drawing;
-using TRImageControl.Helpers;
 using TRLevelControl;
 using TRLevelControl.Model;
 

--- a/TRImageControl/Palette/TRPalette16Control.cs
+++ b/TRImageControl/Palette/TRPalette16Control.cs
@@ -1,7 +1,7 @@
 ﻿using System.Drawing;
 using TRLevelControl.Model;
 
-namespace TRImageControl.Helpers;
+namespace TRImageControl;
 
 public class TRPalette16Control
 {
@@ -19,11 +19,8 @@ public class TRPalette16Control
         _palette = palette16;
 
         IEnumerable<int> colourRefs = meshes
-            .SelectMany(m => m.ColouredRectangles)
-            .Select(f => f.Texture >> 8)
-            .Concat(meshes
-                .SelectMany(m => m.ColouredTriangles)
-                .Select(f => f.Texture >> 8));
+            .SelectMany(m => m.ColouredFaces)
+            .Select(f => f.Texture >> 8);
 
         List<int> range = new(Enumerable.Range(0, palette16.Count));
         _freeIndices = new(range.Except(colourRefs));

--- a/TRImageControl/Palette/TRPalette8Control.cs
+++ b/TRImageControl/Palette/TRPalette8Control.cs
@@ -2,7 +2,7 @@
 using TRLevelControl;
 using TRLevelControl.Model;
 
-namespace TRImageControl.Helpers;
+namespace TRImageControl;
 
 public class TRPalette8Control : IDisposable
 {

--- a/TRImageControl/TRImage.cs
+++ b/TRImageControl/TRImage.cs
@@ -2,7 +2,6 @@
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
-using TRImageControl.Helpers;
 using TRImageControl.Textures;
 
 namespace TRImageControl;

--- a/TRImageControl/TRImage.cs
+++ b/TRImageControl/TRImage.cs
@@ -2,11 +2,12 @@
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
+using TRImageControl.Helpers;
 using TRImageControl.Textures;
 
-namespace TRImageControl.Helpers;
+namespace TRImageControl;
 
-public class BitmapGraphics : IDisposable
+public class TRImage : IDisposable
 {
     private Bitmap _bitmap;
     private int _width, _height;
@@ -28,7 +29,7 @@ public class BitmapGraphics : IDisposable
 
     public event EventHandler GraphicChanged;
 
-    public BitmapGraphics(Bitmap bitmap)
+    public TRImage(Bitmap bitmap)
     {
         Bitmap = bitmap;
     }

--- a/TRImageControl/TextureUtilities.cs
+++ b/TRImageControl/TextureUtilities.cs
@@ -2,7 +2,6 @@
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
-using TRImageControl.Helpers;
 using TRLevelControl;
 using TRLevelControl.Model;
 

--- a/TRImageControl/Textures/Mapping/AbstractTextureMapping.cs
+++ b/TRImageControl/Textures/Mapping/AbstractTextureMapping.cs
@@ -19,14 +19,14 @@ public abstract class AbstractTextureMapping<E, L> : IDisposable
     public Color DefaultSkyBox { get; set; }
     public Dictionary<E, E> EntityMap { get; set; }
 
-    protected readonly Dictionary<int, BitmapGraphics> _tileMap;
+    protected readonly Dictionary<int, TRImage> _tileMap;
     protected readonly L _level;
     protected bool _committed;
 
     protected AbstractTextureMapping(L level)
     {
         _level = level;
-        _tileMap = new Dictionary<int, BitmapGraphics>();
+        _tileMap = new Dictionary<int, TRImage>();
         _committed = false;
     }
 
@@ -190,7 +190,7 @@ public abstract class AbstractTextureMapping<E, L> : IDisposable
     {
         foreach (int tileIndex in targets.Keys)
         {
-            BitmapGraphics bg = GetBitmapGraphics(tileIndex);
+            TRImage bg = GetBitmapGraphics(tileIndex);
             foreach (Rectangle rect in targets[tileIndex])
             {
                 bg.AdjustHSB(rect, operation);
@@ -395,7 +395,7 @@ public abstract class AbstractTextureMapping<E, L> : IDisposable
             // Scan each tile and replace colour Search with above
             foreach (int tile in replacement.ReplacementMap.Keys)
             {
-                BitmapGraphics graphics = GetBitmapGraphics(tile);
+                TRImage graphics = GetBitmapGraphics(tile);
                 foreach (Rectangle rect in replacement.ReplacementMap[tile])
                 {
                     graphics.Replace(search, replace, rect);
@@ -446,11 +446,11 @@ public abstract class AbstractTextureMapping<E, L> : IDisposable
         return texture;
     }
 
-    private BitmapGraphics GetBitmapGraphics(int tile)
+    private TRImage GetBitmapGraphics(int tile)
     {
         if (!_tileMap.ContainsKey(tile))
         {
-            _tileMap.Add(tile, new BitmapGraphics(GetTile(tile)));
+            _tileMap.Add(tile, new TRImage(GetTile(tile)));
         }
 
         return _tileMap[tile];
@@ -468,7 +468,7 @@ public abstract class AbstractTextureMapping<E, L> : IDisposable
         {
             foreach (int tile in _tileMap.Keys)
             {
-                using BitmapGraphics bmp = _tileMap[tile];
+                using TRImage bmp = _tileMap[tile];
                 SetTile(tile, bmp.Bitmap);
             }
             _committed = true;

--- a/TRImageControl/Textures/Mapping/AbstractTextureMapping.cs
+++ b/TRImageControl/Textures/Mapping/AbstractTextureMapping.cs
@@ -1,6 +1,5 @@
 ﻿using Newtonsoft.Json;
 using System.Drawing;
-using TRImageControl.Helpers;
 using TRLevelControl.Model;
 
 namespace TRImageControl.Textures;

--- a/TRImageControl/Textures/Mapping/TR1TextureMapping.cs
+++ b/TRImageControl/Textures/Mapping/TR1TextureMapping.cs
@@ -1,6 +1,5 @@
 ﻿using System.Drawing;
 using TRLevelControl.Model;
-using TRImageControl.Helpers;
 
 namespace TRImageControl.Textures;
 

--- a/TRImageControl/Textures/Mapping/TR2TextureMapping.cs
+++ b/TRImageControl/Textures/Mapping/TR2TextureMapping.cs
@@ -1,6 +1,5 @@
 ﻿using System.Drawing;
 using TRLevelControl.Model;
-using TRImageControl.Helpers;
 
 namespace TRImageControl.Textures;
 

--- a/TRImageControl/Textures/Mapping/TR3TextureMapping.cs
+++ b/TRImageControl/Textures/Mapping/TR3TextureMapping.cs
@@ -1,5 +1,4 @@
 ﻿using System.Drawing;
-using TRImageControl.Helpers;
 using TRLevelControl.Model;
 
 namespace TRImageControl.Textures;

--- a/TRImageControl/Textures/Source/DynamicTextureSource.cs
+++ b/TRImageControl/Textures/Source/DynamicTextureSource.cs
@@ -1,6 +1,4 @@
-﻿using TRImageControl.Helpers;
-
-namespace TRImageControl.Textures;
+﻿namespace TRImageControl.Textures;
 
 public class DynamicTextureSource : AbstractTextureSource
 {

--- a/TRImageControl/Textures/Target/LandmarkTextureTarget.cs
+++ b/TRImageControl/Textures/Target/LandmarkTextureTarget.cs
@@ -1,12 +1,10 @@
-﻿using TRImageControl.Helpers;
-
-namespace TRImageControl.Textures;
+﻿namespace TRImageControl.Textures;
 
 public class LandmarkTextureTarget
 {
     public int MappedTextureIndex { get; set; }
     public int BackgroundIndex { get; set; }
-    public BitmapGraphics Background { get; set; }
+    public TRImage Background { get; set; }
     public int RoomNumber { get; set; }
     public List<int> RectangleIndices { get; set; }
     public PortalSector PortalSector { get; set; }

--- a/TRRandomizerCore/Editors/TR1ClassicEditor.cs
+++ b/TRRandomizerCore/Editors/TR1ClassicEditor.cs
@@ -2,7 +2,7 @@
 using System.Drawing;
 using TRGE.Coord;
 using TRGE.Core;
-using TRImageControl.Helpers;
+using TRImageControl;
 using TRLevelControl.Model;
 using TRRandomizerCore.Helpers;
 using TRRandomizerCore.Processors;
@@ -359,7 +359,7 @@ public class TR1ClassicEditor : TR1LevelEditor, ISettingsProvider
         if (File.Exists(backupTitle))
         {
             string editedTitle = Path.Combine(GetWriteBasePath(), mainMenuPic);
-            using BitmapGraphics bg = new(new Bitmap(backupTitle));
+            using TRImage bg = new(new Bitmap(backupTitle));
             using Bitmap badge = new(@"Resources\Shared\Graphics\goldbadge-small.png");
             bg.Graphics.DrawImage(badge, new Rectangle(
                 scriptEditor.GameMode == GameMode.Gold ? _goldBadgePos : _regularBadgePos, 
@@ -378,7 +378,7 @@ public class TR1ClassicEditor : TR1LevelEditor, ISettingsProvider
             string creditFile = Path.Combine(_io.OutputDirectory.FullName, "trrando.png");
             string creditPath = @"data\trrando.png";
 
-            using (BitmapGraphics bg = new(new Bitmap(1920, 1080)))
+            using (TRImage bg = new(new Bitmap(1920, 1080)))
             using (Bitmap badge = new(@"Resources\Shared\Graphics\goldbadge-large.png"))
             {
                 bg.Graphics.FillRectangle(new SolidBrush(Color.Black), new Rectangle(0, 0, 1920, 1080));

--- a/TRRandomizerCore/Randomizers/TR1/TR1OutfitRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/TR1OutfitRandomizer.cs
@@ -1,7 +1,7 @@
 ﻿using System.Drawing;
 using TRDataControl.Environment;
 using TRGE.Core;
-using TRImageControl.Helpers;
+using TRImageControl;
 using TRImageControl.Packing;
 using TRImageControl.Textures;
 using TRLevelControl;

--- a/TRRandomizerCore/Textures/Landmarks/AbstractLandmarkImporter.cs
+++ b/TRRandomizerCore/Textures/Landmarks/AbstractLandmarkImporter.cs
@@ -1,6 +1,6 @@
 ﻿using RectanglePacker.Events;
 using System.Drawing;
-using TRImageControl.Helpers;
+using TRImageControl;
 using TRImageControl.Packing;
 using TRImageControl.Textures;
 using TRLevelControl;
@@ -106,8 +106,8 @@ public abstract class AbstractLandmarkImporter<E, L>
                             Index = target.BackgroundIndex,
                             Texture = textures[target.BackgroundIndex]
                         };
-                        BitmapGraphics tile = packer.Tiles[indexedTexture.Atlas].BitmapGraphics;
-                        BitmapGraphics clip = new(tile.Extract(indexedTexture.Bounds));
+                        TRImage tile = packer.Tiles[indexedTexture.Atlas].BitmapGraphics;
+                        TRImage clip = new(tile.Extract(indexedTexture.Bounds));
                         clip.Overlay(source.Bitmap);
                         image = clip.Bitmap;
 

--- a/TRRandomizerCore/Textures/Wireframing/AbstractTRWireframer.cs
+++ b/TRRandomizerCore/Textures/Wireframing/AbstractTRWireframer.cs
@@ -1,7 +1,7 @@
 using RectanglePacker.Organisation;
 using System.Drawing;
 using System.Drawing.Drawing2D;
-using TRImageControl.Helpers;
+using TRImageControl;
 using TRImageControl.Packing;
 using TRLevelControl.Model;
 using TRModelTransporter.Helpers;
@@ -256,7 +256,7 @@ public abstract class AbstractTRWireframer<E, L>
         }
 
         IndexedTRObjectTexture texture = CreateTexture(new Rectangle(0, 0, size.W, size.H));
-        BitmapGraphics frame = CreateFrame(size.W, size.H, pen, mode, true);
+        TRImage frame = CreateFrame(size.W, size.H, pen, mode, true);
 
         packer.AddRectangle(new TexturedTileSegment(texture, frame.Bitmap));
 
@@ -271,7 +271,7 @@ public abstract class AbstractTRWireframer<E, L>
         }
 
         IndexedTRObjectTexture texture = CreateTexture(new Rectangle(0, 0, size.W, size.H));
-        BitmapGraphics frame = CreateFrame(size.W, size.H, pen, mode, false);
+        TRImage frame = CreateFrame(size.W, size.H, pen, mode, false);
 
         int rungSplit = size.H / _ladderRungs;
         for (int i = 0; i < _ladderRungs; i++)
@@ -296,7 +296,7 @@ public abstract class AbstractTRWireframer<E, L>
         }
 
         IndexedTRObjectTexture texture = CreateTexture(new Rectangle(0, 0, size.W, size.H));
-        BitmapGraphics frame = CreateFrame(size.W, size.H, pen, mode, true);
+        TRImage frame = CreateFrame(size.W, size.H, pen, mode, true);
         // X marks the spot
         frame.Graphics.DrawLine(pen, 0, size.H, size.W, 0);
 
@@ -313,7 +313,7 @@ public abstract class AbstractTRWireframer<E, L>
         }
 
         IndexedTRObjectTexture texture = CreateTexture(new Rectangle(0, 0, size.W, size.H));
-        BitmapGraphics frame = CreateFrame(size.W, size.H, pen, mode, true);
+        TRImage frame = CreateFrame(size.W, size.H, pen, mode, true);
         // Star symbol
         frame.Graphics.DrawLine(pen, 0, size.H, size.W, 0);
         frame.Graphics.DrawLine(pen, size.W / 2, 0, size.W / 2, size.H);
@@ -348,7 +348,7 @@ public abstract class AbstractTRWireframer<E, L>
         List<TRObjectTexture> textures = GetObjectTextures(level);
         foreach (WireframeClip clip in _data.ManualClips)
         {
-            BitmapGraphics frame = CreateFrame(clip.Clip.Width, clip.Clip.Height, pen, mode, true);
+            TRImage frame = CreateFrame(clip.Clip.Width, clip.Clip.Height, pen, mode, true);
 
             foreach (ushort texture in clip.Textures)
             {
@@ -357,7 +357,7 @@ public abstract class AbstractTRWireframer<E, L>
                     Index = texture,
                     Texture = textures[texture]
                 };
-                BitmapGraphics bmp = packer.Tiles[indexedTexture.Atlas].BitmapGraphics;
+                TRImage bmp = packer.Tiles[indexedTexture.Atlas].BitmapGraphics;
 
                 List<TexturedTileSegment> segments = packer.Tiles[indexedTexture.Atlas].GetObjectTextureIndexSegments(new int[] { texture });
                 foreach (TexturedTileSegment segment in segments)
@@ -383,9 +383,9 @@ public abstract class AbstractTRWireframer<E, L>
         }
     }
 
-    protected BitmapGraphics CreateFrame(int width, int height, Pen pen, SmoothingMode mode, bool addDiagonal)
+    protected TRImage CreateFrame(int width, int height, Pen pen, SmoothingMode mode, bool addDiagonal)
     {
-        BitmapGraphics image = new(new Bitmap(width, height));
+        TRImage image = new(new Bitmap(width, height));
         image.Graphics.SmoothingMode = mode;
 
         image.Graphics.FillRectangle(new SolidBrush(Color.Transparent), new Rectangle(0, 0, width, height));

--- a/TRRandomizerCore/Textures/Wireframing/TR1Wireframer.cs
+++ b/TRRandomizerCore/Textures/Wireframing/TR1Wireframer.cs
@@ -1,6 +1,6 @@
 ﻿using System.Drawing;
 using System.Drawing.Drawing2D;
-using TRImageControl.Helpers;
+using TRImageControl;
 using TRImageControl.Packing;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;
@@ -206,7 +206,7 @@ public class TR1Wireframer : AbstractTRWireframer<TR1Type, TR1Level>
         const int height = 16;
                     
         IndexedTRObjectTexture texture = CreateTexture(new Rectangle(0, 0, width, height));
-        BitmapGraphics frame = CreateFrame(width, height, pen, SmoothingMode.AntiAlias, false);
+        TRImage frame = CreateFrame(width, height, pen, SmoothingMode.AntiAlias, false);
 
         int flags = (doorInstance.Flags & 0x3E00) >> 9;
         for (int i = 0; i < 5; i++)

--- a/TRRandomizerCore/Textures/Wireframing/TR2Wireframer.cs
+++ b/TRRandomizerCore/Textures/Wireframing/TR2Wireframer.cs
@@ -1,5 +1,5 @@
 ﻿using System.Drawing;
-using TRImageControl.Helpers;
+using TRImageControl;
 using TRImageControl.Packing;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;

--- a/TRRandomizerCore/Textures/Wireframing/TR3Wireframer.cs
+++ b/TRRandomizerCore/Textures/Wireframing/TR3Wireframer.cs
@@ -1,7 +1,6 @@
 ﻿using System.Drawing;
 using System.Drawing.Drawing2D;
 using TRImageControl;
-using TRImageControl.Helpers;
 using TRImageControl.Packing;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;

--- a/TRRandomizerCore/Textures/Wireframing/TR3Wireframer.cs
+++ b/TRRandomizerCore/Textures/Wireframing/TR3Wireframer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Drawing;
 using System.Drawing.Drawing2D;
+using TRImageControl;
 using TRImageControl.Helpers;
 using TRImageControl.Packing;
 using TRLevelControl.Helpers;
@@ -167,7 +168,7 @@ public class TR3Wireframer : AbstractTRWireframer<TR3Type, TR3Level>
         const int height = 64;
 
         IndexedTRObjectTexture texture = CreateTexture(new Rectangle(0, 0, width, height));
-        BitmapGraphics frame = CreateFrame(width, height, pen, SmoothingMode.AntiAlias, true);
+        TRImage frame = CreateFrame(width, height, pen, SmoothingMode.AntiAlias, true);
 
         switch (mode)
         {

--- a/TextureExport/Types/HtmlExporter.cs
+++ b/TextureExport/Types/HtmlExporter.cs
@@ -1,7 +1,7 @@
 ﻿using System.Drawing;
 using System.Drawing.Imaging;
 using System.Text;
-using TRImageControl.Helpers;
+using TRImageControl;
 using TRImageControl.Packing;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;


### PR DESCRIPTION
Part of #653.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

`BitmapGraphics` => `TRImage`, and some other files moved around. Hopefully we can (eventually) exclusively use `TRImage` and hide the underlying implementation, it may make shifting away from `System.Drawing` easier.
