### PR TITLE
Add weapon difficulty option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - added an option to stack rewards with secrets in TR1 and TR3, rather than using reward rooms (#687)
 - added separate secret audio for TR1 and TR3 when not using reward rooms (#687)
 - added an option to shuffle items rather than randomize their types and locations in each level (#625)
+- added an option to control weapon allocation in item randomization (#690)
 - fixed several potential key item softlocks in TR2 (#691)
 - fixed a key item softlock in Crash Site (#662)
 - fixed incorrect item and mesh positions in Home Sweet Home when mirrored (#676)

--- a/TRRandomizerCore/Editors/RandomizerSettings.cs
+++ b/TRRandomizerCore/Editors/RandomizerSettings.cs
@@ -212,7 +212,7 @@ public class RandomizerSettings
         RandomizeItems = config.GetBool(nameof(RandomizeItems));
         ItemSeed = config.GetInt(nameof(ItemSeed), defaultSeed);
         ItemMode = (ItemMode)config.GetEnum(nameof(ItemMode), typeof(ItemMode), ItemMode.Default);
-        WeaponDifficulty = (WeaponDifficulty)config.GetEnum(nameof(WeaponDifficulty), typeof(WeaponDifficulty), WeaponDifficulty.Fair);
+        WeaponDifficulty = (WeaponDifficulty)config.GetEnum(nameof(WeaponDifficulty), typeof(WeaponDifficulty), WeaponDifficulty.Easy);
         IncludeKeyItems = config.GetBool(nameof(IncludeKeyItems), true);
         KeyItemRange = (ItemRange)config.GetEnum(nameof(KeyItemRange), typeof(ItemRange), ItemRange.Medium);
         AllowEnemyKeyDrops = config.GetBool(nameof(AllowEnemyKeyDrops), true);

--- a/TRRandomizerCore/Editors/RandomizerSettings.cs
+++ b/TRRandomizerCore/Editors/RandomizerSettings.cs
@@ -40,6 +40,7 @@ public class RandomizerSettings
     public GlobeDisplayOption GlobeDisplay { get; set; }
     public bool HardSecrets { get; set; }
     public ItemMode ItemMode { get; set; }
+    public WeaponDifficulty WeaponDifficulty { get; set; }
     public bool IncludeKeyItems { get; set; }
     public bool AllowReturnPathLocations { get; set; }
     public ItemRange KeyItemRange { get; set; }
@@ -211,6 +212,7 @@ public class RandomizerSettings
         RandomizeItems = config.GetBool(nameof(RandomizeItems));
         ItemSeed = config.GetInt(nameof(ItemSeed), defaultSeed);
         ItemMode = (ItemMode)config.GetEnum(nameof(ItemMode), typeof(ItemMode), ItemMode.Default);
+        WeaponDifficulty = (WeaponDifficulty)config.GetEnum(nameof(WeaponDifficulty), typeof(WeaponDifficulty), WeaponDifficulty.Fair);
         IncludeKeyItems = config.GetBool(nameof(IncludeKeyItems), true);
         KeyItemRange = (ItemRange)config.GetEnum(nameof(KeyItemRange), typeof(ItemRange), ItemRange.Medium);
         AllowEnemyKeyDrops = config.GetBool(nameof(AllowEnemyKeyDrops), true);
@@ -380,6 +382,7 @@ public class RandomizerSettings
         config[nameof(RandomizeItems)] = RandomizeItems;
         config[nameof(ItemSeed)] = ItemSeed;
         config[nameof(ItemMode)] = ItemMode;
+        config[nameof(WeaponDifficulty)] = WeaponDifficulty;
         config[nameof(IncludeKeyItems)] = IncludeKeyItems;
         config[nameof(KeyItemRange)] = KeyItemRange;
         config[nameof(AllowEnemyKeyDrops)] = AllowEnemyKeyDrops;

--- a/TRRandomizerCore/Helpers/CollectionExtensions.cs
+++ b/TRRandomizerCore/Helpers/CollectionExtensions.cs
@@ -4,6 +4,9 @@ public static class CollectionExtensions
 {
     private const int _defaultShuffleCount = 5;
 
+    public static T RandomItem<T>(this List<T> list, Random random)
+        => list[random.Next(0, list.Count)];
+
     public static List<T> RandomSelection<T>(this List<T> list, Random rand, int count, bool allowDuplicates = false, ISet<T> exclusions = null)
     {
         count = Math.Abs(count);

--- a/TRRandomizerCore/Helpers/WeaponDifficulty.cs
+++ b/TRRandomizerCore/Helpers/WeaponDifficulty.cs
@@ -1,0 +1,8 @@
+﻿namespace TRRandomizerCore.Helpers;
+
+public enum WeaponDifficulty
+{
+    Easy,
+    Fair,
+    Hard,
+}

--- a/TRRandomizerCore/Randomizers/TR1/Classic/TR1ItemRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Classic/TR1ItemRandomizer.cs
@@ -23,6 +23,8 @@ public class TR1ItemRandomizer : BaseTR1Randomizer
             ItemFactory = ItemFactory,
         };
 
+        _allocator.AllocateWeapons(Levels.Where(l => !l.Is(TR1LevelNames.ASSAULT)));
+
         foreach (TR1ScriptedLevel lvl in Levels)
         {
             LoadLevelInstance(lvl);
@@ -117,6 +119,11 @@ public class TR1ItemRandomizer : BaseTR1Randomizer
     {
         List<TR1Type> stdItemTypes = TR1TypeUtilities.GetStandardPickupTypes();
         stdItemTypes.Remove(TR1Type.PistolAmmo_S_P);
+        if (Settings.WeaponDifficulty != WeaponDifficulty.Easy)
+        {
+            List<TR1Type> weapons = TR1TypeUtilities.GetWeaponPickups();
+            stdItemTypes.RemoveAll(weapons.Contains);
+        }
 
         foreach (TR1Entity enemy in level.Data.Entities.Where(e => TR1TypeUtilities.IsEnemyType(e.TypeID)))
         {

--- a/TRRandomizerCore/Randomizers/TR1/Remastered/TR1RItemRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Remastered/TR1RItemRandomizer.cs
@@ -22,6 +22,8 @@ public class TR1RItemRandomizer : BaseTR1RRandomizer
             ItemFactory = ItemFactory,
         };
 
+        _allocator.AllocateWeapons(Levels.Where(l => !l.Is(TR1LevelNames.ASSAULT)));
+
         foreach (TRRScriptedLevel lvl in Levels)
         {
             LoadLevelInstance(lvl);

--- a/TRRandomizerCore/Randomizers/TR1/Shared/TR1ItemAllocator.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Shared/TR1ItemAllocator.cs
@@ -196,7 +196,9 @@ public class TR1ItemAllocator : ItemAllocator<TR1Type, TR1Entity>
         }
 
         List<TR1Type> stdItemTypes = GetStandardItemTypes();
+        List<TR1Type> weaponTypes = GetWeaponItemTypes();
         stdItemTypes.Remove(GetPistolType());
+        stdItemTypes.RemoveAll(weaponTypes.Contains);
 
         // Add what we can to the level. The locations and types may be further randomized depending on the selected options.
         for (int i = 0; i < _extraItemCounts[levelName]; i++)

--- a/TRRandomizerCore/Randomizers/TR2/Classic/TR2ItemRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR2/Classic/TR2ItemRandomizer.cs
@@ -36,6 +36,8 @@ public class TR2ItemRandomizer : BaseTR2Randomizer
             ItemFactory = ItemFactory,
         };
 
+        _allocator.AllocateWeapons(Levels.Where(l => !l.Is(TR2LevelNames.ASSAULT)));
+
         foreach (TR2ScriptedLevel lvl in Levels)
         {
             LoadLevelInstance(lvl);

--- a/TRRandomizerCore/Randomizers/TR2/Remastered/TR2RItemRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR2/Remastered/TR2RItemRandomizer.cs
@@ -1,4 +1,5 @@
 ﻿using TRGE.Core;
+using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRRandomizerCore.Helpers;
 
@@ -21,6 +22,8 @@ public class TR2RItemRandomizer : BaseTR2RRandomizer
             Settings = Settings,
             ItemFactory = ItemFactory,
         };
+
+        _allocator.AllocateWeapons(Levels.Where(l => !l.Is(TR2LevelNames.ASSAULT)));
 
         foreach (TRRScriptedLevel lvl in Levels)
         {

--- a/TRRandomizerCore/Randomizers/TR3/Classic/TR3ItemRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Classic/TR3ItemRandomizer.cs
@@ -41,6 +41,8 @@ public class TR3ItemRandomizer : BaseTR3Randomizer
             ItemFactory = ItemFactory,
         };
 
+        _allocator.AllocateWeapons(Levels.Where(l => !l.Is(TR3LevelNames.ASSAULT)));
+
         foreach (TR3ScriptedLevel lvl in Levels)
         {
             LoadLevelInstance(lvl);

--- a/TRRandomizerCore/Randomizers/TR3/Remastered/TR3RItemRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Remastered/TR3RItemRandomizer.cs
@@ -1,4 +1,5 @@
 ﻿using TRGE.Core;
+using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRRandomizerCore.Helpers;
 
@@ -19,6 +20,8 @@ public class TR3RItemRandomizer : BaseTR3RRandomizer
             Settings = Settings,
             ItemFactory = ItemFactory,
         };
+
+        _allocator.AllocateWeapons(Levels.Where(l => !l.Is(TR3LevelNames.ASSAULT)));
 
         foreach (TRRScriptedLevel lvl in Levels)
         {

--- a/TRRandomizerCore/TRRandomizerController.cs
+++ b/TRRandomizerCore/TRRandomizerController.cs
@@ -1107,6 +1107,12 @@ public class TRRandomizerController
         set => LevelRandomizer.ItemMode = value;
     }
 
+    public WeaponDifficulty WeaponDifficulty
+    {
+        get => LevelRandomizer.WeaponDifficulty;
+        set => LevelRandomizer.WeaponDifficulty = value;
+    }
+
     public bool IncludeKeyItems
     {
         get => LevelRandomizer.IncludeKeyItems;

--- a/TRRandomizerView/Model/ControllerOptions.cs
+++ b/TRRandomizerView/Model/ControllerOptions.cs
@@ -112,6 +112,9 @@ public class ControllerOptions : INotifyPropertyChanged
     private ItemMode _itemMode;
     private ItemMode[] _itemModes;
 
+    private WeaponDifficulty _weaponDifficulty;
+    private WeaponDifficulty[] _weaponDifficulties;
+
     #region TR1X Sepcifics
 
     private bool _enableGameModes;
@@ -1027,6 +1030,7 @@ public class ControllerOptions : INotifyPropertyChanged
         AllowReturnPathLocations.IsActive = !defaultMode || IncludeKeyItems.Value;
         AllowEnemyKeyDrops.IsActive = !defaultMode || IncludeKeyItems.Value;
 
+        FirePropertyChanged(nameof(WeaponDifficultyAvailable));
         FirePropertyChanged(nameof(IncludeKeyItemsImplied));
     }
 
@@ -1750,6 +1754,31 @@ public class ControllerOptions : INotifyPropertyChanged
             _itemModes = value;
             FirePropertyChanged();
         }
+    }
+
+    public WeaponDifficulty WeaponDifficulty
+    {
+        get => _weaponDifficulty;
+        set
+        {
+            _weaponDifficulty = value;
+            FirePropertyChanged();
+        }
+    }
+
+    public WeaponDifficulty[] WeaponDifficulties
+    {
+        get => _weaponDifficulties;
+        private set
+        {
+            _weaponDifficulties = value;
+            FirePropertyChanged();
+        }
+    }
+
+    public bool WeaponDifficultyAvailable
+    {
+        get => ItemMode == ItemMode.Default && RandomizeItemTypes.Value;
     }
 
     public BoolItemControlClass IncludeKeyItems
@@ -2972,6 +3001,9 @@ public class ControllerOptions : INotifyPropertyChanged
             Description = "The types of standard pickups will be randomized e.g. a small medi may become a shotgun."
         };
         BindingOperations.SetBinding(RandomizeItemTypes, BoolItemControlClass.IsActiveProperty, randomizeItemsBinding);
+
+        RandomizeItemTypes.PropertyChanged += (s, e) => FirePropertyChanged(nameof(WeaponDifficultyAvailable));
+
         RandomizeItemPositions = new BoolItemControlClass
         {
             Title = "Randomize positions",
@@ -3493,6 +3525,8 @@ public class ControllerOptions : INotifyPropertyChanged
         ItemSeed = _controller.ItemSeed;
         ItemModes = Enum.GetValues<ItemMode>();
         ItemMode = _controller.ItemMode;
+        WeaponDifficulties = Enum.GetValues<WeaponDifficulty>();
+        WeaponDifficulty = _controller.WeaponDifficulty;
         IncludeKeyItems.Value = _controller.IncludeKeyItems;
         AllowReturnPathLocations.Value = _controller.AllowReturnPathLocations;
         IncludeExtraPickups.Value = _controller.IncludeExtraPickups;
@@ -3802,6 +3836,7 @@ public class ControllerOptions : INotifyPropertyChanged
         _controller.RandomizeItems = RandomizeItems;
         _controller.ItemSeed = ItemSeed;
         _controller.ItemMode = ItemMode;
+        _controller.WeaponDifficulty = WeaponDifficulty;
         _controller.IncludeKeyItems = IncludeKeyItems.Value;
         _controller.AllowReturnPathLocations = AllowReturnPathLocations.Value;
         _controller.IncludeExtraPickups = IncludeExtraPickups.Value;

--- a/TRRandomizerView/Windows/AdvancedWindow.xaml
+++ b/TRRandomizerView/Windows/AdvancedWindow.xaml
@@ -64,9 +64,11 @@
                     <Setter Property="Grid.ColumnSpan"
                             Value="2" />
                 </Style>
+                <cvt:ComparisonConverter x:Key="ComparisonConverter" />
             </Grid.Resources>
 
             <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
@@ -111,10 +113,6 @@
             <StackPanel
                 Grid.Row="1"
                 Visibility="{Binding HasItemDifficulty, Converter={StaticResource BoolToCollapsedConverter}}">
-                <StackPanel.Resources>
-                    <cvt:ComparisonConverter x:Key="ComparisonConverter" />
-                </StackPanel.Resources>
-
                 <TextBlock
                     Style="{StaticResource HeaderStyle}"
                     Text="Item Mode"/>
@@ -194,15 +192,45 @@
                 </ItemsControl>
             </StackPanel>
 
-            <!-- (Key Item) Difficulty -->
+            <!-- Weapon Difficulty -->
             <StackPanel
                 Grid.Row="3"
+                Visibility="{Binding HasItemDifficulty, Converter={StaticResource BoolToCollapsedConverter}}"
+                IsEnabled="{Binding ControllerProxy.WeaponDifficultyAvailable}">
+                <TextBlock
+                    Style="{StaticResource HeaderStyle}"
+                    Text="Weapon Difficulty"/>
+
+                <Grid Margin="0,5,0,0">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" SharedSizeGroup="SSG1" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <Border VerticalAlignment="Top">
+                        <ComboBox
+                            ItemsSource="{Binding ControllerProxy.WeaponDifficulties}"
+                            SelectedItem="{Binding ControllerProxy.WeaponDifficulty, Mode=TwoWay}"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Center"/>
+                    </Border>
+
+                    <Border Grid.Column="1">
+                        <Label
+                            Style="{StaticResource OptionDescriptionStyle}"
+                            Content="Sets the relative difficulty of how weapons are allocated throughout the game."/>
+                    </Border>
+                </Grid>
+            </StackPanel>
+            
+            <!-- (Key Item) Difficulty -->
+            <StackPanel
+                Grid.Row="4"
                 IsEnabled="{Binding ControllerProxy.IncludeKeyItemsImplied}"
                 Visibility="{Binding HasItemDifficulty, Converter={StaticResource BoolToCollapsedConverter}}">
-                <StackPanel.Resources>
-                    <cvt:ComparisonConverter x:Key="ComparisonConverter" />
-                </StackPanel.Resources>
-
                 <TextBlock
                     Style="{StaticResource HeaderStyle}"
                     Text="Key Item Range" />
@@ -242,12 +270,8 @@
             </StackPanel>
 
             <!-- (Item) SpriteRandomization -->
-            <StackPanel Grid.Row="4"
+            <StackPanel Grid.Row="5"
                         Visibility="{Binding HasItemSpriteRandomization, Converter={StaticResource BoolToCollapsedConverter}}">
-                <StackPanel.Resources>
-                    <cvt:ComparisonConverter x:Key="ComparisonConverter" />
-                </StackPanel.Resources>
-
                 <TextBlock Style="{StaticResource HeaderStyle}"
                            Text="Sprite Randomization" />
 
@@ -338,12 +362,8 @@
             </StackPanel>
 
             <!-- Chicken Behaviour -->
-            <StackPanel Grid.Row="5"
+            <StackPanel Grid.Row="6"
                         Visibility="{Binding HasBirdMonsterBehaviour, Converter={StaticResource BoolToCollapsedConverter}}">
-                <StackPanel.Resources>
-                    <cvt:ComparisonConverter x:Key="ComparisonConverter" />
-                </StackPanel.Resources>
-
                 <TextBlock Style="{StaticResource HeaderStyle}"
                            Text="Bird Monster Behaviour"/>
 
@@ -419,12 +439,8 @@
             </StackPanel>
 
             <!-- Dragon Spawn -->
-            <StackPanel Grid.Row="6"
+            <StackPanel Grid.Row="7"
                         Visibility="{Binding HasDragonSpawn, Converter={StaticResource BoolToCollapsedConverter}}">
-                <StackPanel.Resources>
-                    <cvt:ComparisonConverter x:Key="ComparisonConverter" />
-                </StackPanel.Resources>
-
                 <TextBlock Style="{StaticResource HeaderStyle}"
                            Text="Dragon Spawns"/>
 
@@ -486,12 +502,8 @@
             </StackPanel>
 
             <!-- (Enemy) Difficulty -->
-            <StackPanel Grid.Row="7"
+            <StackPanel Grid.Row="8"
                         Visibility="{Binding HasDifficulty, Converter={StaticResource BoolToCollapsedConverter}}">
-                <StackPanel.Resources>
-                    <cvt:ComparisonConverter x:Key="ComparisonConverter" />
-                </StackPanel.Resources>
-
                 <TextBlock Style="{StaticResource HeaderStyle}"
                            Text="Difficulty"/>
 
@@ -546,12 +558,8 @@
             </StackPanel>
 
             <!-- Enemy Exclusions -->
-            <StackPanel Grid.Row="8"
+            <StackPanel Grid.Row="9"
                         Visibility="{Binding HasDifficulty, Converter={StaticResource BoolToCollapsedConverter}}">
-                <StackPanel.Resources>
-                    <cvt:ComparisonConverter x:Key="ComparisonConverter" />
-                </StackPanel.Resources>
-
                 <TextBlock Style="{StaticResource HeaderStyle}"
                            Text="Excluded Enemies"/>
 
@@ -589,7 +597,7 @@
             </StackPanel>
 
             <!-- Language -->
-            <StackPanel Grid.Row="9"
+            <StackPanel Grid.Row="10"
                         Visibility="{Binding HasLanguage, Converter={StaticResource BoolToCollapsedConverter}}">
 
                 <TextBlock Style="{StaticResource HeaderStyle}"
@@ -617,7 +625,7 @@
             </StackPanel>
 
             <!-- Mirrored Levels -->
-            <StackPanel Grid.Row="10"
+            <StackPanel Grid.Row="11"
                         Visibility="{Binding HasMirroring, Converter={StaticResource BoolToCollapsedConverter}}">
 
                 <TextBlock Style="{StaticResource HeaderStyle}"
@@ -671,7 +679,7 @@
             </StackPanel>
 
             <!-- Haircuts -->
-            <StackPanel Grid.Row="11"
+            <StackPanel Grid.Row="12"
                         Visibility="{Binding HasHaircuts, Converter={StaticResource BoolToCollapsedConverter}}">
 
                 <TextBlock Style="{StaticResource HeaderStyle}"
@@ -744,7 +752,7 @@
             </StackPanel>
 
             <!-- Invisibility -->
-            <StackPanel Grid.Row="12"
+            <StackPanel Grid.Row="13"
                         Visibility="{Binding HasInvisibility, Converter={StaticResource BoolToCollapsedConverter}}">
 
                 <TextBlock Style="{StaticResource HeaderStyle}"
@@ -798,7 +806,7 @@
             </StackPanel>
 
             <!-- Night Mode general -->
-            <StackPanel Grid.Row="13"
+            <StackPanel Grid.Row="14"
                         Visibility="{Binding HasNightMode, Converter={StaticResource BoolToCollapsedConverter}}">
 
                 <TextBlock Style="{StaticResource HeaderStyle}"
@@ -989,7 +997,7 @@
             </StackPanel>
 
             <!-- Intensity -->
-            <StackPanel Grid.Row="14"
+            <StackPanel Grid.Row="15"
                         Visibility="{Binding HasNightMode, Converter={StaticResource BoolToCollapsedConverter}}">
 
                 <TextBlock Style="{StaticResource HeaderStyle}"
@@ -1045,12 +1053,8 @@
             </StackPanel>
 
             <!-- TR3 Globe Options -->
-            <StackPanel Grid.Row="15"
+            <StackPanel Grid.Row="16"
                         Visibility="{Binding HasGlobeOptions, Converter={StaticResource BoolToCollapsedConverter}}">
-                <StackPanel.Resources>
-                    <cvt:ComparisonConverter x:Key="ComparisonConverter" />
-                </StackPanel.Resources>
-
                 <TextBlock Style="{StaticResource HeaderStyle}"
                            Text="Globe Display"/>
 
@@ -1113,13 +1117,8 @@
 
             <!-- Game Mode -->
             <StackPanel
-                Grid.Row="16"
+                Grid.Row="17"
                 Visibility="{Binding HasGameModeOptions, Converter={StaticResource BoolToCollapsedConverter}}">
-
-                <StackPanel.Resources>
-                    <cvt:ComparisonConverter x:Key="ComparisonConverter" />
-                </StackPanel.Resources>
-
                 <TextBlock
                     Style="{StaticResource HeaderStyle}"
                     Text="Game Mode"/>
@@ -1160,7 +1159,7 @@
             </StackPanel>
 
             <!-- Level Count -->
-            <StackPanel Grid.Row="17"
+            <StackPanel Grid.Row="18"
                         Visibility="{Binding HasLevelCount, Converter={StaticResource BoolToCollapsedConverter}}">
 
                 <TextBlock Style="{StaticResource HeaderStyle}"
@@ -1207,7 +1206,7 @@
             </StackPanel>
 
             <!-- Wireframing -->
-            <StackPanel Grid.Row="18"
+            <StackPanel Grid.Row="19"
                         Visibility="{Binding HasTextureOptions, Converter={StaticResource BoolToCollapsedConverter}}">
 
                 <TextBlock Style="{StaticResource HeaderStyle}"
@@ -1369,7 +1368,7 @@
             </StackPanel>
 
             <!-- SFX -->
-            <StackPanel Grid.Row="19"
+            <StackPanel Grid.Row="20"
                         Visibility="{Binding HasSFXOptions, Converter={StaticResource BoolToCollapsedConverter}}">
 
                 <TextBlock Style="{StaticResource HeaderStyle}"
@@ -1423,7 +1422,7 @@
             </StackPanel>
 
             <!-- Mediless -->
-            <StackPanel Grid.Row="20"
+            <StackPanel Grid.Row="21"
                         Visibility="{Binding HasHealthMode, Converter={StaticResource BoolToCollapsedConverter}}"
                         IsEnabled="{Binding ControllerProxy.IsMedilessTypeSupported}">
 
@@ -1470,7 +1469,7 @@
             </StackPanel>
 
             <!-- Starting Health -->
-            <StackPanel Grid.Row="21"
+            <StackPanel Grid.Row="22"
                         Visibility="{Binding HasHealthMode, Converter={StaticResource BoolToCollapsedConverter}}">
 
                 <TextBlock Style="{StaticResource HeaderStyle}"
@@ -1550,13 +1549,8 @@
 
             <!-- Reward Mode -->
             <StackPanel
-                Grid.Row="22"
+                Grid.Row="23"
                 Visibility="{Binding HasSecretRewardMode, Converter={StaticResource BoolToCollapsedConverter}}">
-
-                <StackPanel.Resources>
-                    <cvt:ComparisonConverter x:Key="ComparisonConverter" />
-                </StackPanel.Resources>
-
                 <TextBlock
                     Style="{StaticResource HeaderStyle}"
                     Text="Secret Reward Mode"/>
@@ -1618,13 +1612,9 @@
             </StackPanel>
             
             <!-- Secret Count -->
-            <StackPanel Grid.Row="23"
+            <StackPanel Grid.Row="24"
                         Visibility="{Binding HasSecretCountMode, Converter={StaticResource BoolToCollapsedConverter}}"
                         IsEnabled="{Binding ControllerProxy.UseGenericSecrets}">
-                <StackPanel.Resources>
-                    <cvt:ComparisonConverter x:Key="ComparisonConverter" />
-                </StackPanel.Resources>
-
                 <TextBlock Style="{StaticResource HeaderStyle}"
                            Text="Secret Count Mode"/>
 
@@ -1694,12 +1684,8 @@
             </StackPanel>
 
             <!-- Secret Packs -->
-            <StackPanel Grid.Row="24"
+            <StackPanel Grid.Row="25"
                         Visibility="{Binding HasSecretPackMode, Converter={StaticResource BoolToCollapsedConverter}}">
-                <StackPanel.Resources>
-                    <cvt:ComparisonConverter x:Key="ComparisonConverter" />
-                </StackPanel.Resources>
-
                 <TextBlock Style="{StaticResource HeaderStyle}"
                            Text="Secret Packs"/>
 
@@ -1746,7 +1732,7 @@
             </StackPanel>
 
             <!-- Weather -->
-            <StackPanel Grid.Row="25"
+            <StackPanel Grid.Row="26"
                         Visibility="{Binding HasWeatherMode, Converter={StaticResource BoolToCollapsedConverter}}">
 
                 <TextBlock Style="{StaticResource HeaderStyle}"
@@ -1858,7 +1844,7 @@
             
             <!-- Enemy Clones -->
             <StackPanel
-                Grid.Row="26"
+                Grid.Row="27"
                 Visibility="{Binding HasClonedEnemyMode, Converter={StaticResource BoolToCollapsedConverter}}">
                 <TextBlock
                     Style="{StaticResource HeaderStyle}"


### PR DESCRIPTION
Resolves #690.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Currently weapons are added in abundance if randomizing item types, so this option gives finer control over that. Easy mode will behave as per the current method, and fair and hard modes have increasingly rarer appearances of guns. We track unarmed levels too in order to reallocate guns after the player loses them all.

This does not apply to secret reward items, so items there can be or become weapons with no restriction checks, similar to easy mode.
