### PR TITLE
Add reward stack option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - added support for TR1X V4 (#626)
 - added Lara's assault course outfit in TR2 for outfit randomization (#672)
 - added gun holsters to Lara's robe outfit in TR2 (#672)
+- added an option to stack rewards with secrets in TR1 and TR3, rather than using reward rooms (#687)
 - fixed a key item softlock in Crash Site (#662)
 - fixed incorrect item and mesh positions in Home Sweet Home when mirrored (#676)
 - fixed uncontrolled SFX in gym/assault course levels not being linked to the correct setting (#684)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - added Lara's assault course outfit in TR2 for outfit randomization (#672)
 - added gun holsters to Lara's robe outfit in TR2 (#672)
 - added an option to stack rewards with secrets in TR1 and TR3, rather than using reward rooms (#687)
+- added separate secret audio for TR1 and TR3 when not using reward rooms (#687)
 - fixed a key item softlock in Crash Site (#662)
 - fixed incorrect item and mesh positions in Home Sweet Home when mirrored (#676)
 - fixed uncontrolled SFX in gym/assault course levels not being linked to the correct setting (#684)

--- a/TRRandomizerCore/Editors/RandomizerSettings.cs
+++ b/TRRandomizerCore/Editors/RandomizerSettings.cs
@@ -90,6 +90,7 @@ public class RandomizerSettings
     public bool UseKillableClonePierres { get; set; }
     public bool GlitchedSecrets { get; set; }
     public bool GuaranteeSecrets { get; set; }
+    public TRSecretRewardMode SecretRewardMode { get; set; }
     public bool UseRewardRoomCameras { get; set; }
     public bool UseRandomSecretModels { get; set; }
     public TRSecretCountMode SecretCountMode { get; set; }
@@ -197,6 +198,7 @@ public class RandomizerSettings
         HardSecrets = config.GetBool(nameof(HardSecrets));
         GlitchedSecrets = config.GetBool(nameof(GlitchedSecrets));
         GuaranteeSecrets = config.GetBool(nameof(GuaranteeSecrets), true);
+        SecretRewardMode = (TRSecretRewardMode)config.GetEnum(nameof(SecretRewardMode), typeof(TRSecretRewardMode), TRSecretRewardMode.Room);
         UseRewardRoomCameras = config.GetBool(nameof(UseRewardRoomCameras), true);
         UseRandomSecretModels = config.GetBool(nameof(UseRandomSecretModels));
         SecretCountMode = (TRSecretCountMode)config.GetEnum(nameof(SecretCountMode), typeof(TRSecretCountMode), TRSecretCountMode.Default);
@@ -364,6 +366,7 @@ public class RandomizerSettings
         config[nameof(HardSecrets)] = HardSecrets;
         config[nameof(GlitchedSecrets)] = GlitchedSecrets;
         config[nameof(GuaranteeSecrets)] = GuaranteeSecrets;
+        config[nameof(SecretRewardMode)] = SecretRewardMode;
         config[nameof(UseRewardRoomCameras)] = UseRewardRoomCameras;
         config[nameof(UseRandomSecretModels)] = UseRandomSecretModels;
         config[nameof(SecretCountMode)] = SecretCountMode;

--- a/TRRandomizerCore/Editors/TR1RemasteredEditor.cs
+++ b/TRRandomizerCore/Editors/TR1RemasteredEditor.cs
@@ -3,6 +3,7 @@ using TRGE.Core;
 using TRLevelControl.Model;
 using TRRandomizerCore.Helpers;
 using TRRandomizerCore.Randomizers;
+using TRRandomizerCore.Secrets;
 
 namespace TRRandomizerCore.Editors;
 
@@ -19,6 +20,7 @@ public class TR1RemasteredEditor : TR1ClassicEditor
         Settings.FixOGBugs = false;
         Settings.ReplaceRequiredEnemies = false;
         Settings.SwapEnemyAppearance = false;
+        Settings.SecretRewardMode = TRSecretRewardMode.Stack;
     }
 
     protected override int GetSaveTarget(int numLevels)

--- a/TRRandomizerCore/Editors/TR3RemasteredEditor.cs
+++ b/TRRandomizerCore/Editors/TR3RemasteredEditor.cs
@@ -3,6 +3,7 @@ using TRGE.Core;
 using TRLevelControl.Model;
 using TRRandomizerCore.Helpers;
 using TRRandomizerCore.Randomizers;
+using TRRandomizerCore.Secrets;
 
 namespace TRRandomizerCore.Editors;
 
@@ -19,6 +20,7 @@ public class TR3RemasteredEditor : TR3ClassicEditor
         Settings.FixOGBugs = false;
         Settings.ReplaceRequiredEnemies = false;
         Settings.SwapEnemyAppearance = false;
+        Settings.SecretRewardMode = TRSecretRewardMode.Stack;
     }
 
     protected override int GetSaveTarget(int numLevels)

--- a/TRRandomizerCore/Randomizers/Shared/AudioAllocator.cs
+++ b/TRRandomizerCore/Randomizers/Shared/AudioAllocator.cs
@@ -145,10 +145,9 @@ public abstract class AudioAllocator
             };
 
             List<FDTriggerEntry> triggers = floorData.GetSecretTriggers(i);
-            foreach (FDTriggerEntry trigger in triggers)
+            foreach (FDTriggerEntry trigger in triggers.Where(t => t.Mask == TRConsts.FullMask))
             {
-                FDActionItem currentMusicAction = trigger.Actions.Find(a => a.Action == FDTrigAction.PlaySoundtrack);
-                if (currentMusicAction == null)
+                if (!trigger.Actions.Any(a => a.Action == FDTrigAction.PlaySoundtrack))
                 {
                     trigger.Actions.Add(musicAction);
                 }

--- a/TRRandomizerCore/Randomizers/TR1/Classic/TR1AudioRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Classic/TR1AudioRandomizer.cs
@@ -40,11 +40,19 @@ public class TR1AudioRandomizer : BaseTR1Randomizer
             }
         }
 
+        TR1ScriptEditor script = (ScriptEditor as TR1ScriptEditor);
         if (Settings.RandomizeWibble)
         {
-            (ScriptEditor as TR1ScriptEditor).EnablePitchedSounds = true;
-            ScriptEditor.SaveScript();
+            script.EnablePitchedSounds = true;
         }
+
+        if (Settings.SeparateSecretTracks && Settings.SecretRewardMode == Secrets.TRSecretRewardMode.Stack)
+        {
+            script.FixSecretsKillingMusic = false;
+            script.FixSpeechesKillingMusic = false;
+        }
+
+        ScriptEditor.SaveScript();
     }
 
     private void RandomizeSoundEffects(TR1CombinedLevel level)

--- a/TRRandomizerCore/Randomizers/TR1/Classic/TR1SecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Classic/TR1SecretRandomizer.cs
@@ -88,23 +88,13 @@ public class TR1SecretRandomizer : BaseTR1Randomizer, ISecretRandomizer
         }
 
         SetMessage("Randomizing secrets - importing models");
-        foreach (SecretProcessor processor in processors)
-        {
-            processor.Start();
-        }
-
-        foreach (SecretProcessor processor in processors)
-        {
-            processor.Join();
-        }
+        processors.ForEach(p => p.Start());
+        processors.ForEach(p => p.Join());
 
         if (!SaveMonitor.IsCancelled && _processingException == null)
         {
             SetMessage("Randomizing secrets - placing items");
-            foreach (SecretProcessor processor in processors)
-            {
-                processor.ApplyRandomization();
-            }
+            processors.ForEach(p => p.ApplyRandomization());
         }
 
         _processingException?.Throw();

--- a/TRRandomizerCore/Randomizers/TR1/Classic/TR1SecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Classic/TR1SecretRandomizer.cs
@@ -1,6 +1,5 @@
 ﻿using Newtonsoft.Json;
 using TRDataControl;
-using TRDataControl.Environment;
 using TRGE.Core;
 using TRGE.Core.Item.Enums;
 using TRLevelControl.Helpers;
@@ -20,7 +19,7 @@ public class TR1SecretRandomizer : BaseTR1Randomizer, ISecretRandomizer
     private readonly Dictionary<string, List<Location>> _locations, _unarmedLocations;
     private readonly LocationPicker _routePicker;
     private SecretPicker<TR1Entity> _secretPicker;
-    private SecretArtefactPlacer<TR1Type> _placer;
+    private SecretArtefactPlacer<TR1Type, TR1Entity> _placer;
 
     public ItemFactory<TR1Entity> ItemFactory { get; set; }
     public IMirrorControl Mirrorer { get; set; }
@@ -54,7 +53,8 @@ public class TR1SecretRandomizer : BaseTR1Randomizer, ISecretRandomizer
 
         _placer = new()
         {
-            Settings = Settings
+            Settings = Settings,
+            ItemFactory = ItemFactory,
         };
 
         if (!Settings.UseSecretPack)
@@ -169,34 +169,12 @@ public class TR1SecretRandomizer : BaseTR1Randomizer, ISecretRandomizer
 
     private TRSecretRoom<TR1Entity> MakePlaceholderRewardRoom(TR1CombinedLevel level)
     {
-        TRSecretRoom<TR1Entity> rewardRoom = null;
-        string mappingPath = @"TR1\SecretMapping\" + level.Name + "-SecretMapping.json";
-        if (ResourceExists(mappingPath))
-        {
-            // Trigger activation masks have 5 bits so we need a specific number of doors to match.
-            // Limited to 1 (5 secrets for the time being).
-            //double countedSecrets = Settings.DevelopmentMode ? _devModeSecretCount : level.Script.NumSecrets;
-            int requiredDoors = 1;// (int)Math.Ceiling(countedSecrets / TRSecretPlacement<TREntities>.MaskBits);
-
-            // Make the doors and store the entity indices for the secret triggers
-            rewardRoom = new()
-            {
-                DoorIndices = new()
-            };
-
-            for (int i = 0; i < requiredDoors; i++)
-            {
-                TR1Entity door = ItemFactory.CreateItem(level.Name, level.Data.Entities);
-                rewardRoom.DoorIndices.Add(level.Data.Entities.IndexOf(door));
-            }
-        }
-
-        return rewardRoom;
+        return _placer.MakePlaceholderRewardRoom(TRGameVersion.TR1, level.Name, level.Script.NumSecrets, level.Data.Entities);
     }
 
     private void ActualiseRewardRoom(TR1CombinedLevel level, TRSecretRoom<TR1Entity> placeholder)
     {
-        TRSecretMapping<TR1Entity> secretMapping = TRSecretMapping<TR1Entity>.Get(GetResourcePath(@"TR1\SecretMapping\" + level.Name + "-SecretMapping.json"));
+        TRSecretMapping<TR1Entity> secretMapping = TRSecretMapping<TR1Entity>.Get(GetResourcePath($@"TR1\SecretMapping\{level.Name}-SecretMapping.json"));
         if (secretMapping == null || secretMapping.Rooms.Count == 0)
         {
             return;
@@ -216,120 +194,18 @@ public class TR1SecretRandomizer : BaseTR1Randomizer, ISecretRandomizer
         rewardRoom.Room.ApplyToLevel(level.Data);
         short roomIndex = (short)(level.Data.Rooms.Count - 1);
 
-        // Convert the temporary doors
-        rewardRoom.DoorIndices = placeholder.DoorIndices;
-        for (int i = 0; i < rewardRoom.DoorIndices.Count; i++)
-        {
-            int doorIndex = rewardRoom.DoorIndices[i];
-            TR1Entity door = rewardRoom.Doors[i];
-            if (door.Room < 0)
-            {
-                door.Room = roomIndex;
-            }
-            level.Data.Entities[doorIndex] = door;
-
-            // If it's a trapdoor, we need to make a dummy trigger for it
-            if (TR1TypeUtilities.IsTrapdoor(door.TypeID))
-            {
-                CreateTrapdoorTrigger(door, (ushort)doorIndex, level.Data);
-            }
-        }
-
-        // Get the reward entities.
-        List<int> rewardEntities = secretMapping.RewardEntities;
-
-        // Spread them out fairly evenly across each defined position in the new room.
-        int rewardPositionCount = rewardRoom.RewardPositions.Count;
-        for (int i = 0; i < rewardEntities.Count; i++)
-        {
-            TR1Entity item = level.Data.Entities[rewardEntities[i]];
-            Location position = rewardRoom.RewardPositions[i % rewardPositionCount];
-
-            item.X = position.X;
-            item.Y = position.Y;
-            item.Z = position.Z;
-            item.Room = roomIndex;
-        }
-
-        // #238 Make the required number of cameras. Because of the masks, we need
-        // a camera per counted secret otherwise it only shows once.
-        if (Settings.UseRewardRoomCameras && rewardRoom.Cameras != null)
-        {
-            double countedSecrets = Settings.DevelopmentMode ? _maxSecretCount : level.Script.NumSecrets;
-            rewardRoom.CameraIndices = new List<int>();
-            for (int i = 0; i < countedSecrets; i++)
-            {
-                rewardRoom.CameraIndices.Add(level.Data.Cameras.Count);
-                level.Data.Cameras.Add(rewardRoom.Cameras[i % rewardRoom.Cameras.Count]);
-            }
-
-            short cameraTarget;
-            if (rewardRoom.CameraTarget != null && ItemFactory.CanCreateItem(level.Name, level.Data.Entities))
-            {
-                TR1Entity target = ItemFactory.CreateItem(level.Name, level.Data.Entities, rewardRoom.CameraTarget);
-                target.TypeID = TR1Type.CameraTarget_N;
-                cameraTarget = (short)level.Data.Entities.IndexOf(target);
-            }
-            else
-            {
-                cameraTarget = (short)rewardRoom.DoorIndices[0];
-            }
-
-            // Get each trigger created for each secret index and add the camera, provided
-            // there isn't any existing camera actions.
-            for (int i = 0; i < countedSecrets; i++)
-            {
-                List<FDTriggerEntry> secretTriggers = level.Data.FloorData.GetSecretTriggers(i);
-                foreach (FDTriggerEntry trigger in secretTriggers)
-                {
-                    if (trigger.Actions.Find(a => a.Action == FDTrigAction.Camera) == null)
-                    {
-                        trigger.Actions.Add(new FDActionItem
-                        {
-                            Action = FDTrigAction.Camera,
-                            CamAction = new()
-                            {
-                                Timer = 4
-                            },
-                            Parameter = (short)rewardRoom.CameraIndices[i]
-                        });
-                        trigger.Actions.Add(new FDActionItem
-                        {
-                            Action = FDTrigAction.LookAtItem,
-                            Parameter = cameraTarget
-                        });
-                    }
-                }
-            }
-        }
-    }
-
-    private static void CreateTrapdoorTrigger(TR1Entity door, ushort doorIndex, TR1Level level)
-    {
-        new EMTriggerFunction
-        {
-            Locations = new()
-            {
-                new()
-                {
-                    X = door.X,
-                    Y = door.Y,
-                    Z = door.Z,
-                    Room = door.Room
-                }
-            },
-            Trigger = new()
-            {
-                TrigType = FDTrigType.Dummy,
-                Actions = new()
-                {
-                    new()
-                    {
-                        Parameter = (short)doorIndex
-                    }
-                }
-            }
-        }.ApplyToLevel(level);
+        _placer.CreateRewardRoom(level.Name,
+            placeholder,
+            rewardRoom,
+            level.Data.Entities,
+            level.Data.Cameras,
+            TR1Type.CameraTarget_N,
+            secretMapping.RewardEntities,
+            level.Data.FloorData,
+            roomIndex,
+            Settings.DevelopmentMode ? _maxSecretCount : level.Script.NumSecrets,
+            t => TR1TypeUtilities.IsTrapdoor(t)
+        );
     }
 
     private void PlaceAllSecrets(TR1CombinedLevel level, List<TR1Type> pickupTypes, TRSecretRoom<TR1Entity> rewardRoom)

--- a/TRRandomizerCore/Randomizers/TR1/Classic/TR1SecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Classic/TR1SecretRandomizer.cs
@@ -175,7 +175,17 @@ public class TR1SecretRandomizer : BaseTR1Randomizer, ISecretRandomizer
     private void ActualiseRewardRoom(TR1CombinedLevel level, TRSecretRoom<TR1Entity> placeholder)
     {
         TRSecretMapping<TR1Entity> secretMapping = TRSecretMapping<TR1Entity>.Get(GetResourcePath($@"TR1\SecretMapping\{level.Name}-SecretMapping.json"));
-        if (secretMapping == null || secretMapping.Rooms.Count == 0)
+        if (secretMapping == null)
+        {
+            return;
+        }
+
+        if (placeholder == null)
+        {
+            _placer.CreateRewardStacks(level.Data.Entities, secretMapping.RewardEntities, level.Data.FloorData);
+            return;
+        }
+        else if (secretMapping.Rooms.Count == 0)
         {
             return;
         }
@@ -277,13 +287,17 @@ public class TR1SecretRandomizer : BaseTR1Randomizer, ISecretRandomizer
             secret.EntityIndex = (short)ItemFactory.GetNextIndex(level.Name, level.Data.Entities);
             secret.PickupType = pickupTypes[pickupIndex % pickupTypes.Count];
 
-            if (Settings.UseRewardRoomCameras && rewardRoom.HasCameras)
+            if (rewardRoom != null)
             {
-                secret.CameraIndex = (short)rewardRoom.CameraIndices[pickupIndex % rewardRoom.CameraIndices.Count];
-                secret.CameraTarget = (short)rewardRoom.DoorIndices[0];
+                if (Settings.UseRewardRoomCameras && rewardRoom.HasCameras)
+                {
+                    secret.CameraIndex = (short)rewardRoom.CameraIndices[pickupIndex % rewardRoom.CameraIndices.Count];
+                    secret.CameraTarget = (short)rewardRoom.DoorIndices[0];
+                }
+
+                secret.SetMaskAndDoor(level.Script.NumSecrets, rewardRoom.DoorIndices);
             }
 
-            secret.SetMaskAndDoor(level.Script.NumSecrets, rewardRoom.DoorIndices);
             _placer.PlaceSecret(secret);
 
             // Turn off walk-to-items in TR1X if we are placing on a slope above water.

--- a/TRRandomizerCore/Randomizers/TR1/Classic/TR1SecretRewardRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Classic/TR1SecretRewardRandomizer.cs
@@ -14,6 +14,7 @@ public class TR1SecretRewardRandomizer : BaseTR1Randomizer
         TR1SecretRewardAllocator allocator = new()
         {
             ItemFactory = ItemFactory,
+            Settings = Settings,
             Generator = _generator
         };
 

--- a/TRRandomizerCore/Randomizers/TR1/Remastered/TR1RItemRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Remastered/TR1RItemRandomizer.cs
@@ -15,7 +15,7 @@ public class TR1RItemRandomizer : BaseTR1RRandomizer
     public override void Randomize(int seed)
     {
         _generator = new(seed);
-        _allocator = new(true)
+        _allocator = new()
         {
             Generator = _generator,
             Settings = Settings,

--- a/TRRandomizerCore/Randomizers/TR1/Remastered/TR1RSecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Remastered/TR1RSecretRandomizer.cs
@@ -154,13 +154,7 @@ public class TR1RSecretRandomizer : BaseTR1RRandomizer, ISecretRandomizer
         _routePicker.Initialise(level.Name, locations, Settings, _generator);
 
         List<Location> pickedLocations = _secretPicker.GetLocations(locations, false, level.Script.NumSecrets);
-
-        // We can't make reward rooms, so the items are instead distrbuted around the secret locations
-        TRSecretMapping<TR1Entity> secretMapping = TRSecretMapping<TR1Entity>.Get(GetResourcePath($@"TR1\SecretMapping\{level.Name}-SecretMapping.json"));
-        List<TR1Entity>[] rewardClusters = secretMapping.RewardEntities
-            .Select(i => level.Data.Entities[i])
-            .Cluster(level.Script.NumSecrets);
-        
+                
         TRSecretPlacement<TR1Type> secret = new();
         int pickupIndex = 0;
         for (int i = 0; i < level.Script.NumSecrets; i++)
@@ -171,7 +165,6 @@ public class TR1RSecretRandomizer : BaseTR1RRandomizer, ISecretRandomizer
             secret.PickupType = pickupTypes[pickupIndex % pickupTypes.Count];
 
             _placer.PlaceSecret(secret);
-            rewardClusters[i].ForEach(r => r.SetLocation(location));
 
             TR1Entity entity = ItemFactory.CreateLockedItem(level.Name, level.Data.Entities, secret.Location);
             entity.TypeID = secret.PickupType;
@@ -179,6 +172,9 @@ public class TR1RSecretRandomizer : BaseTR1RRandomizer, ISecretRandomizer
             secret.SecretIndex++;
             pickupIndex++;
         }
+
+        TRSecretMapping<TR1Entity> secretMapping = TRSecretMapping<TR1Entity>.Get(GetResourcePath($@"TR1\SecretMapping\{level.Name}-SecretMapping.json"));
+        _placer.CreateRewardStacks(level.Data.Entities, secretMapping.RewardEntities, level.Data.FloorData);
 
         AddDamageControl(level, pickedLocations);
         _secretPicker.FinaliseSecretPool(pickedLocations, level.Name, itemIndex => new() { itemIndex });

--- a/TRRandomizerCore/Randomizers/TR1/Remastered/TR1RSecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Remastered/TR1RSecretRandomizer.cs
@@ -78,23 +78,13 @@ public class TR1RSecretRandomizer : BaseTR1RRandomizer, ISecretRandomizer
         }
 
         SetMessage("Randomizing secrets - importing models");
-        foreach (SecretProcessor processor in processors)
-        {
-            processor.Start();
-        }
-
-        foreach (SecretProcessor processor in processors)
-        {
-            processor.Join();
-        }
+        processors.ForEach(p => p.Start());
+        processors.ForEach(p => p.Join());
 
         if (!SaveMonitor.IsCancelled && _processingException == null)
         {
             SetMessage("Randomizing secrets - placing items");
-            foreach (SecretProcessor processor in processors)
-            {
-                processor.ApplyRandomization();
-            }
+            processors.ForEach(p => p.ApplyRandomization());
         }
 
         _processingException?.Throw();

--- a/TRRandomizerCore/Randomizers/TR1/Remastered/TR1RSecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Remastered/TR1RSecretRandomizer.cs
@@ -7,7 +7,6 @@ using TRRandomizerCore.Helpers;
 using TRRandomizerCore.Levels;
 using TRRandomizerCore.Processors;
 using TRRandomizerCore.Secrets;
-using TRRandomizerCore.Utilities;
 
 namespace TRRandomizerCore.Randomizers;
 

--- a/TRRandomizerCore/Randomizers/TR1/Remastered/TR1RSecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Remastered/TR1RSecretRandomizer.cs
@@ -16,7 +16,7 @@ public class TR1RSecretRandomizer : BaseTR1RRandomizer, ISecretRandomizer
     private readonly Dictionary<string, List<Location>> _locations, _unarmedLocations;
     private readonly LocationPicker _routePicker;
     private SecretPicker<TR1Entity> _secretPicker;
-    private SecretArtefactPlacer<TR1Type> _placer;
+    private SecretArtefactPlacer<TR1Type, TR1Entity> _placer;
 
     public TR1RDataCache DataCache { get; set; }
     public ItemFactory<TR1Entity> ItemFactory { get; set; }
@@ -49,7 +49,8 @@ public class TR1RSecretRandomizer : BaseTR1RRandomizer, ISecretRandomizer
 
         _placer = new()
         {
-            Settings = Settings
+            Settings = Settings,
+            ItemFactory = ItemFactory,
         };
 
         SetMessage("Randomizing secrets - loading levels");

--- a/TRRandomizerCore/Randomizers/TR1/Remastered/TR1RSecretRewardRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Remastered/TR1RSecretRewardRandomizer.cs
@@ -14,6 +14,7 @@ public class TR1RSecretRewardRandomizer : BaseTR1RRandomizer
         TR1SecretRewardAllocator allocator = new()
         {
             ItemFactory = ItemFactory,
+            Settings = Settings,
             Generator = _generator
         };
 

--- a/TRRandomizerCore/Randomizers/TR1/Shared/TR1AudioAllocator.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Shared/TR1AudioAllocator.cs
@@ -71,9 +71,6 @@ public class TR1AudioAllocator : AudioAllocator
     public void RandomizeMusicTriggers(TR1Level level)
     {
         RandomizeFloorTracks(level.Rooms, level.FloorData);
-        if (!Settings.RandomizeSecrets)
-        {
-            RandomizeSecretTracks(level.FloorData, _defaultSecretTrack);
-        }
+        RandomizeSecretTracks(level.FloorData, _defaultSecretTrack);
     }
 }

--- a/TRRandomizerCore/Randomizers/TR1/Shared/TR1ItemAllocator.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Shared/TR1ItemAllocator.cs
@@ -51,13 +51,8 @@ public class TR1ItemAllocator : ItemAllocator<TR1Type, TR1Entity>
             = 4,  // Default = 12
     };
 
-    private readonly bool _remaster;
-
-    public TR1ItemAllocator(bool remaster = false)
-        : base(TRGameVersion.TR1)
-    {
-        _remaster = remaster;
-    }
+    public TR1ItemAllocator()
+        : base(TRGameVersion.TR1) { }
 
     protected override List<int> GetExcludedItems(string levelName)
     {
@@ -148,7 +143,7 @@ public class TR1ItemAllocator : ItemAllocator<TR1Type, TR1Entity>
             .Select(e => e.GetFloorLocation(loc => level.GetRoomSector(loc))));
 
         if (Settings.RandomizeSecrets
-            && !_remaster // Eliminate and make UseRewardRooms setting
+            && Settings.SecretRewardMode == TRSecretRewardMode.Room
             && level.FloorData.GetActionItems(FDTrigAction.SecretFound).Any())
         {
             // Make sure to exclude the reward room

--- a/TRRandomizerCore/Randomizers/TR1/Shared/TR1SecretRewardAllocator.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Shared/TR1SecretRewardAllocator.cs
@@ -1,5 +1,6 @@
 ﻿using TRLevelControl.Helpers;
 using TRLevelControl.Model;
+using TRRandomizerCore.Editors;
 using TRRandomizerCore.Helpers;
 using TRRandomizerCore.Secrets;
 using TRRandomizerCore.Utilities;
@@ -12,6 +13,7 @@ public class TR1SecretRewardAllocator
     private static readonly double _doubleRewardChance = (double)1 / 6;
     private static readonly double _extraRewardChance = (double)1 / 3;
 
+    public RandomizerSettings Settings { get; set; }
     public Random Generator { get; set; }
     public ItemFactory<TR1Entity> ItemFactory { get; set; }
 
@@ -33,9 +35,19 @@ public class TR1SecretRewardAllocator
 
         List<int> rewardIndices = new(secretMapping.RewardEntities);
 
-        // Pile extra pickups on top of existing ones, either in their default spots
-        // or in the generated reward rooms (for classic only).
-        List<Location> rewardPositions = new(rewardIndices.Select(i => level.Entities[i].GetLocation()));
+        // Pile extra pickups on top of existing ones. We reference the artefacts if they've been used because the original
+        // reward item count may be less than the number of secrets.
+        List<Location> rewardPositions = new();
+        if (Settings.RandomizeSecrets && Settings.SecretRewardMode == TRSecretRewardMode.Stack)
+        {
+            List<TR1Entity> artefacts = level.Entities.FindAll(e => level.FloorData.GetEntityTriggers(level.Entities.IndexOf(e))
+                .Any(t => t.TrigType == FDTrigType.Pickup && t.Actions.Any(a => a.Action == FDTrigAction.SecretFound)));
+            rewardPositions.AddRange(artefacts.Select(a => a.GetLocation()));
+        }
+        else
+        {
+            rewardPositions.AddRange(rewardIndices.Select(i => level.Entities[i].GetLocation()));
+        }
 
         // Give at least one item per secret, never less than the original reward item count,
         // and potentially some extra bonus items.
@@ -57,6 +69,13 @@ public class TR1SecretRewardAllocator
             TR1Entity item = ItemFactory.CreateItem(levelName, level.Entities, location, true);
             rewardIndices.Add(level.Entities.IndexOf(item));
             item.Room = location.Room;
+        }
+
+        if (Settings.RandomizeSecrets && Settings.SecretRewardMode == TRSecretRewardMode.Stack)
+        {
+            // Redistribute the rewards in case there weren't enough originally - we want at least one on each secret
+            SecretArtefactPlacer<TR1Type, TR1Entity> placer = new();
+            placer.CreateRewardStacks(level.Entities, rewardIndices, level.FloorData);
         }
 
         foreach (int rewardIndex in rewardIndices)

--- a/TRRandomizerCore/Randomizers/TR3/Classic/TR3SecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Classic/TR3SecretRandomizer.cs
@@ -120,6 +120,16 @@ public class TR3SecretRandomizer : BaseTR3Randomizer, ISecretRandomizer
             return;
         }
 
+        if (placeholder == null)
+        {
+            _placer.CreateRewardStacks(level.Data.Entities, secretMapping.RewardEntities, level.Data.FloorData);
+            return;
+        }
+        else if (secretMapping.Rooms.Count == 0)
+        {
+            return;
+        }
+
         // Are any rooms enforced based on level specifics?
         TRSecretRoom<TR3Entity> rewardRoom = secretMapping.Rooms.Find(r => r.HasUsageCondition);
         if (rewardRoom == null || !rewardRoom.UsageCondition.GetResult(level.Data))
@@ -219,13 +229,17 @@ public class TR3SecretRandomizer : BaseTR3Randomizer, ISecretRandomizer
             secret.EntityIndex = (short)ItemFactory.GetNextIndex(level.Name, level.Data.Entities);
             secret.PickupType = pickupTypes[pickupIndex % pickupTypes.Count];
 
-            if (Settings.UseRewardRoomCameras && rewardRoom.HasCameras)
+            if (rewardRoom != null)
             {
-                secret.CameraIndex = (short)rewardRoom.CameraIndices[pickupIndex % rewardRoom.CameraIndices.Count];
-                secret.CameraTarget = (short)rewardRoom.DoorIndices[0];
+                if (Settings.UseRewardRoomCameras && rewardRoom.HasCameras)
+                {
+                    secret.CameraIndex = (short)rewardRoom.CameraIndices[pickupIndex % rewardRoom.CameraIndices.Count];
+                    secret.CameraTarget = (short)rewardRoom.DoorIndices[0];
+                }
+
+                secret.SetMaskAndDoor(level.Script.NumSecrets, rewardRoom.DoorIndices);
             }
 
-            secret.SetMaskAndDoor(level.Script.NumSecrets, rewardRoom.DoorIndices);
             _placer.PlaceSecret(secret);
 
             // This will either make a new entity or repurpose an old one. Ensure it is locked

--- a/TRRandomizerCore/Randomizers/TR3/Classic/TR3SecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Classic/TR3SecretRandomizer.cs
@@ -2,7 +2,6 @@
 using TRDataControl;
 using TRGE.Core;
 using TRGE.Core.Item.Enums;
-using TRLevelControl;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRRandomizerCore.Helpers;
@@ -21,7 +20,7 @@ public class TR3SecretRandomizer : BaseTR3Randomizer, ISecretRandomizer
     private readonly Dictionary<string, List<Location>> _locations, _unarmedLocations;
     private readonly LocationPicker _routePicker;
     private SecretPicker<TR3Entity> _secretPicker;
-    private SecretArtefactPlacer<TR3Type> _placer;
+    private SecretArtefactPlacer<TR3Type, TR3Entity> _placer;
 
     internal TR3TextureMonitorBroker TextureMonitor { get; set; }
     public ItemFactory<TR3Entity> ItemFactory { get; set; }
@@ -56,7 +55,8 @@ public class TR3SecretRandomizer : BaseTR3Randomizer, ISecretRandomizer
 
         _placer = new()
         {
-            Settings = Settings
+            Settings = Settings,
+            ItemFactory = ItemFactory,
         };
 
         SetMessage("Randomizing secrets - loading levels");
@@ -107,33 +107,12 @@ public class TR3SecretRandomizer : BaseTR3Randomizer, ISecretRandomizer
         _processingException?.Throw();
     }
 
-    private TRSecretRoom<TR2Entity> MakePlaceholderRewardRoom(TR3CombinedLevel level)
+    private TRSecretRoom<TR3Entity> MakePlaceholderRewardRoom(TR3CombinedLevel level)
     {
-        TRSecretRoom<TR2Entity> rewardRoom = null;
-        string mappingPath = @"TR3\SecretMapping\" + level.Name + "-SecretMapping.json";
-        if (ResourceExists(mappingPath))
-        {
-            // Trigger activation masks have 5 bits so we need a specific number of doors to match.
-            // For development mode, test the maximum.
-            double countedSecrets = Settings.DevelopmentMode ? _devModeSecretCount : level.Script.NumSecrets;
-            int requiredDoors = (int)Math.Ceiling(countedSecrets / TRConsts.MaskBits);
-
-            // Make the doors and store the entity indices for the secret triggers
-            rewardRoom = new TRSecretRoom<TR2Entity>
-            {
-                DoorIndices = new List<int>()
-            };
-            for (int i = 0; i < requiredDoors; i++)
-            {
-                TR3Entity door = ItemFactory.CreateItem(level.Name, level.Data.Entities);
-                rewardRoom.DoorIndices.Add(level.Data.Entities.IndexOf(door));
-            }
-        }
-
-        return rewardRoom;
+        return _placer.MakePlaceholderRewardRoom(TRGameVersion.TR3, level.Name, level.Script.NumSecrets, level.Data.Entities);
     }
 
-    private void ActualiseRewardRoom(TR3CombinedLevel level, TRSecretRoom<TR2Entity> placeholder)
+    private void ActualiseRewardRoom(TR3CombinedLevel level, TRSecretRoom<TR3Entity> placeholder)
     {
         TR3SecretMapping secretMapping = TR3SecretMapping.Get(level);
         if (secretMapping == null)
@@ -155,101 +134,21 @@ public class TR3SecretRandomizer : BaseTR3Randomizer, ISecretRandomizer
         rewardRoom.Room.ApplyToLevel(level.Data);
         short roomIndex = (short)(level.Data.Rooms.Count - 1);
 
-        // Convert the temporary doors
-        rewardRoom.DoorIndices = placeholder.DoorIndices;
-        for (int i = 0; i < rewardRoom.DoorIndices.Count; i++)
-        {
-            int doorIndex = rewardRoom.DoorIndices[i];
-            TR3Entity door = rewardRoom.Doors[i];
-            if (door.Room < 0)
-            {
-                door.Room = roomIndex;
-            }
-            level.Data.Entities[doorIndex] = door;
-
-            // If it's a trapdoor, we need to make a dummy trigger for it
-            if (TR3TypeUtilities.IsTrapdoor(door.TypeID))
-            {
-                CreateTrapdoorTrigger(door, (short)doorIndex, level.Data);
-            }
-        }
-
-        // Spread the rewards out fairly evenly across each defined position in the new room.
-        int rewardPositionCount = rewardRoom.RewardPositions.Count;
-        for (int i = 0; i < secretMapping.RewardEntities.Count; i++)
-        {
-            TR3Entity item = level.Data.Entities[secretMapping.RewardEntities[i]];
-            Location position = rewardRoom.RewardPositions[i % rewardPositionCount];
-
-            item.X = position.X;
-            item.Y = position.Y;
-            item.Z = position.Z;
-            item.Room = roomIndex;
-        }
-
-        // #238 Make the required number of cameras. Because of the masks, we need
-        // a camera per counted secret otherwise it only shows once.
-        if (Settings.UseRewardRoomCameras && rewardRoom.Cameras != null)
-        {
-            double countedSecrets = Settings.DevelopmentMode ? _devModeSecretCount : level.Script.NumSecrets;
-            rewardRoom.CameraIndices = new List<int>();
-            for (int i = 0; i < countedSecrets; i++)
-            {
-                rewardRoom.CameraIndices.Add(level.Data.Cameras.Count);
-                level.Data.Cameras.Add(rewardRoom.Cameras[i % rewardRoom.Cameras.Count]);
-            }
-
-            // Get each trigger created for each secret index and add the camera, provided
-            // there isn't any existing camera actions.
-            for (int i = 0; i < countedSecrets; i++)
-            {
-                List<FDTriggerEntry> secretTriggers = level.Data.FloorData.GetSecretTriggers(i);
-                foreach (FDTriggerEntry trigger in secretTriggers)
-                {
-                    if (trigger.Actions.Find(a => a.Action == FDTrigAction.Camera) == null)
-                    {
-                        trigger.Actions.Add(new()
-                        {
-                            Action = FDTrigAction.Camera,
-                            CamAction = new()
-                            {
-                                Timer = 4
-                            },
-                            Parameter = (short)rewardRoom.CameraIndices[i]
-                        });
-                        trigger.Actions.Add(new()
-                        {
-                            Action = FDTrigAction.LookAtItem,
-                            Parameter = (short)rewardRoom.DoorIndices[0]
-                        });
-                    }
-                }
-            }
-        }
+        _placer.CreateRewardRoom(level.Name,
+            placeholder,
+            rewardRoom,
+            level.Data.Entities,
+            level.Data.Cameras,
+            TR3Type.LookAtItem_H,
+            secretMapping.RewardEntities,
+            level.Data.FloorData,
+            roomIndex,
+            Settings.DevelopmentMode ? _devModeSecretCount : level.Script.NumSecrets,
+            t => TR3TypeUtilities.IsTrapdoor(t)
+        );
     }
 
-    private static void CreateTrapdoorTrigger(TR3Entity door, short doorIndex, TR3Level level)
-    {
-        TRRoomSector sector = level.GetRoomSector(door);
-        if (sector.FDIndex == 0)
-        {
-            level.FloorData.CreateFloorData(sector);
-        }
-
-        level.FloorData[sector.FDIndex].Add(new FDTriggerEntry
-        {
-            TrigType = FDTrigType.Dummy,
-            Actions = new()
-            {
-                new()
-                {
-                    Parameter = doorIndex
-                }
-            }
-        });
-    }
-
-    private void PlaceAllSecrets(TR3CombinedLevel level, List<TR3Type> pickupTypes, TRSecretRoom<TR2Entity> rewardRoom)
+    private void PlaceAllSecrets(TR3CombinedLevel level, List<TR3Type> pickupTypes, TRSecretRoom<TR3Entity> rewardRoom)
     {
         if (!_locations.ContainsKey(level.Name))
         {
@@ -296,7 +195,7 @@ public class TR3SecretRandomizer : BaseTR3Randomizer, ISecretRandomizer
         AddDamageControl(level, pickupTypes, locations);
     }
 
-    private void RandomizeSecrets(TR3CombinedLevel level, List<TR3Type> pickupTypes, TRSecretRoom<TR2Entity> rewardRoom)
+    private void RandomizeSecrets(TR3CombinedLevel level, List<TR3Type> pickupTypes, TRSecretRoom<TR3Entity> rewardRoom)
     {
         List<Location> locations = _locations[level.Name];
         locations.Shuffle(_generator);
@@ -582,7 +481,7 @@ public class TR3SecretRandomizer : BaseTR3Randomizer, ISecretRandomizer
 
                     // Reward rooms can be conditionally chosen based on level state after placing secrets,
                     // but we need to make a placholder for door indices and masks to create those secrets.
-                    TRSecretRoom<TR2Entity> rewardRoom = _outer.MakePlaceholderRewardRoom(level);
+                    TRSecretRoom<TR3Entity> rewardRoom = _outer.MakePlaceholderRewardRoom(level);
 
                     // Pass the list of artefacts we can use as pickups along with the temporary reward
                     // room to the secret placers.

--- a/TRRandomizerCore/Randomizers/TR3/Classic/TR3SecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Classic/TR3SecretRandomizer.cs
@@ -85,23 +85,13 @@ public class TR3SecretRandomizer : BaseTR3Randomizer, ISecretRandomizer
         }
 
         SetMessage("Randomizing secrets - importing models");
-        foreach (SecretProcessor processor in processors)
-        {
-            processor.Start();
-        }
-
-        foreach (SecretProcessor processor in processors)
-        {
-            processor.Join();
-        }
+        processors.ForEach(p => p.Start());
+        processors.ForEach(p => p.Join());
 
         if (!SaveMonitor.IsCancelled && _processingException == null)
         {
             SetMessage("Randomizing secrets - placing items");
-            foreach (SecretProcessor processor in processors)
-            {
-                processor.ApplyRandomization();
-            }
+            processors.ForEach(p => p.ApplyRandomization());
         }
 
         _processingException?.Throw();

--- a/TRRandomizerCore/Randomizers/TR3/Remastered/TR3RItemRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Remastered/TR3RItemRandomizer.cs
@@ -13,7 +13,7 @@ public class TR3RItemRandomizer : BaseTR3RRandomizer
     public override void Randomize(int seed)
     {
         _generator = new(seed);
-        _allocator = new(true)
+        _allocator = new()
         {
             Generator = _generator,
             Settings = Settings,

--- a/TRRandomizerCore/Randomizers/TR3/Remastered/TR3RSecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Remastered/TR3RSecretRandomizer.cs
@@ -18,7 +18,7 @@ public class TR3RSecretRandomizer : BaseTR3RRandomizer, ISecretRandomizer
     private readonly Dictionary<string, List<Location>> _locations, _unarmedLocations;
     private readonly LocationPicker _routePicker;
     private SecretPicker<TR3Entity> _secretPicker;
-    private SecretArtefactPlacer<TR3Type> _placer;
+    private SecretArtefactPlacer<TR3Type, TR3Entity> _placer;
 
     public TR3RDataCache DataCache { get; set; }
     public ItemFactory<TR3Entity> ItemFactory { get; set; }
@@ -51,7 +51,8 @@ public class TR3RSecretRandomizer : BaseTR3RRandomizer, ISecretRandomizer
 
         _placer = new()
         {
-            Settings = Settings
+            Settings = Settings,
+            ItemFactory = ItemFactory,
         };
 
         SetMessage("Randomizing secrets - loading levels");

--- a/TRRandomizerCore/Randomizers/TR3/Remastered/TR3RSecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Remastered/TR3RSecretRandomizer.cs
@@ -160,12 +160,6 @@ public class TR3RSecretRandomizer : BaseTR3RRandomizer, ISecretRandomizer
 
         List<Location> pickedLocations = _secretPicker.GetLocations(locations, false, level.Script.NumSecrets);
 
-        // We can't make reward rooms, so the items are instead distrbuted around the secret locations
-        TRSecretMapping<TR3Entity> secretMapping = TRSecretMapping<TR3Entity>.Get(GetResourcePath($@"TR3\SecretMapping\{level.Name}-SecretMapping.json"));
-        List<TR3Entity>[] rewardClusters = secretMapping.RewardEntities
-            .Select(i => level.Data.Entities[i])
-            .Cluster(level.Script.NumSecrets);
-
         int pickupIndex = 0;
         TRSecretPlacement<TR3Type> secret = new();
         for (int i = 0; i < level.Script.NumSecrets; i++)
@@ -176,7 +170,6 @@ public class TR3RSecretRandomizer : BaseTR3RRandomizer, ISecretRandomizer
             secret.PickupType = pickupTypes[pickupIndex % pickupTypes.Count];
 
             _placer.PlaceSecret(secret);
-            rewardClusters[i].ForEach(r => r.SetLocation(location));
 
             // This will either make a new entity or repurpose an old one. Ensure it is locked
             // to prevent item rando from potentially treating it as a key item.
@@ -186,6 +179,9 @@ public class TR3RSecretRandomizer : BaseTR3RRandomizer, ISecretRandomizer
             secret.SecretIndex++;
             pickupIndex++;
         }
+
+        TRSecretMapping<TR3Entity> secretMapping = TRSecretMapping<TR3Entity>.Get(GetResourcePath($@"TR3\SecretMapping\{level.Name}-SecretMapping.json"));
+        _placer.CreateRewardStacks(level.Data.Entities, secretMapping.RewardEntities, level.Data.FloorData);
 
         AddDamageControl(level, pickedLocations);
         _secretPicker.FinaliseSecretPool(pickedLocations, level.Name, itemIndex => GetDependentLockedItems(level, itemIndex));

--- a/TRRandomizerCore/Randomizers/TR3/Remastered/TR3RSecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Remastered/TR3RSecretRandomizer.cs
@@ -81,23 +81,13 @@ public class TR3RSecretRandomizer : BaseTR3RRandomizer, ISecretRandomizer
         }
 
         SetMessage("Randomizing secrets - importing models");
-        foreach (SecretProcessor processor in processors)
-        {
-            processor.Start();
-        }
-
-        foreach (SecretProcessor processor in processors)
-        {
-            processor.Join();
-        }
+        processors.ForEach(p => p.Start());
+        processors.ForEach(p => p.Join());
 
         if (!SaveMonitor.IsCancelled && _processingException == null)
         {
             SetMessage("Randomizing secrets - placing items");
-            foreach (SecretProcessor processor in processors)
-            {
-                processor.ApplyRandomization();
-            }
+            processors.ForEach(p => p.ApplyRandomization());
         }
 
         _processingException?.Throw();

--- a/TRRandomizerCore/Randomizers/TR3/Shared/TR3AudioAllocator.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Shared/TR3AudioAllocator.cs
@@ -41,10 +41,7 @@ public class TR3AudioAllocator : AudioAllocator
     public void RandomizeMusicTriggers(TR3Level level)
     {
         RandomizeFloorTracks(level.Rooms, level.FloorData);
-        if (!Settings.RandomizeSecrets)
-        {
-            RandomizeSecretTracks(level.FloorData, _defaultSecretTrack);
-        }
+        RandomizeSecretTracks(level.FloorData, _defaultSecretTrack);
     }
 
     public void RandomizeSoundEffects(string levelName, TR3Level level)

--- a/TRRandomizerCore/Randomizers/TR3/Shared/TR3ItemAllocator.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Shared/TR3ItemAllocator.cs
@@ -8,13 +8,8 @@ namespace TRRandomizerCore.Randomizers;
 
 public class TR3ItemAllocator : ItemAllocator<TR3Type, TR3Entity>
 {
-    private readonly bool _remaster;
-
-    public TR3ItemAllocator(bool remaster = false)
-        : base(TRGameVersion.TR3)
-    {
-        _remaster = remaster;
-    }
+    public TR3ItemAllocator()
+        : base(TRGameVersion.TR3) { }
 
     protected override List<int> GetExcludedItems(string levelName)
     {
@@ -96,7 +91,7 @@ public class TR3ItemAllocator : ItemAllocator<TR3Type, TR3Entity>
             .Select(e => e.GetFloorLocation(loc => level.GetRoomSector(loc))));
 
         if (Settings.RandomizeSecrets
-            && !_remaster // Eliminate and make UseRewardRooms setting
+            && Settings.SecretRewardMode == TRSecretRewardMode.Room
             && level.FloorData.GetActionItems(FDTrigAction.SecretFound).Any())
         {
             // Make sure to exclude the reward room

--- a/TRRandomizerCore/Secrets/TRSecretRewardMode.cs
+++ b/TRRandomizerCore/Secrets/TRSecretRewardMode.cs
@@ -1,0 +1,7 @@
+﻿namespace TRRandomizerCore.Secrets;
+
+public enum TRSecretRewardMode
+{
+    Room,
+    Stack,
+}

--- a/TRRandomizerCore/TRRandomizerController.cs
+++ b/TRRandomizerCore/TRRandomizerController.cs
@@ -1036,6 +1036,12 @@ public class TRRandomizerController
         set => LevelRandomizer.GuaranteeSecrets = value;
     }
 
+    public TRSecretRewardMode SecretRewardMode
+    {
+        get => LevelRandomizer.SecretRewardMode;
+        set => LevelRandomizer.SecretRewardMode = value;
+    }
+
     public bool UseRewardRoomCameras
     {
         get => LevelRandomizer.UseRewardRoomCameras;

--- a/TRRandomizerView/Controls/EditorControl.xaml
+++ b/TRRandomizerView/Controls/EditorControl.xaml
@@ -231,6 +231,7 @@
                                         BoolItemsSource="{Binding Data.SecretBoolItemControls, Source={StaticResource proxy}}"
                                         HasBoolItems="True"
                                         HasSecretPackMode="{Binding Data.IsSecretPackTypeSupported, Source={StaticResource proxy}}"
+                                        HasSecretRewardMode="{Binding Data.IsRewardRoomsTypeSupported, Source={StaticResource proxy}}"
                                         HasSecretCountMode="{Binding Data.IsSecretCountTypeSupported, Source={StaticResource proxy}}"
                                         ControllerProxy="{Binding Data, Source={StaticResource proxy}}">
                 </windows:AdvancedWindow>

--- a/TRRandomizerView/Model/ControllerOptions.cs
+++ b/TRRandomizerView/Model/ControllerOptions.cs
@@ -31,6 +31,8 @@ public class ControllerOptions : INotifyPropertyChanged
 
     private BoolItemControlClass _randomizeLevelSequencing;
     private BoolItemControlClass _isHardSecrets, _allowGlitched, _guaranteeSecrets, _useRewardRoomCameras, _useRandomSecretModels;
+    private TRSecretRewardMode[] _secretRewardModes;
+    private TRSecretRewardMode _secretRewardMode;
     private TRSecretCountMode _secretCountMode;
     private uint _minSecretCount, _maxSecretCount;
     private BoolItemControlClass _includeKeyItems, _allowReturnPathLocations, _includeExtraPickups, _randomizeItemTypes, _randomizeItemLocations, _allowEnemyKeyDrops, _maintainKeyContinuity;
@@ -2231,6 +2233,26 @@ public class ControllerOptions : INotifyPropertyChanged
         }
     }
 
+    public TRSecretRewardMode[] SecretRewardModes
+    {
+        get => _secretRewardModes;
+        private set
+        {
+            _secretRewardModes = value;
+            FirePropertyChanged();
+        }
+    }
+
+    public TRSecretRewardMode SecretRewardMode
+    {
+        get => _secretRewardMode;
+        set
+        {
+            _secretRewardMode = value;
+            FirePropertyChanged();
+        }
+    }
+
     public BoolItemControlClass UseRewardRoomCameras
     {
         get => _useRewardRoomCameras;
@@ -3434,6 +3456,8 @@ public class ControllerOptions : INotifyPropertyChanged
         IsHardSecrets.Value = _controller.HardSecrets;
         IsGlitchedSecrets.Value = _controller.GlitchedSecrets;
         GuaranteeSecrets.Value = _controller.GuaranteeSecrets;
+        SecretRewardModes = Enum.GetValues<TRSecretRewardMode>();
+        SecretRewardMode = _controller.SecretRewardMode;
         UseRewardRoomCameras.Value = _controller.UseRewardRoomCameras;
         UseRandomSecretModels.Value = _controller.UseRandomSecretModels;
         SecretCountMode = _controller.SecretCountMode;
@@ -3739,6 +3763,7 @@ public class ControllerOptions : INotifyPropertyChanged
         _controller.HardSecrets = IsHardSecrets.Value;
         _controller.GlitchedSecrets = IsGlitchedSecrets.Value;
         _controller.GuaranteeSecrets = GuaranteeSecrets.Value;
+        _controller.SecretRewardMode = SecretRewardMode;
         _controller.UseRewardRoomCameras = UseRewardRoomCameras.Value;
         _controller.UseRandomSecretModels = UseRandomSecretModels.Value;
         _controller.SecretCountMode = SecretCountMode;
@@ -3988,7 +4013,7 @@ public class ControllerOptions : INotifyPropertyChanged
         }
         else if (IsTR1Main || IsTR3Main)
         {
-            _randomSecretsControl.Description = "Randomize secret locations. Artefacts will be added as pickups and reward rooms created for collecting all secrets.";
+            _randomSecretsControl.Description = "Randomize secret locations. Artefacts will be added as pickups and either reward rooms created for collecting all secrets, or rewards will be stacked with the secrets.";
         }
         else
         {

--- a/TRRandomizerView/Model/ControllerOptions.cs
+++ b/TRRandomizerView/Model/ControllerOptions.cs
@@ -30,11 +30,12 @@ public class ControllerOptions : INotifyPropertyChanged
     private bool _addReturnPaths, _fixOGBugs, _disableDemos, _autoLaunchGame;
 
     private BoolItemControlClass _randomizeLevelSequencing;
-    private BoolItemControlClass _isHardSecrets, _allowGlitched, _guaranteeSecrets, _useRewardRoomCameras, _useRandomSecretModels;
+    private BoolItemControlClass _isHardSecrets, _allowGlitched, _guaranteeSecrets, _useRandomSecretModels;
     private TRSecretRewardMode[] _secretRewardModes;
     private TRSecretRewardMode _secretRewardMode;
     private TRSecretCountMode[] _secretCountModes;
     private TRSecretCountMode _secretCountMode;
+    private bool _useRewardRoomCameras;
     private uint _minSecretCount, _maxSecretCount;
     private BoolItemControlClass _includeKeyItems, _allowReturnPathLocations, _includeExtraPickups, _randomizeItemTypes, _randomizeItemLocations, _allowEnemyKeyDrops, _maintainKeyContinuity;
     private BoolItemControlClass _crossLevelEnemies, _protectMonks, _docileWillard, _swapEnemyAppearance, _allowEmptyEggs, _hideEnemies, _removeLevelEndingLarson, _giveUnarmedItems;
@@ -2264,7 +2265,7 @@ public class ControllerOptions : INotifyPropertyChanged
         }
     }
 
-    public BoolItemControlClass UseRewardRoomCameras
+    public bool UseRewardRoomCameras
     {
         get => _useRewardRoomCameras;
         set
@@ -2899,12 +2900,6 @@ public class ControllerOptions : INotifyPropertyChanged
             Description = "Guarantees that at least one hard and/or glitched secret (based on above selection) will appear in each level where possible."
         };
         BindingOperations.SetBinding(GuaranteeSecrets, BoolItemControlClass.IsActiveProperty, randomizeSecretsBinding);
-        UseRewardRoomCameras = new BoolItemControlClass()
-        {
-            Title = "Enable reward room cameras",
-            Description = "When picking up secrets, show a hint where the reward room for the level is located."
-        };
-        BindingOperations.SetBinding(UseRewardRoomCameras, BoolItemControlClass.IsActiveProperty, randomizeSecretsBinding);
         UseRandomSecretModels = new BoolItemControlClass()
         {
             Title = "Use random secret types",
@@ -3254,7 +3249,7 @@ public class ControllerOptions : INotifyPropertyChanged
         };
         SecretBoolItemControls = new List<BoolItemControlClass>()
         {
-            _isHardSecrets, _allowGlitched, _guaranteeSecrets, _useRewardRoomCameras, _useRandomSecretModels
+            _isHardSecrets, _allowGlitched, _guaranteeSecrets, _useRandomSecretModels
         };
         ItemBoolItemControls = new List<BoolItemControlClass>()
         {
@@ -3326,7 +3321,6 @@ public class ControllerOptions : INotifyPropertyChanged
 
         _changeWeaponSFX.IsAvailable = _changeCrashSFX.IsAvailable = _changeEnemySFX.IsAvailable = _linkCreatureSFX.IsAvailable = _changeDoorSFX.IsAvailable = IsSFXTypeSupported;
 
-        _useRewardRoomCameras.IsAvailable = IsRewardRoomsTypeSupported;
         _useRandomSecretModels.IsAvailable = IsSecretModelsTypeSupported;
 
         _swapEnemyAppearance.IsAvailable = IsMeshSwapsTypeSupported;
@@ -3476,7 +3470,7 @@ public class ControllerOptions : INotifyPropertyChanged
         GuaranteeSecrets.Value = _controller.GuaranteeSecrets;
         SecretRewardModes = Enum.GetValues<TRSecretRewardMode>();
         SecretRewardMode = _controller.SecretRewardMode;
-        UseRewardRoomCameras.Value = _controller.UseRewardRoomCameras;
+        UseRewardRoomCameras = _controller.UseRewardRoomCameras;
         UseRandomSecretModels.Value = _controller.UseRandomSecretModels;
         SecretCountModes = Enum.GetValues<TRSecretCountMode>();
         SecretCountMode = _controller.SecretCountMode;
@@ -3783,7 +3777,7 @@ public class ControllerOptions : INotifyPropertyChanged
         _controller.GlitchedSecrets = IsGlitchedSecrets.Value;
         _controller.GuaranteeSecrets = GuaranteeSecrets.Value;
         _controller.SecretRewardMode = SecretRewardMode;
-        _controller.UseRewardRoomCameras = UseRewardRoomCameras.Value;
+        _controller.UseRewardRoomCameras = UseRewardRoomCameras;
         _controller.UseRandomSecretModels = UseRandomSecretModels.Value;
         _controller.SecretCountMode = SecretCountMode;
         _controller.MinSecretCount = MinSecretCount;

--- a/TRRandomizerView/Model/ControllerOptions.cs
+++ b/TRRandomizerView/Model/ControllerOptions.cs
@@ -1000,6 +1000,16 @@ public class ControllerOptions : INotifyPropertyChanged
         ColdLevelCount = (uint)Math.Min(ColdLevelCount, MaximumLevelCount);
     }
 
+    private void UpdateSeparateSecretTracks()
+    {
+        bool available = IsTR2 || !RandomizeSecrets || SecretRewardMode == TRSecretRewardMode.Stack;
+        if (available != _separateSecretTracks.IsActive)
+        {
+            _separateSecretTracks.IsActive = available;
+            FirePropertyChanged(nameof(SeparateSecretTracks));
+        }
+    }
+
     public bool RandomizationPossible
     {
         get => RandomizeGameMode || RandomizeUnarmedLevels || RandomizeAmmolessLevels || RandomizeSecretRewards || RandomizeHealth || RandomizeSunsets ||
@@ -1651,9 +1661,8 @@ public class ControllerOptions : INotifyPropertyChanged
         set
         {
             _randomSecretsControl.IsActive = value;
-            _separateSecretTracks.IsActive = IsTR2 || !value;
             FirePropertyChanged();
-            FirePropertyChanged(nameof(SeparateSecretTracks));
+            UpdateSeparateSecretTracks();
         }
     }
 
@@ -2250,6 +2259,7 @@ public class ControllerOptions : INotifyPropertyChanged
         {
             _secretRewardMode = value;
             FirePropertyChanged();
+            UpdateSeparateSecretTracks();
         }
     }
 

--- a/TRRandomizerView/Model/ControllerOptions.cs
+++ b/TRRandomizerView/Model/ControllerOptions.cs
@@ -33,6 +33,7 @@ public class ControllerOptions : INotifyPropertyChanged
     private BoolItemControlClass _isHardSecrets, _allowGlitched, _guaranteeSecrets, _useRewardRoomCameras, _useRandomSecretModels;
     private TRSecretRewardMode[] _secretRewardModes;
     private TRSecretRewardMode _secretRewardMode;
+    private TRSecretCountMode[] _secretCountModes;
     private TRSecretCountMode _secretCountMode;
     private uint _minSecretCount, _maxSecretCount;
     private BoolItemControlClass _includeKeyItems, _allowReturnPathLocations, _includeExtraPickups, _randomizeItemTypes, _randomizeItemLocations, _allowEnemyKeyDrops, _maintainKeyContinuity;
@@ -2283,6 +2284,16 @@ public class ControllerOptions : INotifyPropertyChanged
         }
     }
 
+    public TRSecretCountMode[] SecretCountModes
+    {
+        get => _secretCountModes;
+        private set
+        {
+            _secretCountModes = value;
+            FirePropertyChanged();
+        }
+    }
+
     public TRSecretCountMode SecretCountMode
     {
         get => _secretCountMode;
@@ -2290,11 +2301,8 @@ public class ControllerOptions : INotifyPropertyChanged
         {
             _secretCountMode = value;
             FirePropertyChanged();
-            FirePropertyChanged(nameof(IsCustomizedSecretModeCount));
         }
     }
-
-    public bool IsCustomizedSecretModeCount => SecretCountMode == TRSecretCountMode.Customized;
 
     public uint MinSecretCount
     {
@@ -3470,6 +3478,7 @@ public class ControllerOptions : INotifyPropertyChanged
         SecretRewardMode = _controller.SecretRewardMode;
         UseRewardRoomCameras.Value = _controller.UseRewardRoomCameras;
         UseRandomSecretModels.Value = _controller.UseRandomSecretModels;
+        SecretCountModes = Enum.GetValues<TRSecretCountMode>();
         SecretCountMode = _controller.SecretCountMode;
         MaxSecretCount = _controller.MaxSecretCount;
         MinSecretCount = _controller.MinSecretCount;            

--- a/TRRandomizerView/Windows/AdvancedWindow.xaml
+++ b/TRRandomizerView/Windows/AdvancedWindow.xaml
@@ -1573,7 +1573,7 @@
             <!-- Reward Mode -->
             <StackPanel
                 Grid.Row="20"
-                Visibility="{Binding ControllerProxy.IsRewardRoomsTypeSupported, Converter={StaticResource BoolToCollapsedConverter}}">
+                Visibility="{Binding HasSecretRewardMode, Converter={StaticResource BoolToCollapsedConverter}}">
 
                 <StackPanel.Resources>
                     <cvt:ComparisonConverter x:Key="ComparisonConverter" />
@@ -1668,7 +1668,7 @@
                             <Label
                                 Content="Min"
                                 VerticalAlignment="Center"
-                                Padding="0,0,3,0" Margin="0"/>
+                                Padding="0,0,3,0"/>
                             <ctrl:NumericUpDown
                                 HorizontalAlignment="Left"
                                 VerticalAlignment="Center"
@@ -1679,7 +1679,7 @@
                             <Label
                                 Content="Max"
                                 VerticalAlignment="Center"
-                                Padding="6,0,3,0" Margin="0"/>
+                                Padding="6,0,3,0"/>
                             <ctrl:NumericUpDown
                                 HorizontalAlignment="Left"
                                 VerticalAlignment="Center"

--- a/TRRandomizerView/Windows/AdvancedWindow.xaml
+++ b/TRRandomizerView/Windows/AdvancedWindow.xaml
@@ -1631,9 +1631,6 @@
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" SharedSizeGroup="SSG1"/>
@@ -1641,95 +1638,56 @@
                     </Grid.ColumnDefinitions>
 
                     <Border>
-                        <RadioButton Content="Default"
-                                     GroupName="secretCount"
-                                     x:Name="_defaultSecretCountButton"
-                                     VerticalAlignment="Center"
-                                     Padding="4,0,0,0"
-                                     IsChecked="{Binding ControllerProxy.SecretCountMode, Converter={StaticResource ComparisonConverter}, ConverterParameter={x:Static secrets:TRSecretCountMode.Default}, Mode=TwoWay}"/>
+                        <ComboBox
+                            ItemsSource="{Binding ControllerProxy.SecretCountModes}"
+                            SelectedItem="{Binding ControllerProxy.SecretCountMode, Mode=TwoWay}"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Center"/>
                     </Border>
 
-                    <Border Grid.Column="1">
-                        <Label Style="{StaticResource OptionDescriptionStyle}"
-                               Content="The number of secrets per level will match the original game."/>
+                    <Border Grid.Column="1"
+                            Grid.RowSpan="2">
+                        <Label Style="{StaticResource OptionDescriptionStyle}">
+                            <Label.Content>
+                                <TextBlock>
+                                    <Run>Choose the number of secrets per level.</Run>
+                                    <LineBreak/>
+                                    <Run>- Default: the number of secrets per level will match the original game.</Run>
+                                    <LineBreak/>
+                                    <Run>- Shuffled: each level will take on the secret count of another - the total number of secrets in the game will remain the same.</Run>
+                                    <LineBreak/>
+                                    <Run>- Customized: each level will be assigned a random number of secrets in the given range.</Run>
+                                </TextBlock>
+                            </Label.Content>
+                        </Label>
                     </Border>
 
-                    <Border Grid.Row="1">
-                        <RadioButton Content="Shuffled"
-                                     GroupName="secretCount"
-                                     x:Name="_shuffledSecretCountButton"
-                                     VerticalAlignment="Center"
-                                     Padding="4,0,0,0"
-                                     IsChecked="{Binding ControllerProxy.SecretCountMode, Converter={StaticResource ComparisonConverter}, ConverterParameter={x:Static secrets:TRSecretCountMode.Shuffled}, Mode=TwoWay}"/>
-                    </Border>
-
-                    <Border Grid.Row="1"
-                            Grid.Column="1">
-                        <Label Style="{StaticResource OptionDescriptionStyle}"
-                            Content="Each level will take on the secret count of another - the total number of secrets in the game will remain the same."/>
-                    </Border>
-
-                    <Border Grid.Row="2">
-                        <RadioButton Content="Customized"
-                                     GroupName="secretCount"
-                                     x:Name="_customizedSecretCountButton"
-                                     VerticalAlignment="Center"
-                                     Padding="4,0,0,0"
-                                     IsChecked="{Binding ControllerProxy.SecretCountMode, Converter={StaticResource ComparisonConverter}, ConverterParameter={x:Static secrets:TRSecretCountMode.Customized}, Mode=TwoWay}"/>
-                    </Border>
-
-                    <Border Grid.Row="2"
-                            Grid.Column="1">
-                        <Label Style="{StaticResource OptionDescriptionStyle}"
-                            Content="Each level will be assigned a random number of secrets in the given range."/>
-                    </Border>
-
-                    <Border Grid.Row="3" Margin="20,3,0,0"
-                            IsEnabled="{Binding ControllerProxy.IsCustomizedSecretModeCount}">
-                        <Grid>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto"/>
-                            </Grid.RowDefinitions>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SSG3"/>
-                                <ColumnDefinition Width="Auto"/>
-                            </Grid.ColumnDefinitions>
-
-                            <Label Content="Minimum value"
-                                   VerticalAlignment="Center"
-                                   Padding="0,0,5,0" Margin="0"/>
-
-                            <ctrl:NumericUpDown HorizontalAlignment="Left"
-                                                Grid.Column="1"
-                                                VerticalAlignment="Center"  
-                                                Value="{Binding ControllerProxy.MinSecretCount, Mode=TwoWay}"
-                                                MinValue="1"
-                                                MaxValue="{Binding ControllerProxy.MaxSecretCount}"/>
-                        </Grid>
-                    </Border>
-
-                    <Border Grid.Row="4" Margin="20,3,0,0"
-                            IsEnabled="{Binding ControllerProxy.IsCustomizedSecretModeCount}">
-                        <Grid>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto"/>
-                            </Grid.RowDefinitions>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SSG3"/>
-                                <ColumnDefinition Width="Auto"/>
-                            </Grid.ColumnDefinitions>
-
-                            <Label Content="Maximum value"
-                                   VerticalAlignment="Center"
-                                   Padding="0,0,5,0" Margin="0"/>
-
-                            <ctrl:NumericUpDown HorizontalAlignment="Left"
-                                                Grid.Column="1"
-                                                VerticalAlignment="Center"  
-                                                Value="{Binding ControllerProxy.MaxSecretCount, Mode=TwoWay}"
-                                                MinValue="{Binding ControllerProxy.MinSecretCount}"
-                                                MaxValue="5"/>
-                        </Grid>
+                    <Border Grid.Row="1" Margin="0,8,0,0"
+                            IsEnabled="{Binding ControllerProxy.SecretCountMode, Converter={StaticResource ComparisonConverter}, ConverterParameter={x:Static secrets:TRSecretCountMode.Customized}, Mode=TwoWay}">
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                            <Label
+                                Content="Min"
+                                VerticalAlignment="Center"
+                                Padding="0,0,3,0" Margin="0"/>
+                            <ctrl:NumericUpDown
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center"
+                                MinWidth="50"
+                                Value="{Binding ControllerProxy.MinSecretCount, Mode=TwoWay}"
+                                MinValue="1"
+                                MaxValue="{Binding ControllerProxy.MaxSecretCount}"/>
+                            <Label
+                                Content="Max"
+                                VerticalAlignment="Center"
+                                Padding="6,0,3,0" Margin="0"/>
+                            <ctrl:NumericUpDown
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center"
+                                MinWidth="50"
+                                Value="{Binding ControllerProxy.MaxSecretCount, Mode=TwoWay}"
+                                MinValue="{Binding ControllerProxy.MinSecretCount}"
+                                MaxValue="5"/>
+                        </StackPanel>
                     </Border>
                 </Grid>
             </StackPanel>

--- a/TRRandomizerView/Windows/AdvancedWindow.xaml
+++ b/TRRandomizerView/Windows/AdvancedWindow.xaml
@@ -1570,8 +1570,54 @@
                 </Grid>
             </StackPanel>
 
+            <!-- Reward Mode -->
+            <StackPanel
+                Grid.Row="20"
+                Visibility="{Binding ControllerProxy.IsRewardRoomsTypeSupported, Converter={StaticResource BoolToCollapsedConverter}}">
+
+                <StackPanel.Resources>
+                    <cvt:ComparisonConverter x:Key="ComparisonConverter" />
+                </StackPanel.Resources>
+
+                <TextBlock
+                    Style="{StaticResource HeaderStyle}"
+                    Text="Secret Reward Mode"/>
+
+                <Grid Margin="0,5,0,5">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" SharedSizeGroup="SSG1" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <Border VerticalAlignment="Top">
+                        <ComboBox
+                            ItemsSource="{Binding ControllerProxy.SecretRewardModes}"
+                            SelectedItem="{Binding ControllerProxy.SecretRewardMode, Mode=TwoWay}"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Center"/>
+                    </Border>
+
+                    <Border Grid.Column="1">
+                        <Label Style="{StaticResource OptionDescriptionStyle}">
+                            <Label.Content>
+                                <TextBlock>
+                                    <Run>Choose how you are rewarded for collecting secrets.</Run>
+                                    <LineBreak/>
+                                    <Run>- Room: a room will be added near the end of the level and will hold all reward items. Every secret in the level will need to be collected to access the room.</Run>
+                                    <LineBreak/>
+                                    <Run>- Stack: a stack of items will be added at the same location as each secret artefact.</Run>
+                                </TextBlock>
+                            </Label.Content>
+                        </Label>
+                    </Border>
+                </Grid>
+            </StackPanel>
+            
             <!-- Secret Count -->
-            <StackPanel Grid.Row="20"
+            <StackPanel Grid.Row="21"
                         Visibility="{Binding HasSecretCountMode, Converter={StaticResource BoolToCollapsedConverter}}"
                         IsEnabled="{Binding ControllerProxy.UseGenericSecrets}">
                 <StackPanel.Resources>
@@ -1689,7 +1735,7 @@
             </StackPanel>
 
             <!-- Secret Packs -->
-            <StackPanel Grid.Row="21"
+            <StackPanel Grid.Row="22"
                         Visibility="{Binding HasSecretPackMode, Converter={StaticResource BoolToCollapsedConverter}}">
                 <StackPanel.Resources>
                     <cvt:ComparisonConverter x:Key="ComparisonConverter" />
@@ -1741,7 +1787,7 @@
             </StackPanel>
 
             <!-- Weather -->
-            <StackPanel Grid.Row="22"
+            <StackPanel Grid.Row="23"
                         Visibility="{Binding HasWeatherMode, Converter={StaticResource BoolToCollapsedConverter}}">
 
                 <TextBlock Style="{StaticResource HeaderStyle}"
@@ -1853,7 +1899,7 @@
             
             <!-- Enemy Clones -->
             <StackPanel
-                Grid.Row="23"
+                Grid.Row="24"
                 Visibility="{Binding HasClonedEnemyMode, Converter={StaticResource BoolToCollapsedConverter}}">
                 <TextBlock
                     Style="{StaticResource HeaderStyle}"

--- a/TRRandomizerView/Windows/AdvancedWindow.xaml
+++ b/TRRandomizerView/Windows/AdvancedWindow.xaml
@@ -1586,6 +1586,7 @@
                 <Grid Margin="0,5,0,5">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" SharedSizeGroup="SSG1" />
@@ -1600,6 +1601,19 @@
                             VerticalAlignment="Center"/>
                     </Border>
 
+                    <Border
+                        Grid.Row="1"
+                        Margin="0,6,0,0">
+                        <CheckBox
+                            IsChecked="{Binding ControllerProxy.UseRewardRoomCameras, Mode=TwoWay}"
+                            IsEnabled="{Binding ControllerProxy.SecretRewardMode, Converter={StaticResource ComparisonConverter}, ConverterParameter={x:Static secrets:TRSecretRewardMode.Room}, Mode=TwoWay}"
+                            VerticalAlignment="Center">
+                            <Label
+                                Padding="0"
+                                Content="Enable reward room cameras" />
+                        </CheckBox>
+                    </Border>
+
                     <Border Grid.Column="1">
                         <Label Style="{StaticResource OptionDescriptionStyle}">
                             <Label.Content>
@@ -1612,6 +1626,15 @@
                                 </TextBlock>
                             </Label.Content>
                         </Label>
+                    </Border>
+
+                    <Border
+                        Grid.Column="1"
+                        Grid.Row="1"
+                        Margin="0,6,0,0">
+                        <Label
+                            Style="{StaticResource OptionDescriptionStyle}"
+                            Content="When picking up secrets, show a hint where the reward room for the level is located."/>
                     </Border>
                 </Grid>
             </StackPanel>

--- a/TRRandomizerView/Windows/AdvancedWindow.xaml.cs
+++ b/TRRandomizerView/Windows/AdvancedWindow.xaml.cs
@@ -119,6 +119,11 @@ public partial class AdvancedWindow : Window
         nameof(HasSecretCountMode), typeof(bool), typeof(AdvancedWindow)
     );
 
+    public static readonly DependencyProperty HasSecretRewardModeProperty = DependencyProperty.Register
+    (
+        nameof(HasSecretRewardMode), typeof(bool), typeof(AdvancedWindow)
+    );
+
     public static readonly DependencyProperty HasSecretPackModeProperty = DependencyProperty.Register
     (
         nameof(HasSecretPackMode), typeof(bool), typeof(AdvancedWindow)
@@ -263,6 +268,12 @@ public partial class AdvancedWindow : Window
     {
         get => (bool)GetValue(HasSecretCountModeProperty);
         set => SetValue(HasSecretCountModeProperty, value);
+    }
+
+    public bool HasSecretRewardMode
+    {
+        get => (bool)GetValue(HasSecretRewardModeProperty);
+        set => SetValue(HasSecretRewardModeProperty, value);
     }
 
     public bool HasSecretPackMode

--- a/TRRandomizerView/Windows/AdvancedWindow.xaml.cs
+++ b/TRRandomizerView/Windows/AdvancedWindow.xaml.cs
@@ -368,21 +368,6 @@ public partial class AdvancedWindow : Window
                     break;
             }
         }
