### PR TITLE
Increase scion collision sphere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - fixed a key item softlock in Crash Site (#662)
 - fixed incorrect item and mesh positions in Home Sweet Home when mirrored (#676)
 - fixed uncontrolled SFX in gym/assault course levels not being linked to the correct setting (#684)
+- fixed the scion being difficult to shoot if Lara only has the shotgun (#696)
 - improved the layout of some options in the UI (#694)
 
 ## [V1.8.4](https://github.com/LostArtefacts/TR-Rando/compare/V1.8.3...V1.8.4) - 2024-02-12

--- a/TRRandomizerCore/Randomizers/TR1/Shared/TR1EnemyAllocator.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Shared/TR1EnemyAllocator.cs
@@ -813,5 +813,10 @@ public class TR1EnemyAllocator : EnemyAllocator<TR1Type>
         {
             createItemCallback(weaponLocation, TR1Type.LargeMed_S_P);
         }
+
+        if (weaponType == TR1Type.Shotgun_S_P && level.Models.ContainsKey(TR1Type.ScionPiece3_S_P))
+        {
+            level.Models[TR1Type.ScionPiece3_S_P].Meshes[0].CollRadius = TRConsts.Step1;
+        }
     }
 }


### PR DESCRIPTION
Resolves #696.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This roughly quadruples the scion's collision sphere so that it can be taken out with the shotgun. @rr- I'm not sure if there is a better way to fix this within TR1X itself, but we can possibly inject a similar fix or have a different check for this scenario.
