### PR TITLE
Add classic/remastered environment tags

### DIFF
--- a/TRDataControl/Environment/EMEditorMapping.cs
+++ b/TRDataControl/Environment/EMEditorMapping.cs
@@ -61,16 +61,10 @@ public class EMEditorMapping
     }
 
     public void SetCommunityPatch(bool isCommunityPatch)
-    {
-        All?.SetCommunityPatch(isCommunityPatch);
-        ConditionalAll?.ForEach(s => s.SetCommunityPatch(isCommunityPatch));
-        Any?.ForEach(s => s.SetCommunityPatch(isCommunityPatch));
-        AllWithin?.ForEach(a => a.ForEach(s => s.SetCommunityPatch(isCommunityPatch)));
-        ConditionalAllWithin?.ForEach(s => s.SetCommunityPatch(isCommunityPatch));
-        OneOf?.ForEach(s => s.SetCommunityPatch(isCommunityPatch));
-        ConditionalOneOf?.ForEach(s => s.SetCommunityPatch(isCommunityPatch));
-        Mirrored?.SetCommunityPatch(isCommunityPatch);
-    }
+        => Scan(e => e.SetCommunityPatch(isCommunityPatch));
+
+    public void SetRemastered(bool isRemastered)
+        => Scan(e => e.SetRemastered(isRemastered));
 
     public List<BaseEMFunction> FindAll(Predicate<BaseEMFunction> predicate = null)
     {

--- a/TRDataControl/Environment/Helpers/EMOptions.cs
+++ b/TRDataControl/Environment/Helpers/EMOptions.cs
@@ -3,6 +3,6 @@
 public class EMOptions
 {
     public bool EnableHardMode { get; set; }
-    public IEnumerable<EMTag> ExcludedTags { get; set; }
+    public List<EMTag> ExcludedTags { get; set; }
     public EMExclusionMode ExclusionMode { get; set; }
 }

--- a/TRDataControl/Environment/Helpers/EMTag.cs
+++ b/TRDataControl/Environment/Helpers/EMTag.cs
@@ -15,4 +15,6 @@ public enum EMTag
     GeneralBugFix,
     ShortcutFix,
     KeyItemFix,
+    RemasteredOnly,
+    ClassicOnly,
 }

--- a/TRDataControl/Environment/Model/BaseEMFunction.cs
+++ b/TRDataControl/Environment/Model/BaseEMFunction.cs
@@ -14,7 +14,7 @@ public abstract class BaseEMFunction
     public BaseEMFunction HardVariant { get; set; }
     public List<EMTag> Tags { get; set; }
 
-    protected bool _isCommunityPatch;
+    protected bool _isCommunityPatch, _isRemastered;
 
     public abstract void ApplyToLevel(TR1Level level);
     public abstract void ApplyToLevel(TR2Level level);
@@ -22,6 +22,9 @@ public abstract class BaseEMFunction
 
     public void SetCommunityPatch(bool isCommunityPatch)
         => _isCommunityPatch = isCommunityPatch;
+
+    public void SetRemastered(bool isRemasterd)
+        => _isRemastered = isRemasterd;
 
     /// <summary>
     /// Gets the expected vertices for a flat tile.

--- a/TRRandomizerCore/Randomizers/Shared/EnvironmentPicker.cs
+++ b/TRRandomizerCore/Randomizers/Shared/EnvironmentPicker.cs
@@ -1,4 +1,5 @@
 ﻿using TRDataControl.Environment;
+using TRGE.Core;
 using TRRandomizerCore.Editors;
 using TRRandomizerCore.Helpers;
 