-        if (HasSecretCountMode)
-        {
-            switch (ControllerProxy.SecretCountMode)
-            {
-                case TRSecretCountMode.Default:
-                    _defaultSecretCountButton.IsChecked = true;
-                    break;
-                case TRSecretCountMode.Shuffled:
-                    _shuffledSecretCountButton.IsChecked = true;
-                    break;
-                case TRSecretCountMode.Customized:
-                    _customizedSecretCountButton.IsChecked = true;
-                    break;
-            }
-        }
         if (HasItemSpriteRandomization)
         {
             switch (ControllerProxy.SpriteRandoMode)

--- a/TRRandomizerView/Windows/TR1XWindow.xaml
+++ b/TRRandomizerView/Windows/TR1XWindow.xaml
@@ -1402,7 +1402,7 @@
                             <CheckBox IsChecked="{Binding ControllerProxy.FixSecretsKillingMusic, Mode=TwoWay}"
                                       VerticalAlignment="Center">
                                 <Label Padding="0"
-                                       Content="Fix secrets killing music" />
+                                       Content="Fix secrets killing music *" />
                             </CheckBox>
                         </Border>
                         <Border Grid.Row="5"
@@ -1418,7 +1418,7 @@
                             <CheckBox IsChecked="{Binding ControllerProxy.FixSpeechesKillingMusic, Mode=TwoWay}"
                                       VerticalAlignment="Center">
                                 <Label Padding="0"
-                                       Content="Fix speech killing music" />
+                                       Content="Fix speech killing music *" />
                             </CheckBox>
                         </Border>
                         <Border Grid.Row="6"


### PR DESCRIPTION
Resolves #687.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Because reward rooms aren't possible in TRR, rewards are stacked on top of secrets, so this change makes that an optional feature for the classics too. Separate secret trigger music is also now supported in TR1/3 if using stacks. We can't use these with reward rooms because of the trigger masks on the secrets.

I've moved most of the reward room logic into `SecretArtefactPlacer`, so a little more duplication has been cut out.

The item allocators for TR1/3 reference the new option when deciding whether or not to exclude reward rooms, mentioned in #688.

The secret options window has been tidied up a little too. Every time there is a UI update I'm reminded the whole thing needs a revamp, but that's for another day.