### PR TITLE
Refactor audio randomization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - added gun holsters to Lara's robe outfit in TR2 (#672)
 - fixed a key item softlock in Crash Site (#662)
 - fixed incorrect item and mesh positions in Home Sweet Home when mirrored (#676)
+- fixed uncontrolled SFX in gym/assault course levels not being linked to the correct setting (#684)
 
 ## [V1.8.4](https://github.com/LostArtefacts/TR-Rando/compare/V1.8.3...V1.8.4) - 2024-02-12
 - fixed item locking logic so that secrets that rely on specific enemies will always be obtainable (#570)

--- a/TRRandomizerCore/Randomizers/Shared/AudioRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/Shared/AudioRandomizer.cs
@@ -3,6 +3,7 @@ using TRGE.Core;
 using TRLevelControl;
 using TRLevelControl.Model;
 using TRRandomizerCore.Editors;
+using TRRandomizerCore.Helpers;
 using TRRandomizerCore.SFX;
 
 namespace TRRandomizerCore.Randomizers;
@@ -11,12 +12,29 @@ public class AudioRandomizer
 {
     private readonly IReadOnlyDictionary<TRAudioCategory, List<TRAudioTrack>> _tracks;
     private readonly Dictionary<Vector2, ushort> _trackMap;
+    private List<string> _uncontrolledLevels;
+
+    public Random Generator { get; set; }
+    public RandomizerSettings Settings { get; set; }
 
     public AudioRandomizer(IReadOnlyDictionary<TRAudioCategory, List<TRAudioTrack>> tracks)
     {
         _tracks = tracks;
-        _trackMap = new Dictionary<Vector2, ushort>();
+        _trackMap = new();
     }
+
+    public void ChooseUncontrolledLevels(List<string> levels, string assaultCourse)
+    {
+        HashSet<string> exlusions = new() { assaultCourse };
+        _uncontrolledLevels = levels.RandomSelection(Generator, (int)Settings.UncontrolledSFXCount, exclusions: exlusions);
+        if (Settings.UncontrolledSFXAssaultCourse)
+        {
+            _uncontrolledLevels.Add(assaultCourse);
+        }
+    }
+
+    public bool IsUncontrolledLevel(string level)
+        => _uncontrolledLevels.Contains(level);
 
     public void ResetFloorMap()
     {

--- a/TRRandomizerCore/Randomizers/Shared/AudioRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/Shared/AudioRandomizer.cs
@@ -41,11 +41,11 @@ public class AudioRandomizer
         _trackMap.Clear();
     }
 
-    public void RandomizeFloorTracks(List<TRRoomSector> sectors, FDControl floorData, Random generator, Func<int, Vector2> positionAction)
+    public void RandomizeFloorTracks(TRRoom room, FDControl floorData)
     {
-        for (int i = 0; i < sectors.Count; i++)
+        for (int i = 0; i < room.Sectors.Count; i++)
         {
-            TRRoomSector sector = sectors[i];
+            TRRoomSector sector = room.Sectors[i];
             FDActionItem trackItem = null;
             if (sector.FDIndex > 0)
             {
@@ -63,7 +63,11 @@ public class AudioRandomizer
 
             // Get this sector's midpoint in world coordinates. Store each immediately
             // neighbouring tile to use the same track as this one, regardless of room.
-            Vector2 position = positionAction.Invoke(i);
+            Vector2 position = new
+            (
+                TRConsts.Step2 + room.Info.X + i / room.NumZSectors * TRConsts.Step4,
+                TRConsts.Step2 + room.Info.Z + i % room.NumZSectors * TRConsts.Step4
+            );
             int x = (int)position.X;
             int z = (int)position.Y;
 
@@ -71,7 +75,7 @@ public class AudioRandomizer
             {
                 TRAudioCategory category = FindTrackCategory((ushort)trackItem.Parameter);
                 List<TRAudioTrack> tracks = _tracks[category];
-                _trackMap[position] = tracks[generator.Next(0, tracks.Count)].ID;
+                _trackMap[position] = tracks[Generator.Next(0, tracks.Count)].ID;
             }
 
             for (int xNorm = -1; xNorm < 2; xNorm++)

--- a/TRRandomizerCore/Randomizers/TR1/Classic/TR1AudioRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Classic/TR1AudioRandomizer.cs
@@ -31,7 +31,7 @@ public class TR1AudioRandomizer : BaseTR1Randomizer
             _allocator.RandomizeMusicTriggers(_levelInstance.Data);
             RandomizeSoundEffects(_levelInstance);
             ImportSpeechSFX(_levelInstance.Data);
-            _allocator.RandomizeWibble(_levelInstance.Data);
+            _allocator.RandomizePitch(_levelInstance.Data.SoundEffects.Values);
             
             SaveLevelInstance();
             if (!TriggerProgress())
@@ -50,8 +50,7 @@ public class TR1AudioRandomizer : BaseTR1Randomizer
     private void RandomizeSoundEffects(TR1CombinedLevel level)
     {
         List<TR1SFXDefinition> soundEffects = _allocator.GetDefinitions();
-        List<TRSFXGeneralCategory> categories = _allocator.GetCategories();
-        if (categories.Count == 0)
+        if (_allocator.Categories.Count == 0)
         {
             return;
         }
@@ -90,7 +89,7 @@ public class TR1AudioRandomizer : BaseTR1Randomizer
             {
                 TR1SFXDefinition definition = soundEffects.Find(sfx => sfx.InternalIndex == internalIndex);
                 if (!level.Data.SoundEffects.ContainsKey(internalIndex) || definition == null 
-                    || definition.Creature == TRSFXCreatureCategory.Lara || !categories.Contains(definition.PrimaryCategory))
+                    || definition.Creature == TRSFXCreatureCategory.Lara || !_allocator.Categories.Contains(definition.PrimaryCategory))
                 {
                     continue;
                 }

--- a/TRRandomizerCore/Randomizers/TR1/Classic/TR1AudioRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Classic/TR1AudioRandomizer.cs
@@ -15,6 +15,8 @@ public class TR1AudioRandomizer : BaseTR1Randomizer
     private static readonly TR1SFX _sfxFirstSpeechID = TR1SFX.BaldySpeech;
     private static readonly TR1SFX _sfxUziID = TR1SFX.LaraUziFire;
 
+    private const double _psUziChance = 0.4;
+
     private AudioRandomizer _audioRandomizer;
 
     private List<TR1SFXDefinition> _soundEffects;
@@ -116,7 +118,6 @@ public class TR1AudioRandomizer : BaseTR1Randomizer
     {
         if (_sfxCategories.Count == 0)
         {
-            // We haven't selected any SFX categories to change.
             return;
         }
 
@@ -147,6 +148,9 @@ public class TR1AudioRandomizer : BaseTR1Randomizer
         }
         else
         {
+            // Run through the SoundMap for this level and get the SFX definition for each one.
+            // Choose a new sound effect provided the definition is in a category we want to change.
+            // Lara's SFX are not changed by default.
             foreach (TR1SFX internalIndex in Enum.GetValues<TR1SFX>())
             {
                 TR1SFXDefinition definition = _soundEffects.Find(sfx => sfx.InternalIndex == internalIndex);
@@ -177,14 +181,13 @@ public class TR1AudioRandomizer : BaseTR1Randomizer
                 }
 
                 List<TR1SFXDefinition> otherDefinitions;
-                if (internalIndex == _sfxUziID && _generator.NextDouble() < 0.4)
+                if (internalIndex == _sfxUziID && _generator.NextDouble() < _psUziChance)
                 {
                     // 2/5 chance of PS uzis replacing original uzis, but they won't be used for anything else
                     otherDefinitions = new() { _psUziDefinition };
                 }
                 else
                 {
-                    // Try to find definitions that match
                     otherDefinitions = _soundEffects.FindAll(pred);
                 }
 
@@ -218,7 +221,6 @@ public class TR1AudioRandomizer : BaseTR1Randomizer
         // TR1X can play enemy speeches as SFX to avoid killing the current
         // track, so ensure that the required data is in the level if any
         // of these are used on the floor.
-
         List<ushort> usedSpeechTracks = level.Data.FloorData.GetActionItems(FDTrigAction.PlaySoundtrack)
             .Select(action => (ushort)action.Parameter)
             .Distinct()

--- a/TRRandomizerCore/Randomizers/TR1/Classic/TR1AudioRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Classic/TR1AudioRandomizer.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System.Numerics;
 using TRGE.Core;
 using TRLevelControl;
 using TRLevelControl.Helpers;
@@ -101,15 +100,7 @@ public class TR1AudioRandomizer : BaseTR1Randomizer
             _audioRandomizer.ResetFloorMap();
             foreach (TR1Room room in level.Data.Rooms.Where(r => !r.Flags.HasFlag(TRRoomFlag.Unused2)))
             {
-                _audioRandomizer.RandomizeFloorTracks(room.Sectors, level.Data.FloorData, _generator, sectorIndex =>
-                {
-                    // Get the midpoint of the tile in world coordinates
-                    return new Vector2
-                    (
-                        TRConsts.Step2 + room.Info.X + sectorIndex / room.NumZSectors * TRConsts.Step4,
-                        TRConsts.Step2 + room.Info.Z + sectorIndex % room.NumZSectors * TRConsts.Step4
-                    );
-                });
+                _audioRandomizer.RandomizeFloorTracks(room, level.Data.FloorData);
             }
         }
     }

--- a/TRRandomizerCore/Randomizers/TR1/Classic/TR1AudioRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Classic/TR1AudioRandomizer.cs
@@ -101,7 +101,7 @@ public class TR1AudioRandomizer : BaseTR1Randomizer
         ISet<TR1ScriptedLevel> exlusions = new HashSet<TR1ScriptedLevel> { assaultCourse };
 
         _uncontrolledLevels = Levels.RandomSelection(_generator, (int)Settings.UncontrolledSFXCount, exclusions: exlusions);
-        if (Settings.AssaultCourseWireframe)
+        if (Settings.UncontrolledSFXAssaultCourse)
         {
             _uncontrolledLevels.Add(assaultCourse);
         }

--- a/TRRandomizerCore/Randomizers/TR1/Classic/TR1AudioRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Classic/TR1AudioRandomizer.cs
@@ -1,7 +1,4 @@
-﻿using Newtonsoft.Json;
-using TRGE.Core;
-using TRLevelControl;
-using TRLevelControl.Helpers;
+﻿using TRGE.Core;
 using TRLevelControl.Model;
 using TRRandomizerCore.Levels;
 using TRRandomizerCore.SFX;
@@ -12,29 +9,29 @@ public class TR1AudioRandomizer : BaseTR1Randomizer
 {
     private static readonly List<int> _speechTracks = Enumerable.Range(51, 6).ToList();
     private static readonly TR1SFX _sfxFirstSpeechID = TR1SFX.BaldySpeech;
-    private static readonly TR1SFX _sfxUziID = TR1SFX.LaraUziFire;
-
+    
     private const double _psUziChance = 0.4;
 
-    private AudioRandomizer _audioRandomizer;
-
-    private List<TR1SFXDefinition> _soundEffects;
-    private TR1SFXDefinition _psUziDefinition;
-    private List<TRSFXGeneralCategory> _sfxCategories, _persistentCategories;
+    private TR1AudioAllocator _allocator;
 
     public override void Randomize(int seed)
     {
         _generator = new(seed);
-        LoadAudioData();
+        _allocator = new(ScriptEditor.AudioProvider.GetCategorisedTracks())
+        {
+            Generator = _generator,
+            Settings = Settings,
+        };
+        _allocator.Initialise(Levels.Select(l => l.LevelFileBaseName), BackupPath);
 
         foreach (TR1ScriptedLevel lvl in Levels)
         {
             LoadLevelInstance(lvl);
 
-            RandomizeMusicTriggers(_levelInstance);
+            _allocator.RandomizeMusicTriggers(_levelInstance.Data);
             RandomizeSoundEffects(_levelInstance);
-            ImportSpeechSFX(_levelInstance);
-            RandomizeWibble(_levelInstance);
+            ImportSpeechSFX(_levelInstance.Data);
+            _allocator.RandomizeWibble(_levelInstance.Data);
             
             SaveLevelInstance();
             if (!TriggerProgress())
@@ -42,77 +39,24 @@ public class TR1AudioRandomizer : BaseTR1Randomizer
                 break;
             }
         }
-    }
 
-    private void LoadAudioData()
-    {
-        // Get the track data from audio_tracks.json. Loaded from TRGE as it sets the ambient tracks initially.
-        _audioRandomizer = new(ScriptEditor.AudioProvider.GetCategorisedTracks())
+        if (Settings.RandomizeWibble)
         {
-            Generator = _generator,
-            Settings = Settings,
-        };
-        _audioRandomizer.ChooseUncontrolledLevels(new(Levels.Select(l => l.LevelFileBaseName)), TR1LevelNames.ASSAULT);
-
-        // Decide which sound effect categories we want to randomize.
-        _sfxCategories = AudioRandomizer.GetSFXCategories(Settings);
-
-        // SFX in these categories can potentially remain as they are
-        _persistentCategories = new()
-        {
-            TRSFXGeneralCategory.StandardWeaponFiring,
-            TRSFXGeneralCategory.Ricochet,
-            TRSFXGeneralCategory.Flying,
-            TRSFXGeneralCategory.Explosion
-        };
-
-        _soundEffects = JsonConvert.DeserializeObject<List<TR1SFXDefinition>>(ReadResource(@"TR1\Audio\sfx.json"));
-
-        // We don't want to store all SFX WAV data in JSON, so instead we reference the source level
-        // and extract the details from there using the same format for model transport.
-        Dictionary<string, TR1Level> levels = new();
-        TR1LevelControl reader = new();
-        foreach (TR1SFXDefinition definition in _soundEffects)
-        {
-            if (!levels.ContainsKey(definition.SourceLevel))
-            {
-                levels[definition.SourceLevel] = reader.Read(Path.Combine(BackupPath, definition.SourceLevel));
-            }
-
-            TR1Level level = levels[definition.SourceLevel];
-            definition.SoundEffect = level.SoundEffects[definition.InternalIndex];
-        }
-
-        // PS uzis need some manual setup. Make a copy of the standard uzi definition
-        // then replace the sound data from the external wav file.
-        TR1Level caves = levels[TR1LevelNames.CAVES];
-        _psUziDefinition = new TR1SFXDefinition
-        {
-            SoundEffect = caves.SoundEffects[_sfxUziID]
-        };
-        _psUziDefinition.SoundEffect.Samples = new() { File.ReadAllBytes(GetResourcePath(@"TR1\Audio\ps_uzis.wav")) };
-    }
-
-    private void RandomizeMusicTriggers(TR1CombinedLevel level)
-    {
-        if (Settings.ChangeTriggerTracks)
-        {
-            _audioRandomizer.ResetFloorMap();
-            foreach (TR1Room room in level.Data.Rooms.Where(r => !r.Flags.HasFlag(TRRoomFlag.Unused2)))
-            {
-                _audioRandomizer.RandomizeFloorTracks(room, level.Data.FloorData);
-            }
+            (ScriptEditor as TR1ScriptEditor).EnablePitchedSounds = true;
+            ScriptEditor.SaveScript();
         }
     }
 
     private void RandomizeSoundEffects(TR1CombinedLevel level)
     {
-        if (_sfxCategories.Count == 0)
+        List<TR1SFXDefinition> soundEffects = _allocator.GetDefinitions();
+        List<TRSFXGeneralCategory> categories = _allocator.GetCategories();
+        if (categories.Count == 0)
         {
             return;
         }
 
-        if (_audioRandomizer.IsUncontrolledLevel(level.Name))
+        if (_allocator.IsUncontrolledLevel(level.Name))
         {
             HashSet<string> usedSamples = new();
 
@@ -125,7 +69,7 @@ public class TR1AudioRandomizer : BaseTR1Randomizer
                     string id;
                     do
                     {
-                        TR1SFXDefinition definition = _soundEffects[_generator.Next(0, _soundEffects.Count)];
+                        TR1SFXDefinition definition = soundEffects[_generator.Next(0, soundEffects.Count)];
                         int sampleIndex = _generator.Next(0, definition.SoundEffect.Samples.Count);
                         sample = definition.SoundEffect.Samples[sampleIndex];
 
@@ -144,9 +88,9 @@ public class TR1AudioRandomizer : BaseTR1Randomizer
             // Lara's SFX are not changed by default.
             foreach (TR1SFX internalIndex in Enum.GetValues<TR1SFX>())
             {
-                TR1SFXDefinition definition = _soundEffects.Find(sfx => sfx.InternalIndex == internalIndex);
+                TR1SFXDefinition definition = soundEffects.Find(sfx => sfx.InternalIndex == internalIndex);
                 if (!level.Data.SoundEffects.ContainsKey(internalIndex) || definition == null 
-                    || definition.Creature == TRSFXCreatureCategory.Lara || !_sfxCategories.Contains(definition.PrimaryCategory))
+                    || definition.Creature == TRSFXCreatureCategory.Lara || !categories.Contains(definition.PrimaryCategory))
                 {
                     continue;
                 }
@@ -159,7 +103,7 @@ public class TR1AudioRandomizer : BaseTR1Randomizer
                     pred = sfx =>
                     {
                         return sfx.Categories.Contains(definition.PrimaryCategory) &&
-                        (sfx != definition || _persistentCategories.Contains(definition.PrimaryCategory)) &&
+                        (sfx != definition || _allocator.IsPersistent(definition.PrimaryCategory)) &&
                         (
                             sfx.Creature == definition.Creature ||
                             (sfx.Creature == TRSFXCreatureCategory.Lara && definition.Creature == TRSFXCreatureCategory.Human)
@@ -168,18 +112,18 @@ public class TR1AudioRandomizer : BaseTR1Randomizer
                 }
                 else
                 {
-                    pred = sfx => sfx.Categories.Contains(definition.PrimaryCategory) && (sfx != definition || _persistentCategories.Contains(definition.PrimaryCategory));
+                    pred = sfx => sfx.Categories.Contains(definition.PrimaryCategory) && (sfx != definition || _allocator.IsPersistent(definition.PrimaryCategory));
                 }
 
                 List<TR1SFXDefinition> otherDefinitions;
-                if (internalIndex == _sfxUziID && _generator.NextDouble() < _psUziChance)
+                if (internalIndex == TR1SFX.LaraUziFire && _generator.NextDouble() < _psUziChance)
                 {
                     // 2/5 chance of PS uzis replacing original uzis, but they won't be used for anything else
-                    otherDefinitions = new() { _psUziDefinition };
+                    otherDefinitions = new() { _allocator.GetPSUziDefinition() };
                 }
                 else
                 {
-                    otherDefinitions = _soundEffects.FindAll(pred);
+                    otherDefinitions = soundEffects.FindAll(pred);
                 }
 
                 if (otherDefinitions.Count > 0)
@@ -202,17 +146,16 @@ public class TR1AudioRandomizer : BaseTR1Randomizer
         }
     }
 
-    private void ImportSpeechSFX(TR1CombinedLevel level)
+    private void ImportSpeechSFX(TR1Level level)
     {
         if (!(ScriptEditor as TR1ScriptEditor).FixSpeechesKillingMusic)
         {
             return;
         }
 
-        // TR1X can play enemy speeches as SFX to avoid killing the current
-        // track, so ensure that the required data is in the level if any
-        // of these are used on the floor.
-        List<ushort> usedSpeechTracks = level.Data.FloorData.GetActionItems(FDTrigAction.PlaySoundtrack)
+        // TR1X can play enemy speeches as SFX to avoid killing the current track, so ensure that
+        // the required data is in the level if any of these are used on the floor.
+        List<ushort> usedSpeechTracks = level.FloorData.GetActionItems(FDTrigAction.PlaySoundtrack)
             .Select(action => (ushort)action.Parameter)
             .Distinct()
             .Where(trackID => _speechTracks.Contains(trackID))
@@ -223,33 +166,18 @@ public class TR1AudioRandomizer : BaseTR1Randomizer
             return;
         }
 
+        List<TR1SFXDefinition> soundEffects = _allocator.GetDefinitions();
         foreach (ushort trackID in usedSpeechTracks)
         {
             TR1SFX sfxID = (TR1SFX)((int)_sfxFirstSpeechID + trackID - _speechTracks.First());
             TR1SFXDefinition definition;
-            if (level.Data.SoundEffects.ContainsKey(sfxID)
-                || (definition = _soundEffects.Find(sfx => sfx.InternalIndex == sfxID)) == null)
+            if (level.SoundEffects.ContainsKey(sfxID)
+                || (definition = soundEffects.Find(sfx => sfx.InternalIndex == sfxID)) == null)
             {
                 continue;
             }
 
-            level.Data.SoundEffects[sfxID] = definition.SoundEffect;
-        }
-    }
-
-    private void RandomizeWibble(TR1CombinedLevel level)
-    {
-        if (Settings.RandomizeWibble)
-        {
-            // The engine does the actual randomization, we just tell it that every
-            // sound effect should be included.
-            foreach (var (_, effect) in level.Data.SoundEffects)
-            {
-                effect.RandomizePitch = true;
-            }
-
-            (ScriptEditor as TR1ScriptEditor).EnablePitchedSounds = true;
-            ScriptEditor.SaveScript();
+            level.SoundEffects[sfxID] = definition.SoundEffect;
         }
     }
 }

--- a/TRRandomizerCore/Randomizers/TR1/Remastered/TR1RAudioRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Remastered/TR1RAudioRandomizer.cs
@@ -25,7 +25,7 @@ public class TR1RAudioRandomizer : BaseTR1RRandomizer
 
             _allocator.RandomizeMusicTriggers(_levelInstance.Data);
             RandomizeSoundEffects(_levelInstance);
-            _allocator.RandomizeWibble(_levelInstance.Data);
+            _allocator.RandomizePitch(_levelInstance.Data.SoundEffects.Values);
 
             SaveLevelInstance();
             if (!TriggerProgress())
@@ -37,8 +37,7 @@ public class TR1RAudioRandomizer : BaseTR1RRandomizer
 
     private void RandomizeSoundEffects(TR1RCombinedLevel level)
     {
-        List<TRSFXGeneralCategory> categories = _allocator.GetCategories();
-        if (categories.Count == 0)
+        if (_allocator.Categories.Count == 0)
         {
             return;
         }
@@ -79,7 +78,6 @@ public class TR1RAudioRandomizer : BaseTR1RRandomizer
     private TR1SFXDefinition SelectSFXReplacement(TR1RCombinedLevel level, TR1SFX currentSFX)
     {
         List<TR1SFXDefinition> soundEffects = _allocator.GetDefinitions();
-        List<TRSFXGeneralCategory> categories = _allocator.GetCategories();
 
         if (_allocator.IsUncontrolledLevel(level.Name))
         {
@@ -88,7 +86,7 @@ public class TR1RAudioRandomizer : BaseTR1RRandomizer
 
         TR1SFXDefinition definition = soundEffects.Find(sfx => sfx.InternalIndex == currentSFX);
         if (definition == null
-            || definition.Creature == TRSFXCreatureCategory.Lara || !categories.Contains(definition.PrimaryCategory))
+            || definition.Creature == TRSFXCreatureCategory.Lara || !_allocator.Categories.Contains(definition.PrimaryCategory))
         {
             return null;
         }

--- a/TRRandomizerCore/Randomizers/TR1/Remastered/TR1RAudioRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Remastered/TR1RAudioRandomizer.cs
@@ -1,8 +1,12 @@
-﻿using System.Numerics;
+﻿using Newtonsoft.Json;
+using System.Numerics;
 using TRGE.Core;
 using TRLevelControl;
+using TRLevelControl.Helpers;
 using TRLevelControl.Model;
+using TRRandomizerCore.Helpers;
 using TRRandomizerCore.Levels;
+using TRRandomizerCore.SFX;
 
 namespace TRRandomizerCore.Randomizers;
 
@@ -12,17 +16,23 @@ public class TR1RAudioRandomizer : BaseTR1RRandomizer
 
     private AudioRandomizer _audioRandomizer;
 
+    private List<TR1SFXDefinition> _soundEffects;
+    private List<TRSFXGeneralCategory> _sfxCategories, _persistentCategories;
+    private List<TRRScriptedLevel> _uncontrolledLevels;
+
     public override void Randomize(int seed)
     {
         _generator = new(seed);
 
         LoadAudioData();
+        ChooseUncontrolledLevels();
 
         foreach (TRRScriptedLevel lvl in Levels)
         {
             LoadLevelInstance(lvl);
 
             RandomizeMusicTriggers(_levelInstance);
+            RandomizeSoundEffects(_levelInstance);
             RandomizeWibble(_levelInstance);
 
             SaveLevelInstance();
@@ -36,6 +46,46 @@ public class TR1RAudioRandomizer : BaseTR1RRandomizer
     private void LoadAudioData()
     {
         _audioRandomizer = new(ScriptEditor.AudioProvider.GetCategorisedTracks());
+        _sfxCategories = AudioRandomizer.GetSFXCategories(Settings);
+        _persistentCategories = new()
+        {
+            TRSFXGeneralCategory.StandardWeaponFiring,
+            TRSFXGeneralCategory.Ricochet,
+            TRSFXGeneralCategory.Flying,
+            TRSFXGeneralCategory.Explosion
+        };
+
+        _soundEffects = JsonConvert.DeserializeObject<List<TR1SFXDefinition>>(ReadResource(@"TR1\Audio\sfx.json"));
+
+        Dictionary<string, TR1Level> levels = new();
+        TR1LevelControl reader = new();
+        foreach (TR1SFXDefinition definition in _soundEffects)
+        {
+            if (!levels.ContainsKey(definition.SourceLevel))
+            {
+                levels[definition.SourceLevel] = reader.Read(Path.Combine(BackupPath, definition.SourceLevel));
+            }
+
+            TR1Level level = levels[definition.SourceLevel];
+            definition.SoundEffect = level.SoundEffects[definition.InternalIndex];
+        }
+    }
+
+    private void ChooseUncontrolledLevels()
+    {
+        TRRScriptedLevel assaultCourse = Levels.Find(l => l.Is(TR1LevelNames.ASSAULT));
+        HashSet<TRRScriptedLevel> exlusions = new() { assaultCourse };
+
+        _uncontrolledLevels = Levels.RandomSelection(_generator, (int)Settings.UncontrolledSFXCount, exclusions: exlusions);
+        if (Settings.UncontrolledSFXAssaultCourse)
+        {
+            _uncontrolledLevels.Add(assaultCourse);
+        }
+    }
+
+    public bool IsUncontrolledLevel(TRRScriptedLevel level)
+    {
+        return _uncontrolledLevels.Contains(level);
     }
 
     private void RandomizeMusicTriggers(TR1RCombinedLevel level)
@@ -95,6 +145,84 @@ public class TR1RAudioRandomizer : BaseTR1RRandomizer
                 }
             }
         }
+    }
+
+    private void RandomizeSoundEffects(TR1RCombinedLevel level)
+    {
+        if (_sfxCategories.Count == 0)
+        {
+            return;
+        }
+
+        // TR1R has hardcoded sample indices (into MAIN.SFX) so we use a different approach compared to OG, by
+        // instead changing any animation commands and sound sources to point to different IDs. This does
+        // however mean hardcoded SFX like Lara's guns remain unchanged.
+        void ChangeCommands(IEnumerable<TRModel> models)
+        {
+            IEnumerable<TRSFXCommand> commands = models
+                .SelectMany(m => m.Animations.SelectMany(a => a.Commands.Where(c => c is TRSFXCommand)))
+                .Cast<TRSFXCommand>();
+            foreach (TRSFXCommand command in commands)
+            {
+                TR1SFXDefinition definition = SelectSFXReplacement(level, (TR1SFX)command.SoundID);
+                if (definition != null)
+                {
+                    command.SoundID = (short)definition.InternalIndex;
+                    level.Data.SoundEffects[definition.InternalIndex] = definition.SoundEffect.Clone();
+                }
+            }
+        }
+
+        ChangeCommands(level.Data.Models.Values);
+        ChangeCommands(level.PDPData.Values);
+
+        foreach (TRSoundSource<TR1SFX> soundSource in level.Data.SoundSources)
+        {
+            TR1SFXDefinition definition = SelectSFXReplacement(level, soundSource.ID);
+            if (definition != null)
+            {
+                soundSource.ID = definition.InternalIndex;
+                level.Data.SoundEffects[definition.InternalIndex] = definition.SoundEffect.Clone();
+            }
+        }
+    }
+
+    private TR1SFXDefinition SelectSFXReplacement(TR1RCombinedLevel level, TR1SFX currentSFX)
+    {
+        if (IsUncontrolledLevel(level.Script))
+        {
+            return _soundEffects[_generator.Next(0, _soundEffects.Count)];
+        }
+
+        TR1SFXDefinition definition = _soundEffects.Find(sfx => sfx.InternalIndex == currentSFX);
+        if (definition == null
+            || definition.Creature == TRSFXCreatureCategory.Lara || !_sfxCategories.Contains(definition.PrimaryCategory))
+        {
+            return null;
+        }
+
+        Predicate<TR1SFXDefinition> pred;
+        if (Settings.LinkCreatureSFX && definition.Creature > TRSFXCreatureCategory.Lara)
+        {
+            pred = sfx =>
+            {
+                return sfx.Categories.Contains(definition.PrimaryCategory) &&
+                (sfx != definition || _persistentCategories.Contains(definition.PrimaryCategory)) &&
+                (
+                    sfx.Creature == definition.Creature ||
+                    (sfx.Creature == TRSFXCreatureCategory.Lara && definition.Creature == TRSFXCreatureCategory.Human)
+                );
+            };
+        }
+        else
+        {
+            pred = sfx => sfx.Categories.Contains(definition.PrimaryCategory) && (sfx != definition || _persistentCategories.Contains(definition.PrimaryCategory));
+        }
+
+        List<TR1SFXDefinition> otherDefinitions = _soundEffects.FindAll(pred);
+        return otherDefinitions.Any()
+            ? otherDefinitions[_generator.Next(0, otherDefinitions.Count)]
+            : null;
     }
 
     private void RandomizeWibble(TR1RCombinedLevel level)

--- a/TRRandomizerCore/Randomizers/TR1/Remastered/TR1RAudioRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Remastered/TR1RAudioRandomizer.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System.Numerics;
 using TRGE.Core;
 using TRLevelControl;
 using TRLevelControl.Helpers;
@@ -91,14 +90,7 @@ public class TR1RAudioRandomizer : BaseTR1RRandomizer
         _audioRandomizer.ResetFloorMap();
         foreach (TR1Room room in level.Rooms.Where(r => !r.Flags.HasFlag(TRRoomFlag.Unused2)))
         {
-            _audioRandomizer.RandomizeFloorTracks(room.Sectors, level.FloorData, _generator, sectorIndex =>
-            {
-                return new Vector2
-                (
-                    TRConsts.Step2 + room.Info.X + sectorIndex / room.NumZSectors * TRConsts.Step4,
-                    TRConsts.Step2 + room.Info.Z + sectorIndex % room.NumZSectors * TRConsts.Step4
-                );
-            });
+            _audioRandomizer.RandomizeFloorTracks(room, level.FloorData);
         }
     }
 

--- a/TRRandomizerCore/Randomizers/TR1/Shared/TR1AudioAllocator.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Shared/TR1AudioAllocator.cs
@@ -1,0 +1,148 @@
+﻿using Newtonsoft.Json;
+using TRGE.Core;
+using TRLevelControl;
+using TRLevelControl.Helpers;
+using TRLevelControl.Model;
+using TRRandomizerCore.Levels;
+using TRRandomizerCore.SFX;
+
+namespace TRRandomizerCore.Randomizers;
+
+public class TR1AudioAllocator : AudioRandomizer
+{
+    private const int _defaultSecretTrack = 13;
+
+    private List<TR1SFXDefinition> _soundEffects;
+    private TR1SFXDefinition _psUziDefinition;
+    private List<TRSFXGeneralCategory> _sfxCategories, _persistentCategories;
+
+    public TR1AudioAllocator(IReadOnlyDictionary<TRAudioCategory, List<TRAudioTrack>> tracks)
+        : base(tracks) { }
+
+    public List<TR1SFXDefinition> GetDefinitions()
+        => _soundEffects;
+
+    public List<TRSFXGeneralCategory> GetCategories()
+        => _sfxCategories;
+
+    public bool IsPersistent(TRSFXGeneralCategory category)
+        => _persistentCategories.Contains(category);
+
+    public TR1SFXDefinition GetPSUziDefinition()
+        => _psUziDefinition;
+
+    public void Initialise(IEnumerable<string> levelNames, string backupPath)
+    {
+        ChooseUncontrolledLevels(new(levelNames), TR1LevelNames.ASSAULT);
+
+        _sfxCategories = GetSFXCategories(Settings);
+
+        // SFX in these categories can potentially remain as they are
+        _persistentCategories = new()
+        {
+            TRSFXGeneralCategory.StandardWeaponFiring,
+            TRSFXGeneralCategory.Ricochet,
+            TRSFXGeneralCategory.Flying,
+            TRSFXGeneralCategory.Explosion,
+        };
+
+        _soundEffects = JsonConvert.DeserializeObject<List<TR1SFXDefinition>>(File.ReadAllText(@"Resources\TR1\Audio\sfx.json"));
+
+        // We don't want to store all SFX WAV data in JSON, so instead we reference the source level
+        // and extract the details from there using the same format for model transport.
+        Dictionary<string, TR1Level> levels = new();
+        TR1LevelControl reader = new();
+        foreach (TR1SFXDefinition definition in _soundEffects)
+        {
+            if (!levels.ContainsKey(definition.SourceLevel))
+            {
+                levels[definition.SourceLevel] = reader.Read(Path.Combine(backupPath, definition.SourceLevel));
+            }
+
+            TR1Level level = levels[definition.SourceLevel];
+            definition.SoundEffect = level.SoundEffects[definition.InternalIndex];
+        }
+
+        // PS uzis need some manual setup. Make a copy of the standard uzi definition
+        // then replace the sound data from the external wav file.
+        TR1Level caves = levels[TR1LevelNames.CAVES];
+        _psUziDefinition = new TR1SFXDefinition
+        {
+            SoundEffect = caves.SoundEffects[TR1SFX.LaraUziFire]
+        };
+        _psUziDefinition.SoundEffect.Samples = new() { File.ReadAllBytes(@"Resources\TR1\Audio\ps_uzis.wav") };
+    }
+
+    public void RandomizeMusicTriggers(TR1Level level)
+    {
+        if (Settings.ChangeTriggerTracks)
+        {
+            RandomizeFloorTracks(level);
+        }
+
+        if (Settings.SeparateSecretTracks && !Settings.RandomizeSecrets)
+        {
+            RandomizeSecretTracks(level);
+        }
+    }
+
+    public void RandomizeFloorTracks(TR1Level level)
+    {
+        ResetFloorMap();
+        foreach (TR1Room room in level.Rooms.Where(r => !r.Flags.HasFlag(TRRoomFlag.Unused2)))
+        {
+            RandomizeFloorTracks(room, level.FloorData);
+        }
+    }
+
+    private void RandomizeSecretTracks(TR1Level level)
+    {
+        int numSecrets = level.FloorData.GetActionItems(FDTrigAction.SecretFound)
+            .Select(a => a.Parameter)
+            .Distinct().Count();
+        if (numSecrets == 0)
+        {
+            return;
+        }
+
+        List<TRAudioTrack> secretTracks = GetTracks(TRAudioCategory.Secret);
+
+        for (int i = 0; i < numSecrets; i++)
+        {
+            TRAudioTrack secretTrack = secretTracks[Generator.Next(0, secretTracks.Count)];
+            if (secretTrack.ID == _defaultSecretTrack)
+            {
+                continue;
+            }
+
+            FDActionItem musicAction = new()
+            {
+                Action = FDTrigAction.PlaySoundtrack,
+                Parameter = (short)secretTrack.ID
+            };
+
+            List<FDTriggerEntry> triggers = level.FloorData.GetSecretTriggers(i);
+            foreach (FDTriggerEntry trigger in triggers)
+            {
+                FDActionItem currentMusicAction = trigger.Actions.Find(a => a.Action == FDTrigAction.PlaySoundtrack);
+                if (currentMusicAction == null)
+                {
+                    trigger.Actions.Add(musicAction);
+                }
+            }
+        }
+    }
+
+    public void RandomizeWibble(TR1Level level)
+    {
+        if (Settings.RandomizeWibble)
+        {
+            // The engine does the actual randomization, we just tell it that every
+            // sound effect should be included.
+            foreach (var (_, effect) in level.SoundEffects)
+            {
+                effect.RandomizePitch = true;
+            }
+        }
+    }
+}

--- a/TRRandomizerCore/Randomizers/TR2/Classic/TR2AudioRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR2/Classic/TR2AudioRandomizer.cs
@@ -21,7 +21,7 @@ public class TR2AudioRandomizer : BaseTR2Randomizer
 
             allocator.RandomizeMusicTriggers(_levelInstance.Data);
             allocator.RandomizeSoundEffects(_levelInstance.Name, _levelInstance.Data);
-            allocator.RandomizePitch(_levelInstance.Data);
+            allocator.RandomizePitch(_levelInstance.Data.SoundEffects.Values);
 
             SaveLevelInstance();
             if (!TriggerProgress())

--- a/TRRandomizerCore/Randomizers/TR2/Classic/TR2AudioRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR2/Classic/TR2AudioRandomizer.cs
@@ -52,7 +52,7 @@ public class TR2AudioRandomizer : BaseTR2Randomizer
         ISet<TR2ScriptedLevel> exlusions = new HashSet<TR2ScriptedLevel> { assaultCourse };
 
         _uncontrolledLevels = Levels.RandomSelection(_generator, (int)Settings.UncontrolledSFXCount, exclusions: exlusions);
-        if (Settings.AssaultCourseWireframe)
+        if (Settings.UncontrolledSFXAssaultCourse)
         {
             _uncontrolledLevels.Add(assaultCourse);
         }

--- a/TRRandomizerCore/Randomizers/TR2/Classic/TR2AudioRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR2/Classic/TR2AudioRandomizer.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System.Numerics;
 using TRGE.Core;
 using TRLevelControl;
 using TRLevelControl.Helpers;
@@ -57,14 +56,7 @@ public class TR2AudioRandomizer : BaseTR2Randomizer
         _audioRandomizer.ResetFloorMap();
         foreach (TR2Room room in level.Rooms)
         {
-            _audioRandomizer.RandomizeFloorTracks(room.Sectors, level.FloorData, _generator, sectorIndex =>
-            {
-                return new Vector2
-                (
-                    TRConsts.Step2 + room.Info.X + sectorIndex / room.NumZSectors * TRConsts.Step4,
-                    TRConsts.Step2 + room.Info.Z + sectorIndex % room.NumZSectors * TRConsts.Step4
-                );
-            });
+            _audioRandomizer.RandomizeFloorTracks(room, level.FloorData);
         }
     }
 

--- a/TRRandomizerCore/Randomizers/TR2/Classic/TR2AudioRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR2/Classic/TR2AudioRandomizer.cs
@@ -1,10 +1,4 @@
-﻿using Newtonsoft.Json;
-using TRGE.Core;
-using TRLevelControl;
-using TRLevelControl.Helpers;
-using TRLevelControl.Model;
-using TRRandomizerCore.Levels;
-using TRRandomizerCore.SFX;
+﻿using TRGE.Core;
 
 namespace TRRandomizerCore.Randomizers;
 
@@ -12,224 +6,27 @@ public class TR2AudioRandomizer : BaseTR2Randomizer
 {
     private const int _numSamples = 408; // Number of entries in MAIN.SFX
 
-    private AudioRandomizer _audioRandomizer;
-
-    private List<TR2SFXDefinition> _soundEffects;
-    private List<TRSFXGeneralCategory> _sfxCategories;
-
     public override void Randomize(int seed)
     {
-        _generator = new(seed);
-        LoadAudioData();
+        TR2AudioAllocator allocator = new(ScriptEditor.AudioProvider.GetCategorisedTracks(), _numSamples)
+        {
+            Generator = new(seed),
+            Settings = Settings,
+        };
+        allocator.Initialise(Levels.Select(l => l.LevelFileBaseName), BackupPath);
 
         foreach (TR2ScriptedLevel lvl in Levels)
         {
             LoadLevelInstance(lvl);
 
-            RandomizeMusicTriggers(_levelInstance);
-            RandomizeSoundEffects(_levelInstance);
-            RandomizeWibble(_levelInstance);
+            allocator.RandomizeMusicTriggers(_levelInstance.Data);
+            allocator.RandomizeSoundEffects(_levelInstance.Name, _levelInstance.Data);
+            allocator.RandomizePitch(_levelInstance.Data);
 
             SaveLevelInstance();
             if (!TriggerProgress())
             {
                 break;
-            }
-        }
-    }
-
-    private void RandomizeMusicTriggers(TR2CombinedLevel level)
-    {
-        if (Settings.ChangeTriggerTracks)
-        {
-            RandomizeFloorTracks(level.Data);
-        }
-
-        if (Settings.SeparateSecretTracks)
-        {
-            RandomizeSecretTracks(level.Data);
-        }
-    }
-
-    private void RandomizeFloorTracks(TR2Level level)
-    {
-        _audioRandomizer.ResetFloorMap();
-        foreach (TR2Room room in level.Rooms)
-        {
-            _audioRandomizer.RandomizeFloorTracks(room, level.FloorData);
-        }
-    }
-
-    private void RandomizeSecretTracks(TR2Level level)
-    {
-        List<TRAudioTrack> secretTracks = _audioRandomizer.GetTracks(TRAudioCategory.Secret);
-        Dictionary<int, TR2Entity> secrets = GetSecretItems(level);
-        foreach (int entityIndex in secrets.Keys)
-        {
-            TR2Entity secret = secrets[entityIndex];
-            TRRoomSector sector = level.GetRoomSector(secret);
-            if (sector.FDIndex == 0)
-            {
-                level.FloorData.CreateFloorData(sector);
-            }
-
-            List<FDEntry> entries = level.FloorData[sector.FDIndex];
-            FDTriggerEntry existingTriggerEntry = entries.Find(e => e is FDTriggerEntry) as FDTriggerEntry;
-            bool existingEntityPickup = false;
-            if (existingTriggerEntry != null)
-            {
-                if (existingTriggerEntry.TrigType == FDTrigType.Pickup && existingTriggerEntry.Actions[0].Parameter == entityIndex)
-                {
-                    // GW gold secret (default location) already has a pickup trigger to spawn the
-                    // TRex (or whatever enemy) so we'll just append to that item list here
-                    existingEntityPickup = true;
-                }
-                else
-                {
-                    // There is already a non-pickup trigger for this sector so while nothing is wrong with
-                    // adding a pickup trigger, the game ignores it. So in this instance, the sound that
-                    // plays will just be whatever is set in the script.
-                    continue;
-                }
-            }
-
-            FDActionItem musicAction = new()
-            {
-                Action = FDTrigAction.PlaySoundtrack,
-                Parameter = (short)secretTracks[_generator.Next(0, secretTracks.Count)].ID
-            };
-
-            if (existingEntityPickup)
-            {
-                existingTriggerEntry.Actions.Add(musicAction);
-            }
-            else
-            {
-                entries.Add(new FDTriggerEntry
-                {
-                    TrigType = FDTrigType.Pickup,
-                    Actions = new()
-                    {
-                        new() { Parameter = (short)entityIndex },
-                        musicAction
-                    }
-                });
-            }
-        }
-    }
-
-    private static Dictionary<int, TR2Entity> GetSecretItems(TR2Level level)
-    {
-        Dictionary<int, TR2Entity> entities = new();
-        for (int i = 0; i < level.Entities.Count; i++)
-        {
-            if (TR2TypeUtilities.IsSecretType(level.Entities[i].TypeID))
-            {
-                entities[i] = level.Entities[i];
-            }
-        }
-
-        return entities;
-    }
-
-    private void LoadAudioData()
-    {
-        _audioRandomizer = new(ScriptEditor.AudioProvider.GetCategorisedTracks())
-        {
-            Generator = _generator,
-            Settings = Settings,
-        };
-        _audioRandomizer.ChooseUncontrolledLevels(new(Levels.Select(l => l.LevelFileBaseName)), TR2LevelNames.ASSAULT);
-
-        _sfxCategories = AudioRandomizer.GetSFXCategories(Settings);
-        if (_sfxCategories.Count > 0)
-        {
-            _soundEffects = JsonConvert.DeserializeObject<List<TR2SFXDefinition>>(ReadResource(@"TR2\Audio\sfx.json"));
-
-            Dictionary<string, TR2Level> levels = new();
-            TR2LevelControl reader = new();
-            foreach (TR2SFXDefinition definition in _soundEffects)
-            {
-                if (!levels.ContainsKey(definition.SourceLevel))
-                {
-                    levels[definition.SourceLevel] = reader.Read(Path.Combine(BackupPath, definition.SourceLevel));
-                }
-
-                TR2Level level = levels[definition.SourceLevel];
-                definition.SoundEffect = level.SoundEffects[definition.InternalIndex];
-            }
-        }
-    }
-
-    private void RandomizeSoundEffects(TR2CombinedLevel level)
-    {
-        if (_sfxCategories.Count == 0)
-        {
-            return;
-        }
-
-        if (_audioRandomizer.IsUncontrolledLevel(level.Name))
-        {
-            // Choose a random but unique pointer into MAIN.SFX for each sample.
-            HashSet<uint> indices = new();
-            foreach (TR2SoundEffect effect in level.Data.SoundEffects.Values)
-            {
-                do
-                {
-                    effect.SampleID = (uint)_generator.Next(0, _numSamples + 1 - Math.Max(effect.SampleCount, 1));
-                }
-                while (!indices.Add(effect.SampleID));
-            }
-        }
-        else
-        {
-            foreach (TR2SFX internalIndex in Enum.GetValues<TR2SFX>())
-            {
-                TR2SFXDefinition definition = _soundEffects.Find(sfx => sfx.InternalIndex == internalIndex);
-                if (!level.Data.SoundEffects.ContainsKey(internalIndex) || definition == null
-                    || definition.Creature == TRSFXCreatureCategory.Lara || !_sfxCategories.Contains(definition.PrimaryCategory))
-                {
-                    continue;
-                }
-
-                Predicate<TR2SFXDefinition> pred;
-                if (Settings.LinkCreatureSFX && definition.Creature > TRSFXCreatureCategory.Lara)
-                {
-                    pred = sfx =>
-                    {
-                        return sfx.Categories.Contains(definition.PrimaryCategory) &&
-                        sfx != definition &&
-                        (
-                            sfx.Creature == definition.Creature ||
-                            (sfx.Creature == TRSFXCreatureCategory.Lara && definition.Creature == TRSFXCreatureCategory.Human)
-                        );
-                    };
-                }
-                else
-                {
-                    pred = sfx => sfx.Categories.Contains(definition.PrimaryCategory) && sfx != definition;
-                }
-
-                List<TR2SFXDefinition> otherDefinitions = _soundEffects.FindAll(pred);
-                if (otherDefinitions.Count > 0)
-                {
-                    TR2SFXDefinition nextDefinition = otherDefinitions[_generator.Next(0, otherDefinitions.Count)];
-                    if (nextDefinition != definition)
-                    {
-                        level.Data.SoundEffects[internalIndex] = nextDefinition.SoundEffect;
-                    }
-                }
-            }
-        }
-    }
-
-    private void RandomizeWibble(TR2CombinedLevel level)
-    {
-        if (Settings.RandomizeWibble)
-        {
-            foreach (var (_, effect) in level.Data.SoundEffects)
-            {
-                effect.RandomizePitch = true;
             }
         }
     }

--- a/TRRandomizerCore/Randomizers/TR2/Remastered/TR2RAudioRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR2/Remastered/TR2RAudioRandomizer.cs
@@ -1,10 +1,4 @@
-﻿using Newtonsoft.Json;
-using TRGE.Core;
-using TRLevelControl;
-using TRLevelControl.Helpers;
-using TRLevelControl.Model;
-using TRRandomizerCore.Levels;
-using TRRandomizerCore.SFX;
+﻿using TRGE.Core;
 
 namespace TRRandomizerCore.Randomizers;
 
@@ -12,218 +6,27 @@ public class TR2RAudioRandomizer : BaseTR2RRandomizer
 {
     private const int _numSamples = 412;
 
-    private AudioRandomizer _audioRandomizer;
-
-    private List<TR2SFXDefinition> _soundEffects;
-    private List<TRSFXGeneralCategory> _sfxCategories;
-
     public override void Randomize(int seed)
     {
-        _generator = new(seed);
-        LoadAudioData();
+        TR2AudioAllocator allocator = new(ScriptEditor.AudioProvider.GetCategorisedTracks(), _numSamples)
+        {
+            Generator = new(seed),
+            Settings = Settings,
+        };
+        allocator.Initialise(Levels.Select(l => l.LevelFileBaseName), BackupPath);
 
         foreach (TRRScriptedLevel lvl in Levels)
         {
             LoadLevelInstance(lvl);
 
-            RandomizeMusicTriggers(_levelInstance);
-            RandomizeSoundEffects(_levelInstance);
-            RandomizeWibble(_levelInstance);
+            allocator.RandomizeMusicTriggers(_levelInstance.Data);
+            allocator.RandomizeSoundEffects(_levelInstance.Name, _levelInstance.Data);
+            allocator.RandomizePitch(_levelInstance.Data);
 
             SaveLevelInstance();
             if (!TriggerProgress())
             {
                 break;
-            }
-        }
-    }
-
-    private void RandomizeMusicTriggers(TR2RCombinedLevel level)
-    {
-        if (Settings.ChangeTriggerTracks)
-        {
-            RandomizeFloorTracks(level.Data);
-        }
-
-        if (Settings.SeparateSecretTracks)
-        {
-            RandomizeSecretTracks(level.Data);
-        }
-    }
-
-    private void RandomizeFloorTracks(TR2Level level)
-    {
-        _audioRandomizer.ResetFloorMap();
-        foreach (TR2Room room in level.Rooms)
-        {
-            _audioRandomizer.RandomizeFloorTracks(room, level.FloorData);
-        }
-    }
-
-    private void RandomizeSecretTracks(TR2Level level)
-    {
-        List<TRAudioTrack> secretTracks = _audioRandomizer.GetTracks(TRAudioCategory.Secret);
-        Dictionary<int, TR2Entity> secrets = GetSecretItems(level);
-        foreach (int entityIndex in secrets.Keys)
-        {
-            TR2Entity secret = secrets[entityIndex];
-            TRRoomSector sector = level.GetRoomSector(secret);
-            if (sector.FDIndex == 0)
-            {
-                level.FloorData.CreateFloorData(sector);
-            }
-
-            List<FDEntry> entries = level.FloorData[sector.FDIndex];
-            FDTriggerEntry existingTriggerEntry = entries.Find(e => e is FDTriggerEntry) as FDTriggerEntry;
-            bool existingEntityPickup = false;
-            if (existingTriggerEntry != null)
-            {
-                if (existingTriggerEntry.TrigType == FDTrigType.Pickup && existingTriggerEntry.Actions[0].Parameter == entityIndex)
-                {
-                    existingEntityPickup = true;
-                }
-                else
-                {
-                    continue;
-                }
-            }
-
-            FDActionItem musicAction = new()
-            {
-                Action = FDTrigAction.PlaySoundtrack,
-                Parameter = (short)secretTracks[_generator.Next(0, secretTracks.Count)].ID
-            };
-
-            if (existingEntityPickup)
-            {
-                existingTriggerEntry.Actions.Add(musicAction);
-            }
-            else
-            {
-                entries.Add(new FDTriggerEntry
-                {
-                    TrigType = FDTrigType.Pickup,
-                    Actions = new()
-                    {
-                        new() { Parameter = (short)entityIndex },
-                        musicAction
-                    }
-                });
-            }
-        }
-    }
-
-    private static Dictionary<int, TR2Entity> GetSecretItems(TR2Level level)
-    {
-        Dictionary<int, TR2Entity> entities = new();
-        for (int i = 0; i < level.Entities.Count; i++)
-        {
-            if (TR2TypeUtilities.IsSecretType(level.Entities[i].TypeID))
-            {
-                entities[i] = level.Entities[i];
-            }
-        }
-
-        return entities;
-    }
-
-    private void LoadAudioData()
-    {
-        _audioRandomizer = new(ScriptEditor.AudioProvider.GetCategorisedTracks())
-        {
-            Generator = _generator,
-            Settings = Settings,
-        };
-        _audioRandomizer.ChooseUncontrolledLevels(new(Levels.Select(l => l.LevelFileBaseName)), TR2LevelNames.ASSAULT);
-
-        _sfxCategories = AudioRandomizer.GetSFXCategories(Settings);
-        if (_sfxCategories.Count > 0)
-        {
-            _soundEffects = JsonConvert.DeserializeObject<List<TR2SFXDefinition>>(ReadResource(@"TR2\Audio\sfx.json"));
-
-            Dictionary<string, TR2Level> levels = new();
-            TR2LevelControl reader = new();
-            foreach (TR2SFXDefinition definition in _soundEffects)
-            {
-                if (!levels.ContainsKey(definition.SourceLevel))
-                {
-                    levels[definition.SourceLevel] = reader.Read(Path.Combine(BackupPath, definition.SourceLevel));
-                }
-
-                TR2Level level = levels[definition.SourceLevel];
-                definition.SoundEffect = level.SoundEffects[definition.InternalIndex];
-            }
-        }
-    }
-
-    private void RandomizeSoundEffects(TR2RCombinedLevel level)
-    {
-        if (_sfxCategories.Count == 0)
-        {
-            return;
-        }
-
-        if (_audioRandomizer.IsUncontrolledLevel(level.Name))
-        {
-            HashSet<uint> indices = new();
-            foreach (TR2SoundEffect effect in level.Data.SoundEffects.Values)
-            {
-                do
-                {
-                    effect.SampleID = (uint)_generator.Next(0, _numSamples + 1 - Math.Max(effect.SampleCount, 1));
-                }
-                while (!indices.Add(effect.SampleID));
-            }
-        }
-        else
-        {
-            foreach (TR2SFX internalIndex in Enum.GetValues<TR2SFX>())
-            {
-                TR2SFXDefinition definition = _soundEffects.Find(sfx => sfx.InternalIndex == internalIndex);
-                if (!level.Data.SoundEffects.ContainsKey(internalIndex) || definition == null
-                    || definition.Creature == TRSFXCreatureCategory.Lara || !_sfxCategories.Contains(definition.PrimaryCategory))
-                {
-                    continue;
-                }
-
-                Predicate<TR2SFXDefinition> pred;
-                if (Settings.LinkCreatureSFX && definition.Creature > TRSFXCreatureCategory.Lara)
-                {
-                    pred = sfx =>
-                    {
-                        return sfx.Categories.Contains(definition.PrimaryCategory) &&
-                        sfx != definition &&
-                        (
-                            sfx.Creature == definition.Creature ||
-                            (sfx.Creature == TRSFXCreatureCategory.Lara && definition.Creature == TRSFXCreatureCategory.Human)
-                        );
-                    };
-                }
-                else
-                {
-                    pred = sfx => sfx.Categories.Contains(definition.PrimaryCategory) && sfx != definition;
-                }
-
-                List<TR2SFXDefinition> otherDefinitions = _soundEffects.FindAll(pred);
-                if (otherDefinitions.Count > 0)
-                {
-                    TR2SFXDefinition nextDefinition = otherDefinitions[_generator.Next(0, otherDefinitions.Count)];
-                    if (nextDefinition != definition)
-                    {
-                        level.Data.SoundEffects[internalIndex] = nextDefinition.SoundEffect;
-                    }
-                }
-            }
-        }
-    }
-
-    private void RandomizeWibble(TR2RCombinedLevel level)
-    {
-        if (Settings.RandomizeWibble)
-        {
-            foreach (var (_, effect) in level.Data.SoundEffects)
-            {
-                effect.RandomizePitch = true;
             }
         }
     }

--- a/TRRandomizerCore/Randomizers/TR2/Remastered/TR2RAudioRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR2/Remastered/TR2RAudioRandomizer.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System.Numerics;
 using TRGE.Core;
 using TRLevelControl;
 using TRLevelControl.Helpers;
@@ -57,14 +56,7 @@ public class TR2RAudioRandomizer : BaseTR2RRandomizer
         _audioRandomizer.ResetFloorMap();
         foreach (TR2Room room in level.Rooms)
         {
-            _audioRandomizer.RandomizeFloorTracks(room.Sectors, level.FloorData, _generator, sectorIndex =>
-            {
-                return new Vector2
-                (
-                    TRConsts.Step2 + room.Info.X + sectorIndex / room.NumZSectors * TRConsts.Step4,
-                    TRConsts.Step2 + room.Info.Z + sectorIndex % room.NumZSectors * TRConsts.Step4
-                );
-            });
+            _audioRandomizer.RandomizeFloorTracks(room, level.FloorData);
         }
     }
 

--- a/TRRandomizerCore/Randomizers/TR2/Remastered/TR2RAudioRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR2/Remastered/TR2RAudioRandomizer.cs
@@ -49,7 +49,7 @@ public class TR2RAudioRandomizer : BaseTR2RRandomizer
         HashSet<TRRScriptedLevel> exlusions = new() { assaultCourse };
 
         _uncontrolledLevels = Levels.RandomSelection(_generator, (int)Settings.UncontrolledSFXCount, exclusions: exlusions);
-        if (Settings.AssaultCourseWireframe)
+        if (Settings.UncontrolledSFXAssaultCourse)
         {
             _uncontrolledLevels.Add(assaultCourse);
         }

--- a/TRRandomizerCore/Randomizers/TR2/Remastered/TR2RAudioRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR2/Remastered/TR2RAudioRandomizer.cs
@@ -21,7 +21,7 @@ public class TR2RAudioRandomizer : BaseTR2RRandomizer
 
             allocator.RandomizeMusicTriggers(_levelInstance.Data);
             allocator.RandomizeSoundEffects(_levelInstance.Name, _levelInstance.Data);
-            allocator.RandomizePitch(_levelInstance.Data);
+            allocator.RandomizePitch(_levelInstance.Data.SoundEffects.Values);
 
             SaveLevelInstance();
             if (!TriggerProgress())

--- a/TRRandomizerCore/Randomizers/TR2/Shared/TR2AudioAllocator.cs
+++ b/TRRandomizerCore/Randomizers/TR2/Shared/TR2AudioAllocator.cs
@@ -1,0 +1,213 @@
+﻿using Newtonsoft.Json;
+using TRGE.Core;
+using TRLevelControl;
+using TRLevelControl.Helpers;
+using TRLevelControl.Model;
+using TRRandomizerCore.SFX;
+
+namespace TRRandomizerCore.Randomizers;
+
+public class TR2AudioAllocator : AudioRandomizer
+{
+    private readonly int _numSamples;
+
+    private List<TR2SFXDefinition> _soundEffects;
+    private List<TRSFXGeneralCategory> _sfxCategories;
+
+    public TR2AudioAllocator(IReadOnlyDictionary<TRAudioCategory, List<TRAudioTrack>> tracks, int numSamples)
+        : base(tracks)
+    {
+        _numSamples = numSamples;
+    }
+
+    public void Initialise(IEnumerable<string> levelNames, string backupPath)
+    {
+        ChooseUncontrolledLevels(new(levelNames), TR2LevelNames.ASSAULT);
+
+        _sfxCategories = GetSFXCategories(Settings);
+        if (_sfxCategories.Count > 0)
+        {
+            _soundEffects = JsonConvert.DeserializeObject<List<TR2SFXDefinition>>(File.ReadAllText(@"Resources\TR2\Audio\sfx.json"));
+
+            Dictionary<string, TR2Level> levels = new();
+            TR2LevelControl reader = new();
+            foreach (TR2SFXDefinition definition in _soundEffects)
+            {
+                if (!levels.ContainsKey(definition.SourceLevel))
+                {
+                    levels[definition.SourceLevel] = reader.Read(Path.Combine(backupPath, definition.SourceLevel));
+                }
+
+                TR2Level level = levels[definition.SourceLevel];
+                definition.SoundEffect = level.SoundEffects[definition.InternalIndex];
+            }
+        }
+    }
+
+    public void RandomizeMusicTriggers(TR2Level level)
+    {
+        if (Settings.ChangeTriggerTracks)
+        {
+            RandomizeFloorTracks(level);
+        }
+
+        if (Settings.SeparateSecretTracks)
+        {
+            RandomizeSecretTracks(level);
+        }
+    }
+
+    private void RandomizeFloorTracks(TR2Level level)
+    {
+        ResetFloorMap();
+        foreach (TR2Room room in level.Rooms)
+        {
+            RandomizeFloorTracks(room, level.FloorData);
+        }
+    }
+
+    public void RandomizeSecretTracks(TR2Level level)
+    {
+        List<TRAudioTrack> secretTracks = GetTracks(TRAudioCategory.Secret);
+        Dictionary<int, TR2Entity> secrets = GetSecretItems(level);
+        foreach (int entityIndex in secrets.Keys)
+        {
+            TR2Entity secret = secrets[entityIndex];
+            TRRoomSector sector = level.GetRoomSector(secret);
+            if (sector.FDIndex == 0)
+            {
+                level.FloorData.CreateFloorData(sector);
+            }
+
+            List<FDEntry> entries = level.FloorData[sector.FDIndex];
+            FDTriggerEntry existingTriggerEntry = entries.Find(e => e is FDTriggerEntry) as FDTriggerEntry;
+            bool existingEntityPickup = false;
+            if (existingTriggerEntry != null)
+            {
+                if (existingTriggerEntry.TrigType == FDTrigType.Pickup && existingTriggerEntry.Actions[0].Parameter == entityIndex)
+                {
+                    // GW gold secret (default location) already has a pickup trigger to spawn the
+                    // TRex (or whatever enemy) so we'll just append to that item list here
+                    existingEntityPickup = true;
+                }
+                else
+                {
+                    // There is already a non-pickup trigger for this sector so while nothing is wrong with
+                    // adding a pickup trigger, the game ignores it. So in this instance, the sound that
+                    // plays will just be whatever is set in the script.
+                    continue;
+                }
+            }
+
+            FDActionItem musicAction = new()
+            {
+                Action = FDTrigAction.PlaySoundtrack,
+                Parameter = (short)secretTracks[Generator.Next(0, secretTracks.Count)].ID
+            };
+
+            if (existingEntityPickup)
+            {
+                existingTriggerEntry.Actions.Add(musicAction);
+            }
+            else
+            {
+                entries.Add(new FDTriggerEntry
+                {
+                    TrigType = FDTrigType.Pickup,
+                    Actions = new()
+                    {
+                        new() { Parameter = (short)entityIndex },
+                        musicAction
+                    }
+                });
+            }
+        }
+    }
+
+    private static Dictionary<int, TR2Entity> GetSecretItems(TR2Level level)
+    {
+        Dictionary<int, TR2Entity> entities = new();
+        for (int i = 0; i < level.Entities.Count; i++)
+        {
+            if (TR2TypeUtilities.IsSecretType(level.Entities[i].TypeID))
+            {
+                entities[i] = level.Entities[i];
+            }
+        }
+
+        return entities;
+    }
+
+    public void RandomizeSoundEffects(string levelName, TR2Level level)
+    {
+        if (_sfxCategories.Count == 0)
+        {
+            return;
+        }
+
+        if (IsUncontrolledLevel(levelName))
+        {
+            // Choose a random but unique pointer into MAIN.SFX for each sample.
+            HashSet<uint> indices = new();
+            foreach (TR2SoundEffect effect in level.SoundEffects.Values)
+            {
+                do
+                {
+                    effect.SampleID = (uint)Generator.Next(0, _numSamples + 1 - Math.Max(effect.SampleCount, 1));
+                }
+                while (!indices.Add(effect.SampleID));
+            }
+        }
+        else
+        {
+            foreach (TR2SFX internalIndex in Enum.GetValues<TR2SFX>())
+            {
+                TR2SFXDefinition definition = _soundEffects.Find(sfx => sfx.InternalIndex == internalIndex);
+                if (!level.SoundEffects.ContainsKey(internalIndex) || definition == null
+                    || definition.Creature == TRSFXCreatureCategory.Lara || !_sfxCategories.Contains(definition.PrimaryCategory))
+                {
+                    continue;
+                }
+
+                Predicate<TR2SFXDefinition> pred;
+                if (Settings.LinkCreatureSFX && definition.Creature > TRSFXCreatureCategory.Lara)
+                {
+                    pred = sfx =>
+                    {
+                        return sfx.Categories.Contains(definition.PrimaryCategory) &&
+                        sfx != definition &&
+                        (
+                            sfx.Creature == definition.Creature ||
+                            (sfx.Creature == TRSFXCreatureCategory.Lara && definition.Creature == TRSFXCreatureCategory.Human)
+                        );
+                    };
+                }
+                else
+                {
+                    pred = sfx => sfx.Categories.Contains(definition.PrimaryCategory) && sfx != definition;
+                }
+
+                List<TR2SFXDefinition> otherDefinitions = _soundEffects.FindAll(pred);
+                if (otherDefinitions.Count > 0)
+                {
+                    TR2SFXDefinition nextDefinition = otherDefinitions[Generator.Next(0, otherDefinitions.Count)];
+                    if (nextDefinition != definition)
+                    {
+                        level.SoundEffects[internalIndex] = nextDefinition.SoundEffect;
+                    }
+                }
+            }
+        }
+    }
+
+    public void RandomizePitch(TR2Level level)
+    {
+        if (Settings.RandomizeWibble)
+        {
+            foreach (var (_, effect) in level.SoundEffects)
+            {
+                effect.RandomizePitch = true;
+            }
+        }
+    }
+}

--- a/TRRandomizerCore/Randomizers/TR3/Classic/TR3AudioRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Classic/TR3AudioRandomizer.cs
@@ -4,7 +4,6 @@ using TRGE.Core;
 using TRLevelControl;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;
-using TRRandomizerCore.Helpers;
 using TRRandomizerCore.Levels;
 using TRRandomizerCore.SFX;
 
@@ -20,49 +19,26 @@ public class TR3AudioRandomizer : BaseTR3Randomizer
 
     private List<TR3SFXDefinition> _soundEffects;
     private List<TRSFXGeneralCategory> _sfxCategories;
-    private List<TR3ScriptedLevel> _uncontrolledLevels;
 
     public override void Randomize(int seed)
     {
-        _generator = new Random(seed);
-
+        _generator = new(seed);
         LoadAudioData();
-        ChooseUncontrolledLevels();
 
         foreach (TR3ScriptedLevel lvl in Levels)
         {
             LoadLevelInstance(lvl);
 
             RandomizeMusicTriggers(_levelInstance);
-
             RandomizeSoundEffects(_levelInstance);
-
             RandomizeWibble(_levelInstance);
 
             SaveLevelInstance();
-
             if (!TriggerProgress())
             {
                 break;
             }
         }
-    }
-
-    private void ChooseUncontrolledLevels()
-    {
-        TR3ScriptedLevel assaultCourse = Levels.Find(l => l.Is(TR3LevelNames.ASSAULT));
-        ISet<TR3ScriptedLevel> exlusions = new HashSet<TR3ScriptedLevel> { assaultCourse };
-
-        _uncontrolledLevels = Levels.RandomSelection(_generator, (int)Settings.UncontrolledSFXCount, exclusions: exlusions);
-        if (Settings.UncontrolledSFXAssaultCourse)
-        {
-            _uncontrolledLevels.Add(assaultCourse);
-        }
-    }
-
-    public bool IsUncontrolledLevel(TR3ScriptedLevel level)
-    {
-        return _uncontrolledLevels.Contains(level);
     }
 
     private void RandomizeMusicTriggers(TR3CombinedLevel level)
@@ -142,7 +118,12 @@ public class TR3AudioRandomizer : BaseTR3Randomizer
     private void LoadAudioData()
     {
         // Get the track data from audio_tracks.json. Loaded from TRGE as it sets the ambient tracks initially.
-        _audioRandomizer = new AudioRandomizer(ScriptEditor.AudioProvider.GetCategorisedTracks());
+        _audioRandomizer = new(ScriptEditor.AudioProvider.GetCategorisedTracks())
+        {
+            Generator = _generator,
+            Settings = Settings,
+        };
+        _audioRandomizer.ChooseUncontrolledLevels(new(Levels.Select(l => l.LevelFileBaseName)), TR3LevelNames.ASSAULT);
 
         // Decide which sound effect categories we want to randomize.
         _sfxCategories = AudioRandomizer.GetSFXCategories(Settings);
@@ -175,7 +156,7 @@ public class TR3AudioRandomizer : BaseTR3Randomizer
             return;
         }
 
-        if (IsUncontrolledLevel(level.Script))
+        if (_audioRandomizer.IsUncontrolledLevel(level.Name))
         {
             // Choose a random but unique pointer into MAIN.SFX for each sample.
             HashSet<uint> indices = new();

--- a/TRRandomizerCore/Randomizers/TR3/Classic/TR3AudioRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Classic/TR3AudioRandomizer.cs
@@ -1,204 +1,30 @@
-﻿using Newtonsoft.Json;
-using TRGE.Core;
-using TRLevelControl;
-using TRLevelControl.Helpers;
-using TRLevelControl.Model;
-using TRRandomizerCore.Levels;
-using TRRandomizerCore.SFX;
+﻿using TRGE.Core;
 
 namespace TRRandomizerCore.Randomizers;
 
 public class TR3AudioRandomizer : BaseTR3Randomizer
 {
-    private const int _defaultSecretTrack = 122;
-    private const int _numSamples = 414;
-
-    private AudioRandomizer _audioRandomizer;
-    private TRAudioTrack _fixedSecretTrack;
-
-    private List<TR3SFXDefinition> _soundEffects;
-    private List<TRSFXGeneralCategory> _sfxCategories;
-
     public override void Randomize(int seed)
     {
-        _generator = new(seed);
-        LoadAudioData();
+        TR3AudioAllocator allocator = new(ScriptEditor.AudioProvider.GetCategorisedTracks())
+        {
+            Generator = new(seed),
+            Settings = Settings,
+        };
+        allocator.Initialise(Levels.Select(l => l.LevelFileBaseName), BackupPath);
 
         foreach (TR3ScriptedLevel lvl in Levels)
         {
             LoadLevelInstance(lvl);
 
-            RandomizeMusicTriggers(_levelInstance);
-            RandomizeSoundEffects(_levelInstance);
-            RandomizeWibble(_levelInstance);
+            allocator.RandomizeMusicTriggers(_levelInstance.Data);
+            allocator.RandomizeSoundEffects(_levelInstance.Name, _levelInstance.Data);
+            allocator.RandomizePitch(_levelInstance.Data);
 
             SaveLevelInstance();
             if (!TriggerProgress())
             {
                 break;
-            }
-        }
-    }
-
-    private void RandomizeMusicTriggers(TR3CombinedLevel level)
-    {
-        if (Settings.ChangeTriggerTracks)
-        {
-            RandomizeFloorTracks(level.Data);
-        }
-
-        // The secret sound is hardcoded in TR3 to track 122. The workaround for this is to 
-        // always set the secret sound on the corresponding triggers regardless of whether
-        // or not secret rando is enabled.
-        RandomizeSecretTracks(level);
-    }
-
-    private void RandomizeFloorTracks(TR3Level level)
-    {
-        _audioRandomizer.ResetFloorMap();
-        foreach (TR3Room room in level.Rooms)
-        {
-            _audioRandomizer.RandomizeFloorTracks(room, level.FloorData);
-        }
-    }
-
-    private void RandomizeSecretTracks(TR3CombinedLevel level)
-    {
-        if (level.Script.NumSecrets == 0)
-        {
-            return;
-        }
-
-        List<TRAudioTrack> secretTracks = _audioRandomizer.GetTracks(TRAudioCategory.Secret);
-
-        if (!Settings.SeparateSecretTracks && _fixedSecretTrack == null)
-        {
-            _fixedSecretTrack = secretTracks[_generator.Next(0, secretTracks.Count)];
-        }
-
-        for (int i = 0; i < level.Script.NumSecrets; i++)
-        {
-            TRAudioTrack secretTrack = _fixedSecretTrack ?? secretTracks[_generator.Next(0, secretTracks.Count)];
-            if (secretTrack.ID == _defaultSecretTrack)
-            {
-                continue;
-            }
-
-            FDActionItem musicAction = new()
-            {
-                Action = FDTrigAction.PlaySoundtrack,
-                Parameter = (short)secretTrack.ID
-            };
-
-            List<FDTriggerEntry> triggers = level.Data.FloorData.GetSecretTriggers(i);
-            foreach (FDTriggerEntry trigger in triggers)
-            {
-                FDActionItem currentMusicAction = trigger.Actions.Find(a => a.Action == FDTrigAction.PlaySoundtrack);
-                if (currentMusicAction == null)
-                {
-                    trigger.Actions.Add(musicAction);
-                }
-            }
-        }
-    }
-
-    private void LoadAudioData()
-    {
-        _audioRandomizer = new(ScriptEditor.AudioProvider.GetCategorisedTracks())
-        {
-            Generator = _generator,
-            Settings = Settings,
-        };
-        _audioRandomizer.ChooseUncontrolledLevels(new(Levels.Select(l => l.LevelFileBaseName)), TR3LevelNames.ASSAULT);
-
-        _sfxCategories = AudioRandomizer.GetSFXCategories(Settings);
-        if (_sfxCategories.Count > 0)
-        {
-            _soundEffects = JsonConvert.DeserializeObject<List<TR3SFXDefinition>>(ReadResource(@"TR3\Audio\sfx.json"));
-
-            Dictionary<string, TR3Level> levels = new();
-            TR3LevelControl reader = new();
-            foreach (TR3SFXDefinition definition in _soundEffects)
-            {
-                if (!levels.ContainsKey(definition.SourceLevel))
-                {
-                    levels[definition.SourceLevel] = reader.Read(Path.Combine(BackupPath, definition.SourceLevel));
-                }
-
-                TR3Level level = levels[definition.SourceLevel];
-                definition.SoundEffect = level.SoundEffects[definition.InternalIndex];
-            }
-        }
-    }
-
-    private void RandomizeSoundEffects(TR3CombinedLevel level)
-    {
-        if (_sfxCategories.Count == 0)
-        {
-            return;
-        }
-
-        if (_audioRandomizer.IsUncontrolledLevel(level.Name))
-        {
-            HashSet<uint> indices = new();
-            foreach (TR3SoundEffect effect in level.Data.SoundEffects.Values)
-            {
-                do
-                {
-                    effect.SampleID = (uint)_generator.Next(0, _numSamples + 1 - Math.Max(effect.SampleCount, 1));
-                }
-                while (!indices.Add(effect.SampleID));
-            }
-        }
-        else
-        {
-            foreach (TR3SFX internalIndex in Enum.GetValues<TR3SFX>())
-            {
-                TR3SFXDefinition definition = _soundEffects.Find(sfx => sfx.InternalIndex == internalIndex);
-                if (!level.Data.SoundEffects.ContainsKey(internalIndex) || definition == null
-                    || definition.Creature == TRSFXCreatureCategory.Lara || !_sfxCategories.Contains(definition.PrimaryCategory))
-                {
-                    continue;
-                }
-
-                Predicate<TR3SFXDefinition> pred;
-                if (Settings.LinkCreatureSFX && definition.Creature > TRSFXCreatureCategory.Lara)
-                {
-                    pred = sfx =>
-                    {
-                        return sfx.Categories.Contains(definition.PrimaryCategory) &&
-                        sfx != definition &&
-                        (
-                            sfx.Creature == definition.Creature ||
-                            (sfx.Creature == TRSFXCreatureCategory.Lara && definition.Creature == TRSFXCreatureCategory.Human)
-                        );
-                    };
-                }
-                else
-                {
-                    pred = sfx => sfx.Categories.Contains(definition.PrimaryCategory) && sfx != definition;
-                }
-
-                List<TR3SFXDefinition> otherDefinitions = _soundEffects.FindAll(pred);
-                if (otherDefinitions.Count > 0)
-                {
-                    TR3SFXDefinition nextDefinition = otherDefinitions[_generator.Next(0, otherDefinitions.Count)];
-                    if (nextDefinition != definition)
-                    {
-                        level.Data.SoundEffects[internalIndex] = nextDefinition.SoundEffect;
-                    }
-                }
-            }
-        }
-    }
-
-    private void RandomizeWibble(TR3CombinedLevel level)
-    {
-        if (Settings.RandomizeWibble)
-        {
-            foreach (var (_, effect) in level.Data.SoundEffects)
-            {
-                effect.RandomizePitch = true;
             }
         }
     }

--- a/TRRandomizerCore/Randomizers/TR3/Classic/TR3AudioRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Classic/TR3AudioRandomizer.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System.Numerics;
 using TRGE.Core;
 using TRLevelControl;
 using TRLevelControl.Helpers;
@@ -59,14 +58,7 @@ public class TR3AudioRandomizer : BaseTR3Randomizer
         _audioRandomizer.ResetFloorMap();
         foreach (TR3Room room in level.Rooms)
         {
-            _audioRandomizer.RandomizeFloorTracks(room.Sectors, level.FloorData, _generator, sectorIndex =>
-            {
-                return new Vector2
-                (
-                    TRConsts.Step2 + room.Info.X + sectorIndex / room.NumZSectors * TRConsts.Step4,
-                    TRConsts.Step2 + room.Info.Z + sectorIndex % room.NumZSectors * TRConsts.Step4
-                );
-            });
+            _audioRandomizer.RandomizeFloorTracks(room, level.FloorData);
         }
     }
 

--- a/TRRandomizerCore/Randomizers/TR3/Classic/TR3AudioRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Classic/TR3AudioRandomizer.cs
@@ -19,7 +19,7 @@ public class TR3AudioRandomizer : BaseTR3Randomizer
 
             allocator.RandomizeMusicTriggers(_levelInstance.Data);
             allocator.RandomizeSoundEffects(_levelInstance.Name, _levelInstance.Data);
-            allocator.RandomizePitch(_levelInstance.Data);
+            allocator.RandomizePitch(_levelInstance.Data.SoundEffects.Values);
 
             SaveLevelInstance();
             if (!TriggerProgress())

--- a/TRRandomizerCore/Randomizers/TR3/Classic/TR3AudioRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Classic/TR3AudioRandomizer.cs
@@ -54,7 +54,7 @@ public class TR3AudioRandomizer : BaseTR3Randomizer
         ISet<TR3ScriptedLevel> exlusions = new HashSet<TR3ScriptedLevel> { assaultCourse };
 
         _uncontrolledLevels = Levels.RandomSelection(_generator, (int)Settings.UncontrolledSFXCount, exclusions: exlusions);
-        if (Settings.AssaultCourseWireframe)
+        if (Settings.UncontrolledSFXAssaultCourse)
         {
             _uncontrolledLevels.Add(assaultCourse);
         }

--- a/TRRandomizerCore/Randomizers/TR3/Remastered/TR3RAudioRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Remastered/TR3RAudioRandomizer.cs
@@ -1,195 +1,30 @@
-﻿using Newtonsoft.Json;
-using TRGE.Core;
-using TRLevelControl;
-using TRLevelControl.Helpers;
-using TRLevelControl.Model;
-using TRRandomizerCore.Levels;
-using TRRandomizerCore.SFX;
+﻿using TRGE.Core;
 
 namespace TRRandomizerCore.Randomizers;
 
 public class TR3RAudioRandomizer : BaseTR3RRandomizer
 {
-    private const int _defaultSecretTrack = 122;
-    private const int _numSamples = 414;
-
-    private AudioRandomizer _audioRandomizer;
-
-    private List<TR3SFXDefinition> _soundEffects;
-    private List<TRSFXGeneralCategory> _sfxCategories;
-
     public override void Randomize(int seed)
     {
-        _generator = new(seed);
-        LoadAudioData();
+        TR3AudioAllocator allocator = new(ScriptEditor.AudioProvider.GetCategorisedTracks())
+        {
+            Generator = new(seed),
+            Settings = Settings,
+        };
+        allocator.Initialise(Levels.Select(l => l.LevelFileBaseName), BackupPath);
 
         foreach (TRRScriptedLevel lvl in Levels)
         {
             LoadLevelInstance(lvl);
 
-            RandomizeMusicTriggers(_levelInstance);
-            RandomizeSoundEffects(_levelInstance);
-            RandomizeWibble(_levelInstance);
+            allocator.RandomizeMusicTriggers(_levelInstance.Data);
+            allocator.RandomizeSoundEffects(_levelInstance.Name, _levelInstance.Data);
+            allocator.RandomizePitch(_levelInstance.Data);
 
             SaveLevelInstance();
             if (!TriggerProgress())
             {
                 break;
-            }
-        }
-    }
-
-    private void RandomizeMusicTriggers(TR3RCombinedLevel level)
-    {
-        if (Settings.ChangeTriggerTracks)
-        {
-            RandomizeFloorTracks(level.Data);
-        }
-
-        if (Settings.SeparateSecretTracks)
-        {
-            RandomizeSecretTracks(level);
-        }
-    }
-
-    private void RandomizeFloorTracks(TR3Level level)
-    {
-        _audioRandomizer.ResetFloorMap();
-        foreach (TR3Room room in level.Rooms)
-        {
-            _audioRandomizer.RandomizeFloorTracks(room, level.FloorData);
-        }
-    }
-
-    private void RandomizeSecretTracks(TR3RCombinedLevel level)
-    {
-        List<TRAudioTrack> secretTracks = _audioRandomizer.GetTracks(TRAudioCategory.Secret);
-
-        for (int i = 0; i < level.Script.NumSecrets; i++)
-        {
-            TRAudioTrack secretTrack = secretTracks[_generator.Next(0, secretTracks.Count)];
-            if (secretTrack.ID == _defaultSecretTrack)
-            {
-                continue;
-            }
-
-            FDActionItem musicAction = new()
-            {
-                Action = FDTrigAction.PlaySoundtrack,
-                Parameter = (short)secretTrack.ID
-            };
-
-            List<FDTriggerEntry> triggers = level.Data.FloorData.GetSecretTriggers(i);
-            foreach (FDTriggerEntry trigger in triggers)
-            {
-                FDActionItem currentMusicAction = trigger.Actions.Find(a => a.Action == FDTrigAction.PlaySoundtrack);
-                if (currentMusicAction == null)
-                {
-                    trigger.Actions.Add(musicAction);
-                }
-            }
-        }
-    }
-
-    private void LoadAudioData()
-    {
-        _audioRandomizer = new(ScriptEditor.AudioProvider.GetCategorisedTracks())
-        {
-            Generator = _generator,
-            Settings = Settings,
-        };
-        _audioRandomizer.ChooseUncontrolledLevels(new(Levels.Select(l => l.LevelFileBaseName)), TR3LevelNames.ASSAULT);
-
-        _sfxCategories = AudioRandomizer.GetSFXCategories(Settings);
-        if (_sfxCategories.Count > 0)
-        {
-            _soundEffects = JsonConvert.DeserializeObject<List<TR3SFXDefinition>>(ReadResource(@"TR3\Audio\sfx.json"));
-
-            Dictionary<string, TR3Level> levels = new();
-            TR3LevelControl reader = new();
-            foreach (TR3SFXDefinition definition in _soundEffects)
-            {
-                if (!levels.ContainsKey(definition.SourceLevel))
-                {
-                    levels[definition.SourceLevel] = reader.Read(Path.Combine(BackupPath, definition.SourceLevel));
-                }
-
-                TR3Level level = levels[definition.SourceLevel];
-                definition.SoundEffect = level.SoundEffects[definition.InternalIndex];
-            }
-        }
-    }
-
-    private void RandomizeSoundEffects(TR3RCombinedLevel level)
-    {
-        if (_sfxCategories.Count == 0)
-        {
-            return;
-        }
-
-        if (_audioRandomizer.IsUncontrolledLevel(level.Name))
-        {
-            HashSet<uint> indices = new();
-            foreach (TR3SoundEffect effect in level.Data.SoundEffects.Values)
-            {
-                uint sampleIndex;
-                do
-                {
-                    sampleIndex = (uint)_generator.Next(0, _numSamples + 1 - Math.Max(effect.SampleCount, 1));
-                }
-                while (!indices.Add(sampleIndex));
-                effect.SampleID = sampleIndex;
-            }
-        }
-        else
-        {
-            foreach (TR3SFX internalIndex in Enum.GetValues<TR3SFX>())
-            {
-                TR3SFXDefinition definition = _soundEffects.Find(sfx => sfx.InternalIndex == internalIndex);
-                if (!level.Data.SoundEffects.ContainsKey(internalIndex) || definition == null
-                    || definition.Creature == TRSFXCreatureCategory.Lara || !_sfxCategories.Contains(definition.PrimaryCategory))
-                {
-                    continue;
-                }
-
-                Predicate<TR3SFXDefinition> pred;
-                if (Settings.LinkCreatureSFX && definition.Creature > TRSFXCreatureCategory.Lara)
-                {
-                    pred = sfx =>
-                    {
-                        return sfx.Categories.Contains(definition.PrimaryCategory) &&
-                        sfx != definition &&
-                        (
-                            sfx.Creature == definition.Creature ||
-                            (sfx.Creature == TRSFXCreatureCategory.Lara && definition.Creature == TRSFXCreatureCategory.Human)
-                        );
-                    };
-                }
-                else
-                {
-                    pred = sfx => sfx.Categories.Contains(definition.PrimaryCategory) && sfx != definition;
-                }
-
-                List<TR3SFXDefinition> otherDefinitions = _soundEffects.FindAll(pred);
-                if (otherDefinitions.Count > 0)
-                {
-                    TR3SFXDefinition nextDefinition = otherDefinitions[_generator.Next(0, otherDefinitions.Count)];
-                    if (nextDefinition != definition)
-                    {
-                        level.Data.SoundEffects[internalIndex] = nextDefinition.SoundEffect;
-                    }
-                }
-            }
-        }
-    }
-
-    private void RandomizeWibble(TR3RCombinedLevel level)
-    {
-        if (Settings.RandomizeWibble)
-        {
-            foreach (var (_, effect) in level.Data.SoundEffects)
-            {
-                effect.RandomizePitch = true;
             }
         }
     }

--- a/TRRandomizerCore/Randomizers/TR3/Remastered/TR3RAudioRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Remastered/TR3RAudioRandomizer.cs
@@ -19,7 +19,7 @@ public class TR3RAudioRandomizer : BaseTR3RRandomizer
 
             allocator.RandomizeMusicTriggers(_levelInstance.Data);
             allocator.RandomizeSoundEffects(_levelInstance.Name, _levelInstance.Data);
-            allocator.RandomizePitch(_levelInstance.Data);
+            allocator.RandomizePitch(_levelInstance.Data.SoundEffects.Values);
 
             SaveLevelInstance();
             if (!TriggerProgress())

--- a/TRRandomizerCore/Randomizers/TR3/Remastered/TR3RAudioRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Remastered/TR3RAudioRandomizer.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System.Numerics;
 using TRGE.Core;
 using TRLevelControl;
 using TRLevelControl.Helpers;
@@ -58,14 +57,7 @@ public class TR3RAudioRandomizer : BaseTR3RRandomizer
         _audioRandomizer.ResetFloorMap();
         foreach (TR3Room room in level.Rooms)
         {
-            _audioRandomizer.RandomizeFloorTracks(room.Sectors, level.FloorData, _generator, sectorIndex =>
-            {
-                return new Vector2
-                (
-                    TRConsts.Step2 + room.Info.X + sectorIndex / room.NumZSectors * TRConsts.Step4,
-                    TRConsts.Step2 + room.Info.Z + sectorIndex % room.NumZSectors * TRConsts.Step4
-                );
-            });
+            _audioRandomizer.RandomizeFloorTracks(room, level.FloorData);
         }
     }
 

--- a/TRRandomizerCore/Randomizers/TR3/Remastered/TR3RAudioRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Remastered/TR3RAudioRandomizer.cs
@@ -50,7 +50,7 @@ public class TR3RAudioRandomizer : BaseTR3RRandomizer
         HashSet<TRRScriptedLevel> exlusions = new () { assaultCourse };
 
         _uncontrolledLevels = Levels.RandomSelection(_generator, (int)Settings.UncontrolledSFXCount, exclusions: exlusions);
-        if (Settings.AssaultCourseWireframe)
+        if (Settings.UncontrolledSFXAssaultCourse)
         {
             _uncontrolledLevels.Add(assaultCourse);
         }

--- a/TRRandomizerCore/Randomizers/TR3/Shared/TR3AudioAllocator.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Shared/TR3AudioAllocator.cs
@@ -1,0 +1,175 @@
+﻿using Newtonsoft.Json;
+using TRGE.Core;
+using TRLevelControl;
+using TRLevelControl.Helpers;
+using TRLevelControl.Model;
+using TRRandomizerCore.SFX;
+
+namespace TRRandomizerCore.Randomizers;
+
+public class TR3AudioAllocator : AudioRandomizer
+{
+    private const int _defaultSecretTrack = 122;
+    private const int _numSamples = 414;
+
+    private List<TR3SFXDefinition> _soundEffects;
+    private List<TRSFXGeneralCategory> _sfxCategories;
+
+    public TR3AudioAllocator(IReadOnlyDictionary<TRAudioCategory, List<TRAudioTrack>> tracks)
+        : base(tracks) { }
+
+    public void Initialise(IEnumerable<string> levelNames, string backupPath)
+    {
+        ChooseUncontrolledLevels(new(levelNames), TR3LevelNames.ASSAULT);
+
+        _sfxCategories = GetSFXCategories(Settings);
+        if (_sfxCategories.Count > 0)
+        {
+            _soundEffects = JsonConvert.DeserializeObject<List<TR3SFXDefinition>>(File.ReadAllText(@"Resources\TR3\Audio\sfx.json"));
+
+            Dictionary<string, TR3Level> levels = new();
+            TR3LevelControl reader = new();
+            foreach (TR3SFXDefinition definition in _soundEffects)
+            {
+                if (!levels.ContainsKey(definition.SourceLevel))
+                {
+                    levels[definition.SourceLevel] = reader.Read(Path.Combine(backupPath, definition.SourceLevel));
+                }
+
+                TR3Level level = levels[definition.SourceLevel];
+                definition.SoundEffect = level.SoundEffects[definition.InternalIndex];
+            }
+        }
+    }
+
+    public void RandomizeMusicTriggers(TR3Level level)
+    {
+        if (Settings.ChangeTriggerTracks)
+        {
+            RandomizeFloorTracks(level);
+        }
+
+        if (Settings.SeparateSecretTracks && !Settings.RandomizeSecrets)
+        {
+            RandomizeSecretTracks(level);
+        }
+    }
+
+    private void RandomizeFloorTracks(TR3Level level)
+    {
+        ResetFloorMap();
+        foreach (TR3Room room in level.Rooms)
+        {
+            RandomizeFloorTracks(room, level.FloorData);
+        }
+    }
+
+    private void RandomizeSecretTracks(TR3Level level)
+    {
+        int numSecrets = level.FloorData.GetActionItems(FDTrigAction.SecretFound)
+            .Select(a => a.Parameter)
+            .Distinct().Count();
+        if (numSecrets == 0)
+        {
+            return;
+        }
+
+        List<TRAudioTrack> secretTracks = GetTracks(TRAudioCategory.Secret);
+        for (int i = 0; i < numSecrets; i++)
+        {
+            TRAudioTrack secretTrack = secretTracks[Generator.Next(0, secretTracks.Count)];
+            if (secretTrack.ID == _defaultSecretTrack)
+            {
+                continue;
+            }
+
+            FDActionItem musicAction = new()
+            {
+                Action = FDTrigAction.PlaySoundtrack,
+                Parameter = (short)secretTrack.ID
+            };
+
+            List<FDTriggerEntry> triggers = level.FloorData.GetSecretTriggers(i);
+            foreach (FDTriggerEntry trigger in triggers)
+            {
+                FDActionItem currentMusicAction = trigger.Actions.Find(a => a.Action == FDTrigAction.PlaySoundtrack);
+                if (currentMusicAction == null)
+                {
+                    trigger.Actions.Add(musicAction);
+                }
+            }
+        }
+    }
+
+    public void RandomizeSoundEffects(string levelName, TR3Level level)
+    {
+        if (_sfxCategories.Count == 0)
+        {
+            return;
+        }
+
+        if (IsUncontrolledLevel(levelName))
+        {
+            HashSet<uint> indices = new();
+            foreach (TR3SoundEffect effect in level.SoundEffects.Values)
+            {
+                do
+                {
+                    effect.SampleID = (uint)Generator.Next(0, _numSamples + 1 - Math.Max(effect.SampleCount, 1));
+                }
+                while (!indices.Add(effect.SampleID));
+            }
+        }
+        else
+        {
+            foreach (TR3SFX internalIndex in Enum.GetValues<TR3SFX>())
+            {
+                TR3SFXDefinition definition = _soundEffects.Find(sfx => sfx.InternalIndex == internalIndex);
+                if (!level.SoundEffects.ContainsKey(internalIndex) || definition == null
+                    || definition.Creature == TRSFXCreatureCategory.Lara || !_sfxCategories.Contains(definition.PrimaryCategory))
+                {
+                    continue;
+                }
+
+                Predicate<TR3SFXDefinition> pred;
+                if (Settings.LinkCreatureSFX && definition.Creature > TRSFXCreatureCategory.Lara)
+                {
+                    pred = sfx =>
+                    {
+                        return sfx.Categories.Contains(definition.PrimaryCategory) &&
+                        sfx != definition &&
+                        (
+                            sfx.Creature == definition.Creature ||
+                            (sfx.Creature == TRSFXCreatureCategory.Lara && definition.Creature == TRSFXCreatureCategory.Human)
+                        );
+                    };
+                }
+                else
+                {
+                    pred = sfx => sfx.Categories.Contains(definition.PrimaryCategory) && sfx != definition;
+                }
+
+                List<TR3SFXDefinition> otherDefinitions = _soundEffects.FindAll(pred);
+                if (otherDefinitions.Count > 0)
+                {
+                    TR3SFXDefinition nextDefinition = otherDefinitions[Generator.Next(0, otherDefinitions.Count)];
+                    if (nextDefinition != definition)
+                    {
+                        level.SoundEffects[internalIndex] = nextDefinition.SoundEffect;
+                    }
+                }
+            }
+        }
+    }
+
+    public void RandomizePitch(TR3Level level)
+    {
+        if (Settings.RandomizeWibble)
+        {
+            foreach (var (_, effect) in level.SoundEffects)
+            {
+                effect.RandomizePitch = true;
+            }
+        }
+    }
+}

--- a/TRRandomizerCore/TRVersionSupport.cs
+++ b/TRRandomizerCore/TRVersionSupport.cs
@@ -42,6 +42,7 @@ internal class TRVersionSupport
         TRRandomizerType.ReturnPaths,
         TRRandomizerType.RewardRooms,
         TRRandomizerType.Secret,
+        TRRandomizerType.SecretAudio,
         TRRandomizerType.SecretCount,
         TRRandomizerType.SecretModels,
         TRRandomizerType.SecretReward,

--- a/TRRandomizerCore/TRVersionSupport.cs
+++ b/TRRandomizerCore/TRVersionSupport.cs
@@ -69,6 +69,7 @@ internal class TRVersionSupport
         TRRandomizerType.Secret,
         TRRandomizerType.SecretAudio,
         TRRandomizerType.SecretReward,
+        TRRandomizerType.SFX,
         TRRandomizerType.StartPosition,
     };
 

--- a/TRRandomizerView/Model/ControllerOptions.cs
+++ b/TRRandomizerView/Model/ControllerOptions.cs
@@ -1649,7 +1649,9 @@ public class ControllerOptions : INotifyPropertyChanged
         set
         {
             _randomSecretsControl.IsActive = value;
+            _separateSecretTracks.IsActive = IsTR2 || !value;
             FirePropertyChanged();
+            FirePropertyChanged(nameof(SeparateSecretTracks));
         }
     }
 


### PR DESCRIPTION
Part of #614.
Resolves #684.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

More deduplication here, so the shared `AudioRandomizer` now handles most things. I will follow up and rename this to `AudioAllocator` to stay in line with the rest; I just wanted to keep it separate to preserve history.

SFX rando is kept separate for TR1. I originally thought it wasn't going to be possible to randomize SFX in TR1R because it now uses MAIN.SFX and it seems to have a hardcoded LUT, meaning the samples and indices in the level files are ignored. But instead, what we now do here is randomize the SFX animation commands and any sound sources, which covers most things. There are still some hardcoded sounds we can't change, like Lara's gunshots. OG TR1 still uses the original method of swapping the WAV samples around.

I've also fixed #684 - `Settings.AssaultCourseWireframe` was being referenced instead of `Settings.UncontrolledSFXAssaultCourse`. The dangers of copy-paste...