@@ -6,81 +7,82 @@ namespace TRRandomizerCore.Randomizers;
 
 public class EnvironmentPicker
 {
+    private readonly Random _generator;
+    private readonly RandomizerSettings _settings;
+    private readonly TREdition _gfEdition;
+
     public EMOptions Options { get; set; }
-    public Random Generator { get; set; }
 
-    public EnvironmentPicker(bool hardMode)
+    public EnvironmentPicker(Random generator, RandomizerSettings settings, TREdition gfEdition)
     {
-        Options = new EMOptions
+        Options = new()
         {
-            EnableHardMode = hardMode,
-            ExcludedTags = new List<EMTag>()
+            EnableHardMode = settings.HardEnvironmentMode,
+            ExcludedTags = new()
         };
+
+        _generator = generator;
+        _settings = settings;
+        _gfEdition = gfEdition;
+
+        ResetTags();
+
+        if (!_settings.AddReturnPaths)
+        {
+            Options.ExcludedTags.Add(EMTag.ReturnPath);
+        }
+        if (!_settings.FixOGBugs)
+        {
+            Options.ExcludedTags.Add(EMTag.GeneralBugFix);
+        }
+        if (!_settings.BlockShortcuts)
+        {
+            Options.ExcludedTags.Add(EMTag.ShortcutFix);
+        }
+        if (!_settings.RandomizeLadders)
+        {
+            Options.ExcludedTags.Add(EMTag.LadderChange);
+        }
+        if (!_settings.RandomizeWaterLevels)
+        {
+            Options.ExcludedTags.Add(EMTag.WaterChange);
+        }
+        if (!_settings.RandomizeSlotPositions)
+        {
+            Options.ExcludedTags.Add(EMTag.SlotChange);
+        }
+        if (!_settings.RandomizeTraps)
+        {
+            Options.ExcludedTags.Add(EMTag.TrapChange);
+        }
+        if (!_settings.RandomizeChallengeRooms)
+        {
+            Options.ExcludedTags.Add(EMTag.PuzzleRoom);
+        }
+        if (!_settings.RandomizeItems || !_settings.IncludeKeyItems)
+        {
+            Options.ExcludedTags.Add(EMTag.KeyItemFix);
+        }
     }
 
-    public void LoadTags(RandomizerSettings settings, bool isCommunityPatch)
+    public void ResetTags()
     {
-        List<EMTag> excludedTags = new();
-        if (!settings.AddReturnPaths)
+        // If we're using a community patch, exclude mods that only apply to non-community patch and vice-versa.
+        // Same idea for classic/remastered only.
+        Options.ExcludedTags = new()
         {
-            excludedTags.Add(EMTag.ReturnPath);
-        }
-        if (!settings.FixOGBugs)
-        {
-            excludedTags.Add(EMTag.GeneralBugFix);
-        }
-        if (!settings.BlockShortcuts)
-        {
-            excludedTags.Add(EMTag.ShortcutFix);
-        }
-        if (!settings.RandomizeLadders)
-        {
-            excludedTags.Add(EMTag.LadderChange);
-        }
-        if (!settings.RandomizeWaterLevels)
-        {
-            excludedTags.Add(EMTag.WaterChange);
-        }
-        if (!settings.RandomizeSlotPositions)
-        {
-            excludedTags.Add(EMTag.SlotChange);
-        }
-        if (!settings.RandomizeTraps)
-        {
-            excludedTags.Add(EMTag.TrapChange);
-        }
-        if (!settings.RandomizeChallengeRooms)
-        {
-            excludedTags.Add(EMTag.PuzzleRoom);
-        }
-        if (!settings.RandomizeItems || !settings.IncludeKeyItems)
-        {
-            excludedTags.Add(EMTag.KeyItemFix);
-        }
-
-        // If we're using a community patch, exclude mods that
-        // only apply to non-community patch and vice-versa.
-        excludedTags.Add(isCommunityPatch 
-            ? EMTag.NonCommunityPatchOnly 
-            : EMTag.CommunityPatchOnly);
-
-        Options.ExcludedTags = excludedTags;
-    }
-
-    public void ResetTags(bool isCommunityPatch)
-    {
-        Options.ExcludedTags = new List<EMTag>
-        {
-            isCommunityPatch
-            ? EMTag.NonCommunityPatchOnly
-            : EMTag.CommunityPatchOnly
+            _gfEdition.IsCommunityPatch
+                ? EMTag.NonCommunityPatchOnly
+                : EMTag.CommunityPatchOnly,
+            _gfEdition.Remastered
+                ? EMTag.ClassicOnly
+                : EMTag.RemasteredOnly
         };
     }
 
     public List<EMEditorSet> GetRandomAny(EMEditorMapping mapping)
     {
-        List<EMEditorSet> sets = new();
-        
+        List<EMEditorSet> sets = new();        
         List<EMEditorSet> pool = Options.EnableHardMode 
             ? mapping.Any 
             : mapping.Any.FindAll(e => !e.IsHard);
@@ -88,7 +90,7 @@ public class EnvironmentPicker
         if (pool.Count > 0)
         {
             // Pick a random number of packs to apply, but at least 1
-            sets = pool.RandomSelection(Generator, Generator.Next(1, pool.Count + 1));
+            sets = pool.RandomSelection(_generator, _generator.Next(1, pool.Count + 1));
         }
 
         return sets;
@@ -99,7 +101,7 @@ public class EnvironmentPicker
         if (Options.EnableHardMode)
         {
             // Anything goes.
-            return modList[Generator.Next(0, modList.Count)];
+            return modList[_generator.Next(0, modList.Count)];
         }
 
         if (modList.Any(e => !e.IsHard))
@@ -108,7 +110,7 @@ public class EnvironmentPicker
             EMEditorSet set;
             do
             {
-                set = modList[Generator.Next(0, modList.Count)];
+                set = modList[_generator.Next(0, modList.Count)];
             }
             while (set.IsHard);
 

--- a/TRRandomizerCore/Randomizers/TR1/Classic/TR1EnvironmentRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Classic/TR1EnvironmentRandomizer.cs
@@ -119,11 +119,7 @@ public class TR1EnvironmentRandomizer : BaseTR1Randomizer, IMirrorControl
             level.Data.SoundEffects[TR1SFX.PendulumBlades] = vilcabamba.SoundEffects[TR1SFX.PendulumBlades];
         }
 
-        EnvironmentPicker picker = new(Settings.HardEnvironmentMode)
-        {
-            Generator = _generator
-        };
-        picker.LoadTags(Settings, true);
+        EnvironmentPicker picker = new(_generator, Settings, ScriptEditor.Edition);
         picker.Options.ExclusionMode = EMExclusionMode.Individual;
 
         // These are applied whether or not environment randomization is enabled,
@@ -224,9 +220,9 @@ public class TR1EnvironmentRandomizer : BaseTR1Randomizer, IMirrorControl
     private void FinalizeEnvironment(TR1CombinedLevel level)
     {
         EMEditorMapping mapping = EMEditorMapping.Get(GetResourcePath($@"TR1\Environment\{level.Name}-Environment.json"));
-        EnvironmentPicker picker = new(Settings.HardEnvironmentMode);
+        EnvironmentPicker picker = new(_generator, Settings, ScriptEditor.Edition);
         picker.Options.ExclusionMode = EMExclusionMode.Individual;
-        picker.ResetTags(true);
+        picker.ResetTags();
 
         if (mapping != null)
         {

--- a/TRRandomizerCore/Randomizers/TR1/Remastered/TR1REnvironmentRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Remastered/TR1REnvironmentRandomizer.cs
@@ -39,7 +39,11 @@ public class TR1REnvironmentRandomizer : BaseTR1RRandomizer
     }
 
     private EMEditorMapping GetMapping(TR1RCombinedLevel level)
-        => EMEditorMapping.Get(GetResourcePath($@"TR1\Environment\{level.Name}-Environment.json"));
+    {
+        EMEditorMapping mapping = EMEditorMapping.Get(GetResourcePath($@"TR1\Environment\{level.Name}-Environment.json"));
+        mapping?.SetRemastered(true);
+        return mapping;
+    }
 
     private void RandomizeEnvironment(TR1RCombinedLevel level)
     {
@@ -52,24 +56,18 @@ public class TR1REnvironmentRandomizer : BaseTR1RRandomizer
 
     private void ApplyMappingToLevel(TR1RCombinedLevel level, EMEditorMapping mapping)
     {
-        EnvironmentPicker picker = new(Settings.HardEnvironmentMode)
-        {
-            Generator = _generator
-        };
-        picker.LoadTags(Settings, true);
+        EnvironmentPicker picker = new(_generator, Settings, ScriptEditor.Edition);
         picker.Options.ExclusionMode = EMExclusionMode.Individual;
 
         mapping.All.ApplyToLevel(level.Data, picker.Options);
-
-        // No further mods supported yet
     }
 
     private void FinalizeEnvironment(TR1RCombinedLevel level)
     {
         EMEditorMapping mapping = GetMapping(level);
-        EnvironmentPicker picker = new(Settings.HardEnvironmentMode);
+        EnvironmentPicker picker = new(_generator, Settings, ScriptEditor.Edition);
         picker.Options.ExclusionMode = EMExclusionMode.Individual;
-        picker.ResetTags(true);
+        picker.ResetTags();
 
         if (mapping != null)
         {

--- a/TRRandomizerCore/Randomizers/TR2/Classic/TR2EnvironmentRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR2/Classic/TR2EnvironmentRandomizer.cs
@@ -112,11 +112,7 @@ public class TR2EnvironmentRandomizer : BaseTR2Randomizer, IMirrorControl
 
     private void ApplyMappingToLevel(TR2CombinedLevel level, EMEditorMapping mapping)
     {
-        EnvironmentPicker picker = new(Settings.HardEnvironmentMode)
-        {
-            Generator = _generator
-        };
-        picker.LoadTags(Settings, ScriptEditor.Edition.IsCommunityPatch);
+        EnvironmentPicker picker = new(_generator, Settings, ScriptEditor.Edition);
         picker.Options.ExclusionMode = EMExclusionMode.Individual;
 
         mapping.All.ApplyToLevel(level.Data, picker.Options);
@@ -168,9 +164,8 @@ public class TR2EnvironmentRandomizer : BaseTR2Randomizer, IMirrorControl
     private void FinalizeEnvironment(TR2CombinedLevel level)
     {
         EMEditorMapping mapping = EMEditorMapping.Get(GetResourcePath($@"TR2\Environment\{level.Name}-Environment.json"));
-        EnvironmentPicker picker = new(Settings.HardEnvironmentMode);
+        EnvironmentPicker picker = new(_generator, Settings, ScriptEditor.Edition);
         picker.Options.ExclusionMode = EMExclusionMode.Individual;
-        picker.ResetTags(ScriptEditor.Edition.IsCommunityPatch);
 
         if (mapping != null)
         {

--- a/TRRandomizerCore/Randomizers/TR2/Remastered/TR2REnvironmentRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR2/Remastered/TR2REnvironmentRandomizer.cs
@@ -39,7 +39,11 @@ public class TR2REnvironmentRandomizer : BaseTR2RRandomizer
     }
 
     private EMEditorMapping GetMapping(TR2RCombinedLevel level)
-        => EMEditorMapping.Get(GetResourcePath($@"TR2\Environment\{level.Name}-Environment.json"));
+    {
+        EMEditorMapping mapping = EMEditorMapping.Get(GetResourcePath($@"TR2\Environment\{level.Name}-Environment.json"));
+        mapping?.SetRemastered(true);
+        return mapping;
+    }
 
     private void RandomizeEnvironment(TR2RCombinedLevel level)
     {
@@ -52,24 +56,17 @@ public class TR2REnvironmentRandomizer : BaseTR2RRandomizer
 
     private void ApplyMappingToLevel(TR2RCombinedLevel level, EMEditorMapping mapping)
     {
-        EnvironmentPicker picker = new(Settings.HardEnvironmentMode)
-        {
-            Generator = _generator
-        };
-        picker.LoadTags(Settings, true);
+        EnvironmentPicker picker = new(_generator, Settings, ScriptEditor.Edition);
         picker.Options.ExclusionMode = EMExclusionMode.Individual;
 
         mapping.All.ApplyToLevel(level.Data, picker.Options);
-
-        // No further mods supported yet
     }
 
     private void FinalizeEnvironment(TR2RCombinedLevel level)
     {
         EMEditorMapping mapping = GetMapping(level);
-        EnvironmentPicker picker = new(Settings.HardEnvironmentMode);
+        EnvironmentPicker picker = new(_generator, Settings, ScriptEditor.Edition);
         picker.Options.ExclusionMode = EMExclusionMode.Individual;
-        picker.ResetTags(true);
 
         if (mapping != null)
         {

--- a/TRRandomizerCore/Randomizers/TR3/Classic/TR3EnvironmentRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Classic/TR3EnvironmentRandomizer.cs
@@ -116,11 +116,7 @@ public class TR3EnvironmentRandomizer : BaseTR3Randomizer, IMirrorControl
 
     private void ApplyMappingToLevel(TR3CombinedLevel level, EMEditorMapping mapping)
     {
-        EnvironmentPicker picker = new(Settings.HardEnvironmentMode)
-        {
-            Generator = _generator
-        };
-        picker.LoadTags(Settings, ScriptEditor.Edition.IsCommunityPatch);
+        EnvironmentPicker picker = new(_generator, Settings, ScriptEditor.Edition);
         picker.Options.ExclusionMode = EMExclusionMode.Individual;
 
         mapping.All.ApplyToLevel(level.Data, picker.Options);
@@ -172,9 +168,8 @@ public class TR3EnvironmentRandomizer : BaseTR3Randomizer, IMirrorControl
     private void FinalizeEnvironment(TR3CombinedLevel level)
     {
         EMEditorMapping mapping = EMEditorMapping.Get(GetResourcePath($@"TR3\Environment\{level.Name}-Environment.json"));
-        EnvironmentPicker picker = new(Settings.HardEnvironmentMode);
+        EnvironmentPicker picker = new(_generator, Settings, ScriptEditor.Edition);
         picker.Options.ExclusionMode = EMExclusionMode.Individual;
-        picker.ResetTags(ScriptEditor.Edition.IsCommunityPatch);
 
         if (mapping != null)
         {

--- a/TRRandomizerCore/Randomizers/TR3/Remastered/TR3REnvironmentRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Remastered/TR3REnvironmentRandomizer.cs
@@ -39,7 +39,11 @@ public class TR3REnvironmentRandomizer : BaseTR3RRandomizer
     }
 
     private EMEditorMapping GetMapping(TR3RCombinedLevel level)
-        => EMEditorMapping.Get(GetResourcePath($@"TR3\Environment\{level.Name}-Environment.json"));
+    {
+        EMEditorMapping mapping = EMEditorMapping.Get(GetResourcePath($@"TR3\Environment\{level.Name}-Environment.json"));
+        mapping?.SetRemastered(true);
+        return mapping;
+    }
 
     private void RandomizeEnvironment(TR3RCombinedLevel level)
     {
@@ -52,24 +56,17 @@ public class TR3REnvironmentRandomizer : BaseTR3RRandomizer
 
     private void ApplyMappingToLevel(TR3RCombinedLevel level, EMEditorMapping mapping)
     {
-        EnvironmentPicker picker = new(Settings.HardEnvironmentMode)
-        {
-            Generator = _generator
-        };
-        picker.LoadTags(Settings, true);
+        EnvironmentPicker picker = new(_generator, Settings, ScriptEditor.Edition);
         picker.Options.ExclusionMode = EMExclusionMode.Individual;
 
         mapping.All.ApplyToLevel(level.Data, picker.Options);
-
-        // No further mods supported yet
     }
 
     private void FinalizeEnvironment(TR3RCombinedLevel level)
     {
         EMEditorMapping mapping = GetMapping(level);
-        EnvironmentPicker picker = new(Settings.HardEnvironmentMode);
+        EnvironmentPicker picker = new(_generator, Settings, ScriptEditor.Edition);
         picker.Options.ExclusionMode = EMExclusionMode.Individual;
-        picker.ResetTags(true);
 
         if (mapping != null)
         {

--- a/TRRandomizerCore/Resources/TR1/Environment/LEVEL10A.PHD-Environment.json
+++ b/TRRandomizerCore/Resources/TR1/Environment/LEVEL10A.PHD-Environment.json
@@ -7823,6 +7823,9 @@
         {
           "Comments": "Remove the fuse static mesh from the conveyor belt.",
           "EMType": 25,
+          "Tags": [
+            14
+          ],
           "ClearFromRooms": {
             "227": [
               45
@@ -7832,6 +7835,9 @@
         {
           "Comments": "Add a sprite instead for the ammo.",
           "EMType": 31,
+          "Tags": [
+            14
+          ],
           "ID": 89,
           "Vertex": {
             "Lighting": 4096

--- a/TRRandomizerCore/Resources/TR1/Environment/LEVEL10B.PHD-Environment.json
+++ b/TRRandomizerCore/Resources/TR1/Environment/LEVEL10B.PHD-Environment.json
@@ -7535,10 +7535,26 @@
       "OnTrue": [
         {
           "EMType": 67,
+          "Tags": [
+            14
+          ],
           "BaseLocation": {
             "X": 57856,
             "Y": 10240,
             "Z": 10752,
+            "Room": 12
+          },
+          "EntityLocation": 38
+        },
+        {
+          "EMType": 67,
+          "Tags": [
+            13
+          ],
+          "BaseLocation": {
+            "X": 57856,
+            "Y": 10240,
+            "Z": 11776,
             "Room": 12
           },
           "EntityLocation": 38

--- a/TRRandomizerCore/Resources/TR1/Environment/LEVEL3B.PHD-Environment.json
+++ b/TRRandomizerCore/Resources/TR1/Environment/LEVEL3B.PHD-Environment.json
@@ -15,6 +15,9 @@
     {
       "Comments": "Make a slight change to face order in room 37 to make further modifications here easier.",
       "EMType": 32,
+      "Tags": [
+        14
+      ],
       "RoomIndex": 37,
       "Swaps": {
         "27": 42

--- a/TRRandomizerCore/Resources/TR1/Environment/LEVEL5.PHD-Environment.json
+++ b/TRRandomizerCore/Resources/TR1/Environment/LEVEL5.PHD-Environment.json
@@ -13,6 +13,9 @@
     {
       "Comments": "Make a slight change to face order in room 8 to make further modifications here easier.",
       "EMType": 32,
+      "Tags": [
+        14
+      ],
       "RoomIndex": 8,
       "Swaps": {
         "269": 184,

--- a/TRRandomizerCore/Resources/TR1/Environment/LEVEL7B.PHD-Environment.json
+++ b/TRRandomizerCore/Resources/TR1/Environment/LEVEL7B.PHD-Environment.json
@@ -7630,6 +7630,9 @@
         {
           "Comments": "Make a side trap room to house the medis. You get nothing for free.",
           "EMType": 126,
+          "Tags": [
+            14
+          ],
           "Location": {
             "X": 26624,
             "Y": -6144,
@@ -7682,6 +7685,9 @@
         {
           "Comments": "Make visibility portals.",
           "EMType": 81,
+          "Tags": [
+            14
+          ],
           "Portals": [
             {
               "BaseRoom": 79,
@@ -7745,6 +7751,9 @@
         },
         {
           "EMType": 82,
+          "Tags": [
+            14
+          ],
           "Portals": {
             "-1": {
               "79": [
@@ -7766,6 +7775,9 @@
         },
         {
           "EMType": 21,
+          "Tags": [
+            14
+          ],
           "TextureMap": {
             "5": {
               "-1": {
@@ -7791,6 +7803,9 @@
         },
         {
           "EMType": 22,
+          "Tags": [
+            14
+          ],
           "GeometryMap": {
             "-1": {
               "Rectangles": [
@@ -7806,6 +7821,9 @@
         },
         {
           "EMType": 128,
+          "Tags": [
+            14
+          ],
           "RoomIndices": [
             -1
           ]
@@ -7861,6 +7879,9 @@
         },
         {
           "EMType": 51,
+          "Tags": [
+            14
+          ],
           "TypeID": 38,
           "Intensity": -1,
           "Location": {
@@ -7872,6 +7893,9 @@
         },
         {
           "EMType": 51,
+          "Tags": [
+            14
+          ],
           "TypeID": 42,
           "Intensity": -1,
           "Location": {
@@ -7884,6 +7908,9 @@
         },
         {
           "EMType": 51,
+          "Tags": [
+            14
+          ],
           "TypeID": 42,
           "Intensity": -1,
           "Location": {
@@ -7896,6 +7923,9 @@
         },
         {
           "EMType": 61,
+          "Tags": [
+            14
+          ],
           "EntityLocation": -2,
           "Trigger": {
             "Mask": 31,
@@ -7914,6 +7944,9 @@
         },
         {
           "EMType": 61,
+          "Tags": [
+            14
+          ],
           "Locations": [
             {
               "X": 28160,
@@ -7937,6 +7970,9 @@
         },
         {
           "EMType": 51,
+          "Tags": [
+            14
+          ],
           "TypeID": 94,
           "Intensity": 4096,
           "Location": {
@@ -7948,6 +7984,23 @@
         },
         {
           "EMType": 51,
+          "Tags": [
+            13
+          ],
+          "TypeID": 94,
+          "Intensity": 4096,
+          "Location": {
+            "X": 28800,
+            "Y": -6144,
+            "Z": 60928,
+            "Room": 79
+          }
+        },
+        {
+          "EMType": 51,
+          "Tags": [
+            14
+          ],
           "TypeID": 94,
           "Intensity": 4096,
           "Location": {
@@ -7959,6 +8012,23 @@
         },
         {
           "EMType": 51,
+          "Tags": [
+            13
+          ],
+          "TypeID": 94,
+          "Intensity": 4096,
+          "Location": {
+            "X": 28800,
+            "Y": -6144,
+            "Z": 60928,
+            "Room": 79
+          }
+        },
+        {
+          "EMType": 51,
+          "Tags": [
+            14
+          ],
           "TypeID": 94,
           "Intensity": 4096,
           "Location": {
@@ -7970,6 +8040,23 @@
         },
         {
           "EMType": 51,
+          "Tags": [
+            13
+          ],
+          "TypeID": 94,
+          "Intensity": 4096,
+          "Location": {
+            "X": 28800,
+            "Y": -6144,
+            "Z": 60928,
+            "Room": 79
+          }
+        },
+        {
+          "EMType": 51,
+          "Tags": [
+            14
+          ],
           "TypeID": 94,
           "Intensity": 4096,
           "Location": {
@@ -7981,6 +8068,23 @@
         },
         {
           "EMType": 51,
+          "Tags": [
+            13
+          ],
+          "TypeID": 94,
+          "Intensity": 4096,
+          "Location": {
+            "X": 28800,
+            "Y": -6144,
+            "Z": 60928,
+            "Room": 79
+          }
+        },
+        {
+          "EMType": 51,
+          "Tags": [
+            14
+          ],
           "TypeID": 94,
           "Intensity": 4096,
           "Location": {
@@ -7992,6 +8096,23 @@
         },
         {
           "EMType": 51,
+          "Tags": [
+            13
+          ],
+          "TypeID": 94,
+          "Intensity": 4096,
+          "Location": {
+            "X": 29184,
+            "Y": -6144,
+            "Z": 60544,
+            "Room": 79
+          }
+        },
+        {
+          "EMType": 51,
+          "Tags": [
+            14
+          ],
           "TypeID": 94,
           "Intensity": 4096,
           "Location": {
@@ -8003,6 +8124,23 @@
         },
         {
           "EMType": 51,
+          "Tags": [
+            13
+          ],
+          "TypeID": 94,
+          "Intensity": 4096,
+          "Location": {
+            "X": 29184,
+            "Y": -6144,
+            "Z": 60544,
+            "Room": 79
+          }
+        },
+        {
+          "EMType": 51,
+          "Tags": [
+            14
+          ],
           "TypeID": 94,
           "Intensity": 4096,
           "Location": {
@@ -8014,6 +8152,23 @@
         },
         {
           "EMType": 51,
+          "Tags": [
+            13
+          ],
+          "TypeID": 94,
+          "Intensity": 4096,
+          "Location": {
+            "X": 29184,
+            "Y": -6144,
+            "Z": 60544,
+            "Room": 79
+          }
+        },
+        {
+          "EMType": 51,
+          "Tags": [
+            14
+          ],
           "TypeID": 94,
           "Intensity": 4096,
           "Location": {
@@ -8025,6 +8180,23 @@
         },
         {
           "EMType": 51,
+          "Tags": [
+            13
+          ],
+          "TypeID": 94,
+          "Intensity": 4096,
+          "Location": {
+            "X": 29184,
+            "Y": -6144,
+            "Z": 60544,
+            "Room": 79
+          }
+        },
+        {
+          "EMType": 51,
+          "Tags": [
+            14
+          ],
           "TypeID": 93,
           "Intensity": 4096,
           "Location": {
@@ -8036,6 +8208,23 @@
         },
         {
           "EMType": 51,
+          "Tags": [
+            13
+          ],
+          "TypeID": 93,
+          "Intensity": 4096,
+          "Location": {
+            "X": 29184,
+            "Y": -6144,
+            "Z": 60928,
+            "Room": 79
+          }
+        },
+        {
+          "EMType": 51,
+          "Tags": [
+            14
+          ],
           "TypeID": 94,
           "Intensity": 4096,
           "Location": {
@@ -8047,6 +8236,23 @@
         },
         {
           "EMType": 51,
+          "Tags": [
+            13
+          ],
+          "TypeID": 94,
+          "Intensity": 4096,
+          "Location": {
+            "X": 29184,
+            "Y": -6144,
+            "Z": 61312,
+            "Room": 79
+          }
+        },
+        {
+          "EMType": 51,
+          "Tags": [
+            14
+          ],
           "TypeID": 94,
           "Intensity": 4096,
           "Location": {
@@ -8058,6 +8264,23 @@
         },
         {
           "EMType": 51,
+          "Tags": [
+            13
+          ],
+          "TypeID": 94,
+          "Intensity": 4096,
+          "Location": {
+            "X": 29184,
+            "Y": -6144,
+            "Z": 61312,
+            "Room": 79
+          }
+        },
+        {
+          "EMType": 51,
+          "Tags": [
+            14
+          ],
           "TypeID": 94,
           "Intensity": 4096,
           "Location": {
@@ -8069,6 +8292,23 @@
         },
         {
           "EMType": 51,
+          "Tags": [
+            13
+          ],
+          "TypeID": 94,
+          "Intensity": 4096,
+          "Location": {
+            "X": 29184,
+            "Y": -6144,
+            "Z": 61312,
+            "Room": 79
+          }
+        },
+        {
+          "EMType": 51,
+          "Tags": [
+            14
+          ],
           "TypeID": 94,
           "Intensity": 4096,
           "Location": {
@@ -8080,6 +8320,23 @@
         },
         {
           "EMType": 51,
+          "Tags": [
+            13
+          ],
+          "TypeID": 94,
+          "Intensity": 4096,
+          "Location": {
+            "X": 29184,
+            "Y": -6144,
+            "Z": 61312,
+            "Room": 79
+          }
+        },
+        {
+          "EMType": 51,
+          "Tags": [
+            14
+          ],
           "TypeID": 94,
           "Intensity": 4096,
           "Location": {
@@ -8091,6 +8348,23 @@
         },
         {
           "EMType": 51,
+          "Tags": [
+            13
+          ],
+          "TypeID": 94,
+          "Intensity": 4096,
+          "Location": {
+            "X": 29568,
+            "Y": -6144,
+            "Z": 60928,
+            "Room": 79
+          }
+        },
+        {
+          "EMType": 51,
+          "Tags": [
+            14
+          ],
           "TypeID": 94,
           "Intensity": 4096,
           "Location": {
@@ -8102,6 +8376,23 @@
         },
         {
           "EMType": 51,
+          "Tags": [
+            13
+          ],
+          "TypeID": 94,
+          "Intensity": 4096,
+          "Location": {
+            "X": 29568,
+            "Y": -6144,
+            "Z": 60928,
+            "Room": 79
+          }
+        },
+        {
+          "EMType": 51,
+          "Tags": [
+            14
+          ],
           "TypeID": 94,
           "Intensity": 4096,
           "Location": {
@@ -8113,6 +8404,23 @@
         },
         {
           "EMType": 51,
+          "Tags": [
+            13
+          ],
+          "TypeID": 94,
+          "Intensity": 4096,
+          "Location": {
+            "X": 29568,
+            "Y": -6144,
+            "Z": 60928,
+            "Room": 79
+          }
+        },
+        {
+          "EMType": 51,
+          "Tags": [
+            14
+          ],
           "TypeID": 94,
           "Intensity": 4096,
           "Location": {
@@ -8120,6 +8428,20 @@
             "Y": -6144,
             "Z": 55808,
             "Room": -1
+          }
+        },
+        {
+          "EMType": 51,
+          "Tags": [
+            13
+          ],
+          "TypeID": 94,
+          "Intensity": 4096,
+          "Location": {
+            "X": 29568,
+            "Y": -6144,
+            "Z": 60928,
+            "Room": 79
           }
         }
       ]

--- a/TRRandomizerCore/Resources/TR1/Environment/LEVEL8B.PHD-Environment.json
+++ b/TRRandomizerCore/Resources/TR1/Environment/LEVEL8B.PHD-Environment.json
@@ -35,6 +35,9 @@
     {
       "Comments": "Fix the wrong flipmap trigger type in room 66.",
       "EMType": 69,
+      "Tags": [
+        10
+      ],
       "Locations": [
         {
           "X": 43520,

--- a/TRRandomizerCore/Resources/TR2/Environment/FLOATING.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR2/Environment/FLOATING.TR2-Environment.json
@@ -4,7 +4,8 @@
       "Comments": "Tweak a slope at the end for easier key item exploration, if enabled.",
       "EMType": 7,
       "Tags": [
-        12
+        12,
+        14
       ],
       "Location": {
         "X": 24064,
@@ -19,7 +20,8 @@
     {
       "EMType": 23,
       "Tags": [
-        12
+        12,
+        14
       ],
       "Modifications": [
         {
@@ -61,7 +63,8 @@
     {
       "EMType": 21,
       "Tags": [
-        12
+        12,
+        14
       ],
       "TextureMap": {
         "1557": {

--- a/TRRandomizerCore/Resources/TR2/Environment/HOUSE.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR2/Environment/HOUSE.TR2-Environment.json
@@ -3,6 +3,9 @@
     {
       "Comments": "Reposition the unused maze button to the bedroom.",
       "EMType": 44,
+      "Tags": [
+        14
+      ],
       "EntityIndex": 107,
       "TargetLocation": {
         "X": 39424,
@@ -15,6 +18,9 @@
     {
       "Comments": "Use it to turn off the alarms.",
       "EMType": 61,
+      "Tags": [
+        14
+      ],
       "EntityLocation": 107,
       "Trigger": {
         "TrigType": 2,
@@ -33,6 +39,9 @@
     {
       "Comments": "Make an unreachable room for a boulder trigger.",
       "EMType": 126,
+      "Tags": [
+        14
+      ],
       "Location": {
         "X": 67584,
         "Y": 2560,
@@ -57,6 +66,9 @@
     {
       "Comments": "Import the boulder model.",
       "EMType": 145,
+      "Tags": [
+        14
+      ],
       "Data": [
         {
           "ModelID": 60,
@@ -68,12 +80,18 @@
     {
       "Comments": "Convert the zipline handle into a boulder (so we can track the index elsewhere).",
       "EMType": 45,
+      "Tags": [
+        14
+      ],
       "EntityIndex": 23,
       "NewEntityType": 60
     },
     {
       "Comments": "Move it to the hidden room.",
       "EMType": 44,
+      "Tags": [
+        14
+      ],
       "EntityIndex": 23,
       "TargetLocation": {
         "X": 69120,
@@ -85,6 +103,9 @@
     {
       "Comments": "Put a new zipline handle in its place.",
       "EMType": 51,
+      "Tags": [
+        14
+      ],
       "TypeID": 102,
       "Intensity": -1,
       "Location": {
@@ -97,6 +118,9 @@
     {
       "Comments": "Move the initial trigger under Lara to the boulder.",
       "EMType": 67,
+      "Tags": [
+        14
+      ],
       "BaseLocation": {
         "X": 34304,
         "Y": 256,
@@ -108,6 +132,9 @@
     {
       "Comments": "Make it heavy.",
       "EMType": 69,
+      "Tags": [
+        14
+      ],
       "Location": {
         "X": 69120,
         "Y": 2560,
@@ -119,6 +146,9 @@
     {
       "Comments": "Trigger the boulder from the start position. All in all, this means the alarms won't get turned back on.",
       "EMType": 61,
+      "Tags": [
+        14
+      ],
       "Locations": [
         {
           "X": 34304,
@@ -138,6 +168,9 @@
     },
     {
       "EMType": 23,
+      "Tags": [
+        14
+      ],
       "Rotations": [
         {
           "RoomNumber": 8,

--- a/TRRandomizerCore/Resources/TR3/Environment/AREA51.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR3/Environment/AREA51.TR2-Environment.json
@@ -143,6 +143,9 @@
         {
           "Comments": "Remove the hand scanner static mesh.",
           "EMType": 25,
+          "Tags": [
+            14
+          ],
           "ClearFromRooms": {
             "417": [
               0
@@ -316,6 +319,9 @@
         {
           "Comments": "Remove the hand scanner static mesh.",
           "EMType": 25,
+          "Tags": [
+            14
+          ],
           "ClearFromRooms": {
             "417": [
               12
@@ -436,6 +442,9 @@
         {
           "Comments": "Remove the hand scanner static mesh.",
           "EMType": 25,
+          "Tags": [
+            14
+          ],
           "ClearFromRooms": {
             "417": [
               120

--- a/TRRandomizerCore/Resources/TR3/Environment/CITY.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR3/Environment/CITY.TR2-Environment.json
@@ -1096,7 +1096,8 @@
       "Comments": "Replace the wall texture.",
       "EMType": 21,
       "Tags": [
-        12
+        12,
+        14
       ],
       "TextureMap": {
         "1889": {

--- a/TRRandomizerCore/Resources/TR3/Environment/COMPOUND.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR3/Environment/COMPOUND.TR2-Environment.json
@@ -542,6 +542,9 @@
         {
           "Comments": "Remove the hand scanner static mesh.",
           "EMType": 25,
+          "Tags": [
+            14
+          ],
           "ClearFromRooms": {
             "413": [
               74

--- a/TRRandomizerCore/Resources/TR3/Environment/QUADCHAS.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR3/Environment/QUADCHAS.TR2-Environment.json
@@ -529,6 +529,9 @@
       "OnTrue": [
         {
           "EMType": 0,
+          "Tags": [
+            14
+          ],
           "TextureMap": {
             "1487": {
               "167": {


### PR DESCRIPTION
Part of #614.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Although general environment randomization isn't going to be possible (at least yet) there are still some functions that always run, such as to tweak areas for specific secrets or at the beginning of HSH to change how things are triggered. This change makes classic-only and remastered-only tags available so we can distinguish in the JSON and ultimately ensure we're not doing anything illegal in TRR.