### PR TITLE
Relocate awkward enemies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - added separate secret audio for TR1 and TR3 when not using reward rooms (#687)
 - added an option to shuffle items rather than randomize their types and locations in each level (#625)
 - added an option to control weapon allocation in item randomization (#690)
+- added an option to move enemies such as eels, whose placement can lead to forced damage or difficulty in passing (#311)
 - added Finnish, Portuguese, and Swedish translations to TR1 and added all supported language translations to TRUB (#701)
 - fixed several potential key item softlocks in TR2 (#691)
 - fixed a key item softlock in Crash Site (#662)

--- a/Resources/Documentation/ENEMIES.md
+++ b/Resources/Documentation/ENEMIES.md
@@ -220,7 +220,7 @@ Because of the increased limits in TR3, most levels have had their number of ene
 | _STPAUL.TR2_ | _2_ | _2_ | _2_ |
 
 # Awkward enemies
-Some enemy placements can cause problems by default, such as causing forced damage or difficulty in getting passed them. The UI option to move awkward enemies will - in most cases - move these enemies to better positions.
+Some enemy placements can cause problems by default, such as causing forced damage or difficulty in getting past them. The UI option to move awkward enemies will - in most cases - move these enemies to better positions.
 
 - TR1: some T-rex and Torso locations are affected, for example on the narrow corridors leading to the Atlantis main chamber.
 - TR2: both types of eel will be moved off the ground in all cases when they are land creatures. This means that they effectively become hazards - they may still be able to snipe Lara if she is jumping, so take care!

--- a/Resources/Documentation/ENEMIES.md
+++ b/Resources/Documentation/ENEMIES.md
@@ -4,6 +4,7 @@ Jump to:
 * [TR1](#tr1)
 * [TR2](#tr2)
 * [TR3](#tr3)
+* [Awkward enemies](#awkward-enemies)
 
 # TR1
 The following enemy restrictions are in place when using "Default" restriction mode during randomization.
@@ -178,6 +179,7 @@ There are further nuances with other enemy types in TR3.
 * RXTechFlameLad is hostile to Lara in any level that falls on Meteorite Cavern's sequence.
 * Crash site Mercenary and RXTechFlameLad will fight each other. The Mercenary always wins.
 * Raptors (288) will attack any other enemy, other than other raptors, unless Lara is the closest target.
+* The T-rex will only ever appear in Caves of Kaliya when _No Restrictions_ mode is enabled.
 
 ## Spawn Points
 
@@ -216,3 +218,10 @@ Because of the increased limits in TR3, most levels have had their number of ene
 | CITY.TR2 | 13 | 2 | 6 |
 | CHAMBER.TR2 | 7 | 3 | 4 |
 | _STPAUL.TR2_ | _2_ | _2_ | _2_ |
+
+# Awkward enemies
+Some enemy placements can cause problems by default, such as causing forced damage or difficulty in getting passed them. The UI option to move awkward enemies will - in most cases - move these enemies to better positions.
+
+- TR1: some T-rex and Torso locations are affected, for example on the narrow corridors leading to the Atlantis main chamber.
+- TR2: both types of eel will be moved off the ground in all cases when they are land creatures. This means that they effectively become hazards - they may still be able to snipe Lara if she is jumping, so take care!
+- TR3: the T-rex is moved in several instances to avoid blocking corridors and crawlspaces.

--- a/TRRandomizerCore/Editors/RandomizerSettings.cs
+++ b/TRRandomizerCore/Editors/RandomizerSettings.cs
@@ -72,6 +72,7 @@ public class RandomizerSettings
     public bool CrossLevelEnemies { get; set; }
     public bool ProtectMonks { get; set; }
     public bool DocileWillard { get; set; }
+    public bool RelocateAwkwardEnemies { get; set; }
     public BirdMonsterBehaviour BirdMonsterBehaviour { get; set; }
     public bool DefaultChickens => BirdMonsterBehaviour == BirdMonsterBehaviour.Default;
     public bool DocileChickens => BirdMonsterBehaviour == BirdMonsterBehaviour.Docile;
@@ -231,6 +232,7 @@ public class RandomizerSettings
         CrossLevelEnemies = config.GetBool(nameof(CrossLevelEnemies), true);
         ProtectMonks = config.GetBool(nameof(ProtectMonks), true);
         DocileWillard = config.GetBool(nameof(DocileWillard));
+        RelocateAwkwardEnemies = config.GetBool(nameof(RelocateAwkwardEnemies), true);
         BirdMonsterBehaviour = (BirdMonsterBehaviour)config.GetEnum(nameof(BirdMonsterBehaviour), typeof(BirdMonsterBehaviour), BirdMonsterBehaviour.Default);
         RandoEnemyDifficulty = (RandoDifficulty)config.GetEnum(nameof(RandoEnemyDifficulty), typeof(RandoDifficulty), RandoDifficulty.Default);
         DragonSpawnType = (DragonSpawnType)config.GetEnum(nameof(DragonSpawnType), typeof(DragonSpawnType), DragonSpawnType.Default);
@@ -404,6 +406,7 @@ public class RandomizerSettings
         config[nameof(CrossLevelEnemies)] = CrossLevelEnemies;
         config[nameof(ProtectMonks)] = ProtectMonks;
         config[nameof(DocileWillard)] = DocileWillard;
+        config[nameof(RelocateAwkwardEnemies)] = RelocateAwkwardEnemies;
         config[nameof(BirdMonsterBehaviour)] = BirdMonsterBehaviour;
         config[nameof(RandoEnemyDifficulty)] = RandoEnemyDifficulty;
         config[nameof(DragonSpawnType)] = DragonSpawnType;

--- a/TRRandomizerCore/Randomizers/TR1/Shared/TR1EnemyAllocator.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Shared/TR1EnemyAllocator.cs
@@ -41,6 +41,7 @@ public class TR1EnemyAllocator : EnemyAllocator<TR1Type>
     public ItemFactory<TR1Entity> ItemFactory { get; set; }
 
     public TR1EnemyAllocator()
+        : base(TRGameVersion.TR1)
     {
         _pistolLocations = JsonConvert.DeserializeObject<Dictionary<string, List<Location>>>(File.ReadAllText(@"Resources\TR1\Locations\unarmed_locations.json"));
         _eggLocations = JsonConvert.DeserializeObject<Dictionary<string, List<Location>>>(File.ReadAllText(@"Resources\TR1\Locations\egg_locations.json"));
@@ -526,6 +527,8 @@ public class TR1EnemyAllocator : EnemyAllocator<TR1Type>
             SetOneShot(currentEntity, entityIndex, level.FloorData);
             _resultantEnemies.Add(newType);
         }
+
+        RelocateEnemies(levelName, level.Entities);
     }
 
     private static int GetEntityCount(TR1Level level, TR1Type entityType)

--- a/TRRandomizerCore/Randomizers/TR2/Shared/TR2EnemyAllocator.cs
+++ b/TRRandomizerCore/Randomizers/TR2/Shared/TR2EnemyAllocator.cs
@@ -29,6 +29,9 @@ public class TR2EnemyAllocator : EnemyAllocator<TR2Type>
         TR2LevelNames.MONASTERY,
     };
 
+    public TR2EnemyAllocator()
+        : base(TRGameVersion.TR2) { }
+
     public List<string> DragonLevels { get; set; }
     public ItemFactory<TR2Entity> ItemFactory { get; set; }
 
@@ -580,6 +583,8 @@ public class TR2EnemyAllocator : EnemyAllocator<TR2Type>
         {
             LimitFriendlyEnemies(level, enemies.Available.Except(friends).ToList(), friends);
         }
+
+        RelocateEnemies(levelName, level.Entities);
 
         if (!Settings.AllowEnemyKeyDrops)
         {

--- a/TRRandomizerCore/Randomizers/TR3/Shared/TR3EnemyAllocator.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Shared/TR3EnemyAllocator.cs
@@ -24,6 +24,7 @@ public class TR3EnemyAllocator : EnemyAllocator<TR3Type>
     public ItemFactory<TR3Entity> ItemFactory { get; set; }
 
     public TR3EnemyAllocator()
+        : base(TRGameVersion.TR3)
     {
         _pistolLocations = JsonConvert.DeserializeObject<Dictionary<string, List<Location>>>(File.ReadAllText(@"Resources\TR3\Locations\unarmed_locations.json"));
     }
@@ -410,6 +411,8 @@ public class TR3EnemyAllocator : EnemyAllocator<TR3Type>
             SetOneShot(targetEntity, level.Entities.IndexOf(targetEntity), level.FloorData);
             _resultantEnemies.Add(newType);
         }
+
+        RelocateEnemies(levelName, level.Entities);
 
         if (!Settings.AllowEnemyKeyDrops)
         {

--- a/TRRandomizerCore/Resources/TR1/Locations/enemy_relocations.json
+++ b/TRRandomizerCore/Resources/TR1/Locations/enemy_relocations.json
@@ -1,0 +1,168 @@
+{
+  "LEVEL2.PHD": [
+    {
+      "X": 31232,
+      "Y": -7936,
+      "Z": 36352,
+      "Room": 67,
+      "Angle": -32768,
+      "EntityIndex": 85,
+      "TargetType": 18
+    }
+  ],
+  "LEVEL7A.PHD": [
+    {
+      "X": 42496,
+      "Y": -8448,
+      "Z": 40448,
+      "Room": 15,
+      "Angle": -32768,
+      "EntityIndex": 21,
+      "TargetType": 18
+    },
+    {
+      "X": 53760,
+      "Y": -3584,
+      "Z": 39424,
+      "Room": 39,
+      "Angle": -16384,
+      "EntityIndex": 43,
+      "TargetType": 18
+    },
+    {
+      "X": 45568,
+      "Y": -3328,
+      "Z": 51712,
+      "Room": 95,
+      "Angle": 0,
+      "EntityIndex": 44,
+      "TargetType": 18
+    },
+    {
+      "X": 40448,
+      "Y": -3328,
+      "Z": 64000,
+      "Room": 99,
+      "Angle": -32768,
+      "EntityIndex": 101,
+      "TargetType": 18
+    }
+  ],
+  "LEVEL7B.PHD": [
+    {
+      "X": 54784,
+      "Y": -3840,
+      "Z": 75264,
+      "Room": 70,
+      "Angle": -32768,
+      "EntityIndex": 31,
+      "TargetType": 18
+    },
+    {
+      "X": 54784,
+      "Y": -3840,
+      "Z": 74240,
+      "Room": 70,
+      "Angle": -32768,
+      "EntityIndex": 31,
+      "TargetType": 34
+    },
+    {
+      "X": 38400,
+      "Y": -4096,
+      "Z": 62976,
+      "Room": 77,
+      "Angle": 0,
+      "EntityIndex": 34,
+      "TargetType": 18
+    },
+    {
+      "X": 38400,
+      "Y": -4096,
+      "Z": 64000,
+      "Room": 77,
+      "Angle": 0,
+      "EntityIndex": 34,
+      "TargetType": 34
+    }
+  ],
+  "LEVEL8C.PHD": [
+    {
+      "X": 47616,
+      "Y": -768,
+      "Z": 38400,
+      "Room": 13,
+      "EntityIndex": 32,
+      "TargetType": 18
+    },
+    {
+      "X": 33280,
+      "Y": 17920,
+      "Z": 44544,
+      "Room": 5,
+      "EntityIndex": 42,
+      "TargetType": 18
+    },
+    {
+      "X": 31232,
+      "Y": 17920,
+      "Z": 44544,
+      "Room": 5,
+      "EntityIndex": 42,
+      "TargetType": 34
+    }
+  ],
+  "LEVEL10B.PHD": [
+    {
+      "X": 62976,
+      "Y": 0,
+      "Z": 46592,
+      "Room": 38,
+      "EntityIndex": 0,
+      "TargetType": 18
+    },
+    {
+      "X": 43520,
+      "Y": 3328,
+      "Z": 44544,
+      "Room": 78,
+      "EntityIndex": 1,
+      "TargetType": 18
+    },
+    {
+      "X": 54784,
+      "Y": 5120,
+      "Z": 44544,
+      "Room": 1,
+      "EntityIndex": 1,
+      "TargetType": 34
+    },
+    {
+      "X": 53760,
+      "Y": -13056,
+      "Z": 56832,
+      "Room": 47,
+      "EntityIndex": 8,
+      "TargetType": 18
+    },
+    {
+      "X": 65024,
+      "Y": -10240,
+      "Z": 51712,
+      "Room": 46,
+      "Angle": -32768,
+      "EntityIndex": 9,
+      "TargetType": 18
+    }
+  ],
+  "LEVEL10C.PHD": [
+    {
+      "X": 53760,
+      "Y": 9728,
+      "Z": 75264,
+      "Room": 34,
+      "EntityIndex": 101,
+      "TargetType": 18
+    }
+  ]
+}

--- a/TRRandomizerCore/Resources/TR2/Environment/DECK.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR2/Environment/DECK.TR2-Environment.json
@@ -1055,10 +1055,18 @@
       "Condition": {
         "Comments": "If enemy 103's type has been randomized, move him outside for some breathing space.",
         "ConditionType": 0,
+        "Negate": true,
+        "And": [
+          {
+            "ConditionType": 0,
+            "EntityIndex": 103,
+            "Room": 110
+          }
+        ],
         "EntityIndex": 103,
         "EntityType": 32
       },
-      "OnFalse": [
+      "OnTrue": [
         {
           "EMType": 44,
           "EntityIndex": 103,

--- a/TRRandomizerCore/Resources/TR2/Environment/PLATFORM.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR2/Environment/PLATFORM.TR2-Environment.json
@@ -2587,34 +2587,6 @@
           }
         }
       ]
-    },
-    {
-      "Condition": {
-        "Comments": "If enemy 59 is an eel, rotate it to avoid blocking puzzle slots.",
-        "ConditionType": 0,
-        "Or": [
-          {
-            "ConditionType": 0,
-            "EntityIndex": 59,
-            "EntityType": 26
-          }
-        ],
-        "EntityIndex": 59,
-        "EntityType": 27
-      },
-      "OnTrue": [
-        {
-          "EMType": 44,
-          "EntityIndex": 59,
-          "TargetLocation": {
-            "X": 59904,
-            "Y": -3584,
-            "Z": 75264,
-            "Room": 30,
-            "Angle": -32768
-          }
-        }
-      ]
     }
   ],
   "ConditionalOneOf": [],

--- a/TRRandomizerCore/Resources/TR2/Locations/enemy_relocations.json
+++ b/TRRandomizerCore/Resources/TR2/Locations/enemy_relocations.json
@@ -1,0 +1,6556 @@
+{
+  "WALL.TR2": [
+    {
+      "X": 36352,
+      "Y": -3072,
+      "Z": 28672,
+      "Room": 2,
+      "Angle": 0,
+      "EntityIndex": 2,
+      "TargetType": 26
+    },
+    {
+      "X": 36352,
+      "Y": -3072,
+      "Z": 28672,
+      "Room": 2,
+      "Angle": 0,
+      "EntityIndex": 2,
+      "TargetType": 27
+    },
+    {
+      "X": 44544,
+      "Y": 1792,
+      "Z": 45056,
+      "Room": 7,
+      "Angle": -32768,
+      "EntityIndex": 11,
+      "TargetType": 26
+    },
+    {
+      "X": 44544,
+      "Y": 1792,
+      "Z": 45056,
+      "Room": 7,
+      "Angle": -32768,
+      "EntityIndex": 11,
+      "TargetType": 27
+    },
+    {
+      "X": 30719,
+      "Y": -3072,
+      "Z": 36352,
+      "Room": 0,
+      "EntityIndex": 12,
+      "TargetType": 26
+    },
+    {
+      "X": 30719,
+      "Y": -3072,
+      "Z": 36352,
+      "Room": 0,
+      "EntityIndex": 12,
+      "TargetType": 27
+    },
+    {
+      "X": 31232,
+      "Y": 0,
+      "Z": 36864,
+      "Room": 7,
+      "Angle": 0,
+      "EntityIndex": 13,
+      "TargetType": 26
+    },
+    {
+      "X": 31232,
+      "Y": 0,
+      "Z": 36864,
+      "Room": 7,
+      "Angle": 0,
+      "EntityIndex": 13,
+      "TargetType": 27
+    },
+    {
+      "X": 29184,
+      "Y": -3584,
+      "Z": 30720,
+      "Room": 4,
+      "Angle": 0,
+      "EntityIndex": 8,
+      "TargetType": 26
+    },
+    {
+      "X": 29184,
+      "Y": -3584,
+      "Z": 30720,
+      "Room": 4,
+      "Angle": 0,
+      "EntityIndex": 8,
+      "TargetType": 27
+    },
+    {
+      "X": 25599,
+      "Y": -2304,
+      "Z": 33280,
+      "Room": 4,
+      "EntityIndex": 16,
+      "TargetType": 26
+    },
+    {
+      "X": 24575,
+      "Y": -2304,
+      "Z": 33280,
+      "Room": 4,
+      "EntityIndex": 16,
+      "TargetType": 27
+    },
+    {
+      "X": 26623,
+      "Y": -2304,
+      "Z": 35328,
+      "Room": 4,
+      "EntityIndex": 9,
+      "TargetType": 26
+    },
+    {
+      "X": 25599,
+      "Y": -2304,
+      "Z": 35328,
+      "Room": 4,
+      "EntityIndex": 9,
+      "TargetType": 27
+    },
+    {
+      "X": 26623,
+      "Y": -2304,
+      "Z": 36352,
+      "Room": 4,
+      "EntityIndex": 10,
+      "TargetType": 26
+    },
+    {
+      "X": 25599,
+      "Y": -2304,
+      "Z": 36352,
+      "Room": 4,
+      "EntityIndex": 10,
+      "TargetType": 27
+    },
+    {
+      "X": 13311,
+      "Y": -1536,
+      "Z": 35328,
+      "Room": 42,
+      "EntityIndex": 25,
+      "TargetType": 26
+    },
+    {
+      "X": 13311,
+      "Y": -1536,
+      "Z": 35328,
+      "Room": 42,
+      "EntityIndex": 25,
+      "TargetType": 27
+    },
+    {
+      "X": 13311,
+      "Y": -1536,
+      "Z": 36352,
+      "Room": 42,
+      "EntityIndex": 26,
+      "TargetType": 26
+    },
+    {
+      "X": 13311,
+      "Y": -1536,
+      "Z": 36352,
+      "Room": 42,
+      "EntityIndex": 26,
+      "TargetType": 27
+    },
+    {
+      "X": 13311,
+      "Y": -1536,
+      "Z": 37376,
+      "Room": 42,
+      "EntityIndex": 27,
+      "TargetType": 26
+    },
+    {
+      "X": 13311,
+      "Y": -1536,
+      "Z": 37376,
+      "Room": 42,
+      "EntityIndex": 27,
+      "TargetType": 27
+    },
+    {
+      "X": 78849,
+      "Y": 20992,
+      "Z": 76288,
+      "Room": 62,
+      "Angle": -16384,
+      "EntityIndex": 22,
+      "TargetType": 26
+    },
+    {
+      "X": 79873,
+      "Y": 20992,
+      "Z": 76288,
+      "Room": 62,
+      "Angle": -16384,
+      "EntityIndex": 22,
+      "TargetType": 27
+    },
+    {
+      "X": 78849,
+      "Y": 20992,
+      "Z": 72192,
+      "Room": 62,
+      "Angle": -16384,
+      "EntityIndex": 23,
+      "TargetType": 26
+    },
+    {
+      "X": 79873,
+      "Y": 20992,
+      "Z": 72192,
+      "Room": 62,
+      "Angle": -16384,
+      "EntityIndex": 23,
+      "TargetType": 27
+    },
+    {
+      "X": 60415,
+      "Y": 15104,
+      "Z": 72192,
+      "Room": 58,
+      "EntityIndex": 95,
+      "TargetType": 26
+    },
+    {
+      "X": 59391,
+      "Y": 15104,
+      "Z": 72192,
+      "Room": 58,
+      "EntityIndex": 95,
+      "TargetType": 27
+    },
+    {
+      "X": 60415,
+      "Y": 23552,
+      "Z": 74240,
+      "Room": 63,
+      "EntityIndex": 99,
+      "TargetType": 26
+    },
+    {
+      "X": 60415,
+      "Y": 23552,
+      "Z": 74240,
+      "Room": 63,
+      "EntityIndex": 99,
+      "TargetType": 27
+    },
+    {
+      "X": 80895,
+      "Y": 25088,
+      "Z": 73216,
+      "Room": 79,
+      "Angle": -16384,
+      "EntityIndex": 104,
+      "TargetType": 26
+    },
+    {
+      "X": 80895,
+      "Y": 25088,
+      "Z": 73216,
+      "Room": 79,
+      "Angle": -16384,
+      "EntityIndex": 104,
+      "TargetType": 27
+    },
+    {
+      "X": 14848,
+      "Y": -3072,
+      "Z": 35328,
+      "Room": 42,
+      "EntityIndex": 24,
+      "TargetType": 34
+    }
+  ],
+  "BOAT.TR2": [
+    {
+      "X": 56319,
+      "Y": -1024,
+      "Z": 35328,
+      "Room": 6,
+      "EntityIndex": 1,
+      "TargetType": 26
+    },
+    {
+      "X": 56319,
+      "Y": -1024,
+      "Z": 35328,
+      "Room": 6,
+      "EntityIndex": 1,
+      "TargetType": 27
+    },
+    {
+      "X": 50175,
+      "Y": -1792,
+      "Z": 39424,
+      "Room": 20,
+      "Angle": -16384,
+      "EntityIndex": 11,
+      "TargetType": 26
+    },
+    {
+      "X": 50175,
+      "Y": -1792,
+      "Z": 39424,
+      "Room": 20,
+      "Angle": -16384,
+      "EntityIndex": 11,
+      "TargetType": 27
+    },
+    {
+      "X": 50688,
+      "Y": -4864,
+      "Z": 40960,
+      "Room": 24,
+      "Angle": -32768,
+      "EntityIndex": 10,
+      "TargetType": 26
+    },
+    {
+      "X": 50688,
+      "Y": -4864,
+      "Z": 40960,
+      "Room": 24,
+      "Angle": -32768,
+      "EntityIndex": 10,
+      "TargetType": 27
+    },
+    {
+      "X": 56319,
+      "Y": -5120,
+      "Z": 38400,
+      "Room": 7,
+      "EntityIndex": 3,
+      "TargetType": 26
+    },
+    {
+      "X": 56319,
+      "Y": -5120,
+      "Z": 38400,
+      "Room": 7,
+      "EntityIndex": 3,
+      "TargetType": 27
+    },
+    {
+      "X": 51199,
+      "Y": -5120,
+      "Z": 44544,
+      "Room": 36,
+      "EntityIndex": 32,
+      "TargetType": 26
+    },
+    {
+      "X": 51199,
+      "Y": -5120,
+      "Z": 44544,
+      "Room": 36,
+      "EntityIndex": 32,
+      "TargetType": 27
+    },
+    {
+      "X": 53247,
+      "Y": -1024,
+      "Z": 36352,
+      "Room": 17,
+      "Angle": -16384,
+      "EntityIndex": 6,
+      "TargetType": 26
+    },
+    {
+      "X": 53247,
+      "Y": -1024,
+      "Z": 36352,
+      "Room": 17,
+      "Angle": -16384,
+      "EntityIndex": 6,
+      "TargetType": 27
+    },
+    {
+      "X": 40448,
+      "Y": 2048,
+      "Z": 34816,
+      "Room": 47,
+      "Angle": -32768,
+      "EntityIndex": 37,
+      "TargetType": 26
+    },
+    {
+      "X": 40448,
+      "Y": 2048,
+      "Z": 34816,
+      "Room": 47,
+      "Angle": -32768,
+      "EntityIndex": 37,
+      "TargetType": 27
+    },
+    {
+      "X": 37376,
+      "Y": 2048,
+      "Z": 24576,
+      "Room": 46,
+      "Angle": 0,
+      "EntityIndex": 36,
+      "TargetType": 26
+    },
+    {
+      "X": 37376,
+      "Y": 2048,
+      "Z": 24576,
+      "Room": 46,
+      "Angle": 0,
+      "EntityIndex": 36,
+      "TargetType": 27
+    },
+    {
+      "X": 34304,
+      "Y": 3328,
+      "Z": 37888,
+      "Room": 62,
+      "Angle": -32768,
+      "EntityIndex": 45,
+      "TargetType": 26
+    },
+    {
+      "X": 34304,
+      "Y": 3328,
+      "Z": 37888,
+      "Room": 62,
+      "Angle": -32768,
+      "EntityIndex": 45,
+      "TargetType": 27
+    },
+    {
+      "X": 33280,
+      "Y": 3328,
+      "Z": 37888,
+      "Room": 62,
+      "Angle": -32768,
+      "EntityIndex": 49,
+      "TargetType": 26
+    },
+    {
+      "X": 33280,
+      "Y": 3328,
+      "Z": 37888,
+      "Room": 62,
+      "Angle": -32768,
+      "EntityIndex": 49,
+      "TargetType": 27
+    },
+    {
+      "X": 20479,
+      "Y": -3584,
+      "Z": 53760,
+      "Room": 96,
+      "EntityIndex": 103,
+      "TargetType": 26
+    },
+    {
+      "X": 20479,
+      "Y": -3584,
+      "Z": 53760,
+      "Room": 96,
+      "EntityIndex": 103,
+      "TargetType": 27
+    },
+    {
+      "X": 20479,
+      "Y": -3584,
+      "Z": 52736,
+      "Room": 96,
+      "EntityIndex": 104,
+      "TargetType": 26
+    },
+    {
+      "X": 20479,
+      "Y": -3584,
+      "Z": 52736,
+      "Room": 96,
+      "EntityIndex": 104,
+      "TargetType": 27
+    },
+    {
+      "X": 31232,
+      "Y": -3840,
+      "Z": 56320,
+      "Room": 77,
+      "Angle": -32768,
+      "EntityIndex": 79,
+      "TargetType": 26
+    },
+    {
+      "X": 31232,
+      "Y": -3840,
+      "Z": 56320,
+      "Room": 77,
+      "Angle": -32768,
+      "EntityIndex": 79,
+      "TargetType": 27
+    },
+    {
+      "X": 29695,
+      "Y": -3840,
+      "Z": 51712,
+      "Room": 77,
+      "EntityIndex": 81,
+      "TargetType": 26
+    },
+    {
+      "X": 29695,
+      "Y": -3840,
+      "Z": 51712,
+      "Room": 77,
+      "EntityIndex": 81,
+      "TargetType": 27
+    },
+    {
+      "X": 24064,
+      "Y": -1792,
+      "Z": 65536,
+      "Room": 94,
+      "Angle": -32768,
+      "EntityIndex": 89,
+      "TargetType": 26
+    },
+    {
+      "X": 24064,
+      "Y": -1792,
+      "Z": 65536,
+      "Room": 94,
+      "Angle": -32768,
+      "EntityIndex": 89,
+      "TargetType": 27
+    },
+    {
+      "X": 24064,
+      "Y": -2816,
+      "Z": 65536,
+      "Room": 94,
+      "Angle": -32768,
+      "EntityIndex": 130,
+      "TargetType": 26
+    },
+    {
+      "X": 24064,
+      "Y": -2816,
+      "Z": 65536,
+      "Room": 94,
+      "Angle": -32768,
+      "EntityIndex": 130,
+      "TargetType": 27
+    },
+    {
+      "X": 58880,
+      "Y": -1024,
+      "Z": 64512,
+      "Room": 147,
+      "Angle": 0,
+      "EntityIndex": 120,
+      "TargetType": 26
+    },
+    {
+      "X": 58880,
+      "Y": -1024,
+      "Z": 64512,
+      "Room": 147,
+      "Angle": 0,
+      "EntityIndex": 120,
+      "TargetType": 27
+    },
+    {
+      "X": 57856,
+      "Y": -768,
+      "Z": 64512,
+      "Room": 147,
+      "Angle": 0,
+      "EntityIndex": 118,
+      "TargetType": 26
+    },
+    {
+      "X": 57856,
+      "Y": -768,
+      "Z": 64512,
+      "Room": 147,
+      "Angle": 0,
+      "EntityIndex": 118,
+      "TargetType": 27
+    },
+    {
+      "X": 59904,
+      "Y": -768,
+      "Z": 64512,
+      "Room": 147,
+      "Angle": 0,
+      "EntityIndex": 119,
+      "TargetType": 26
+    },
+    {
+      "X": 59904,
+      "Y": -768,
+      "Z": 64512,
+      "Room": 147,
+      "Angle": 0,
+      "EntityIndex": 119,
+      "TargetType": 27
+    },
+    {
+      "X": 60928,
+      "Y": -1024,
+      "Z": 51200,
+      "Room": 79,
+      "Angle": 0,
+      "EntityIndex": 85,
+      "TargetType": 26
+    },
+    {
+      "X": 60928,
+      "Y": -1024,
+      "Z": 51200,
+      "Room": 79,
+      "Angle": 0,
+      "EntityIndex": 85,
+      "TargetType": 27
+    },
+    {
+      "X": 57343,
+      "Y": -3072,
+      "Z": 47616,
+      "Room": 150,
+      "EntityIndex": 125,
+      "TargetType": 26
+    },
+    {
+      "X": 57343,
+      "Y": -3072,
+      "Z": 47616,
+      "Room": 150,
+      "EntityIndex": 125,
+      "TargetType": 27
+    },
+    {
+      "X": 57343,
+      "Y": -3072,
+      "Z": 48640,
+      "Room": 150,
+      "EntityIndex": 124,
+      "TargetType": 26
+    },
+    {
+      "X": 57343,
+      "Y": -3072,
+      "Z": 48640,
+      "Room": 150,
+      "EntityIndex": 124,
+      "TargetType": 27
+    },
+    {
+      "X": 79871,
+      "Y": -1280,
+      "Z": 60928,
+      "Room": 71,
+      "Angle": -16384,
+      "EntityIndex": 115,
+      "TargetType": 26
+    },
+    {
+      "X": 79871,
+      "Y": -1280,
+      "Z": 60928,
+      "Room": 71,
+      "Angle": -16384,
+      "EntityIndex": 115,
+      "TargetType": 27
+    },
+    {
+      "X": 39935,
+      "Y": -1024,
+      "Z": 49664,
+      "Room": 69,
+      "EntityIndex": 59,
+      "TargetType": 26
+    },
+    {
+      "X": 39935,
+      "Y": -1024,
+      "Z": 49664,
+      "Room": 69,
+      "EntityIndex": 59,
+      "TargetType": 27
+    }
+  ],
+  "VENICE.TR2": [
+    {
+      "X": 70655,
+      "Y": 3328,
+      "Z": 43520,
+      "Room": 106,
+      "EntityIndex": 99,
+      "TargetType": 26
+    },
+    {
+      "X": 70655,
+      "Y": 3328,
+      "Z": 43520,
+      "Room": 106,
+      "EntityIndex": 99,
+      "TargetType": 27
+    },
+    {
+      "X": 70655,
+      "Y": 3328,
+      "Z": 44544,
+      "Room": 106,
+      "EntityIndex": 100,
+      "TargetType": 26
+    },
+    {
+      "X": 70655,
+      "Y": 3328,
+      "Z": 44544,
+      "Room": 106,
+      "EntityIndex": 100,
+      "TargetType": 27
+    },
+    {
+      "X": 66559,
+      "Y": 1280,
+      "Z": 33280,
+      "Room": 101,
+      "EntityIndex": 92,
+      "TargetType": 26
+    },
+    {
+      "X": 66559,
+      "Y": 1280,
+      "Z": 33280,
+      "Room": 101,
+      "EntityIndex": 92,
+      "TargetType": 27
+    },
+    {
+      "X": 66559,
+      "Y": 256,
+      "Z": 33280,
+      "Room": 104,
+      "EntityIndex": 93,
+      "TargetType": 26
+    },
+    {
+      "X": 66559,
+      "Y": 256,
+      "Z": 33280,
+      "Room": 104,
+      "EntityIndex": 93,
+      "TargetType": 27
+    },
+    {
+      "X": 71168,
+      "Y": 2048,
+      "Z": 31744,
+      "Room": 106,
+      "Angle": 0,
+      "EntityIndex": 76,
+      "TargetType": 26
+    },
+    {
+      "X": 71168,
+      "Y": 2048,
+      "Z": 31744,
+      "Room": 106,
+      "Angle": 0,
+      "EntityIndex": 76,
+      "TargetType": 27
+    },
+    {
+      "X": 74751,
+      "Y": 1024,
+      "Z": 33280,
+      "Room": 106,
+      "Angle": -16384,
+      "EntityIndex": 78,
+      "TargetType": 26
+    },
+    {
+      "X": 74751,
+      "Y": 1024,
+      "Z": 33280,
+      "Room": 106,
+      "Angle": -16384,
+      "EntityIndex": 78,
+      "TargetType": 27
+    },
+    {
+      "X": 70655,
+      "Y": -512,
+      "Z": 35328,
+      "Room": 107,
+      "EntityIndex": 106,
+      "TargetType": 26
+    },
+    {
+      "X": 70655,
+      "Y": -512,
+      "Z": 35328,
+      "Room": 107,
+      "EntityIndex": 106,
+      "TargetType": 27
+    },
+    {
+      "X": 66559,
+      "Y": 512,
+      "Z": 23040,
+      "Room": 91,
+      "Angle": -16384,
+      "EntityIndex": 67,
+      "TargetType": 26
+    },
+    {
+      "X": 66559,
+      "Y": 512,
+      "Z": 23040,
+      "Room": 91,
+      "Angle": -16384,
+      "EntityIndex": 67,
+      "TargetType": 27
+    },
+    {
+      "X": 65535,
+      "Y": 3072,
+      "Z": 42496,
+      "Room": 49,
+      "EntityIndex": 46,
+      "TargetType": 26
+    },
+    {
+      "X": 65535,
+      "Y": 3072,
+      "Z": 42496,
+      "Room": 49,
+      "EntityIndex": 46,
+      "TargetType": 27
+    },
+    {
+      "X": 61439,
+      "Y": 3072,
+      "Z": 43520,
+      "Room": 118,
+      "EntityIndex": 120,
+      "TargetType": 26
+    },
+    {
+      "X": 61439,
+      "Y": 3072,
+      "Z": 43520,
+      "Room": 118,
+      "EntityIndex": 120,
+      "TargetType": 27
+    },
+    {
+      "X": 65535,
+      "Y": 1024,
+      "Z": 42496,
+      "Room": 116,
+      "EntityIndex": 118,
+      "TargetType": 26
+    },
+    {
+      "X": 65535,
+      "Y": 1024,
+      "Z": 42496,
+      "Room": 116,
+      "EntityIndex": 118,
+      "TargetType": 27
+    },
+    {
+      "X": 66559,
+      "Y": 3072,
+      "Z": 30208,
+      "Room": 108,
+      "Angle": -16384,
+      "EntityIndex": 109,
+      "TargetType": 26
+    },
+    {
+      "X": 66559,
+      "Y": 3072,
+      "Z": 30208,
+      "Room": 108,
+      "Angle": -16384,
+      "EntityIndex": 109,
+      "TargetType": 27
+    },
+    {
+      "X": 66559,
+      "Y": 3072,
+      "Z": 31232,
+      "Room": 108,
+      "Angle": -16384,
+      "EntityIndex": 110,
+      "TargetType": 26
+    },
+    {
+      "X": 66559,
+      "Y": 3072,
+      "Z": 31232,
+      "Room": 108,
+      "Angle": -16384,
+      "EntityIndex": 110,
+      "TargetType": 27
+    },
+    {
+      "X": 66559,
+      "Y": -1024,
+      "Z": 37376,
+      "Room": 13,
+      "Angle": -16384,
+      "EntityIndex": 130,
+      "TargetType": 26
+    },
+    {
+      "X": 66559,
+      "Y": -1024,
+      "Z": 37376,
+      "Room": 13,
+      "Angle": -16384,
+      "EntityIndex": 130,
+      "TargetType": 27
+    },
+    {
+      "X": 66559,
+      "Y": -1024,
+      "Z": 38400,
+      "Room": 13,
+      "Angle": -16384,
+      "EntityIndex": 131,
+      "TargetType": 26
+    },
+    {
+      "X": 66559,
+      "Y": -1024,
+      "Z": 38400,
+      "Room": 13,
+      "Angle": -16384,
+      "EntityIndex": 131,
+      "TargetType": 27
+    },
+    {
+      "X": 62976,
+      "Y": -1024,
+      "Z": 34816,
+      "Room": 1,
+      "Angle": -32768,
+      "EntityIndex": 5,
+      "TargetType": 26
+    },
+    {
+      "X": 62976,
+      "Y": -1024,
+      "Z": 34816,
+      "Room": 1,
+      "Angle": -32768,
+      "EntityIndex": 5,
+      "TargetType": 27
+    },
+    {
+      "X": 56321,
+      "Y": -1536,
+      "Z": 25088,
+      "Room": 96,
+      "EntityIndex": 89,
+      "TargetType": 26
+    },
+    {
+      "X": 56321,
+      "Y": -1536,
+      "Z": 25088,
+      "Room": 96,
+      "EntityIndex": 89,
+      "TargetType": 27
+    },
+    {
+      "X": 57856,
+      "Y": -1792,
+      "Z": 26624,
+      "Room": 0,
+      "Angle": 0,
+      "EntityIndex": 88,
+      "TargetType": 26
+    },
+    {
+      "X": 57856,
+      "Y": -1792,
+      "Z": 26624,
+      "Room": 0,
+      "Angle": 0,
+      "EntityIndex": 88,
+      "TargetType": 27
+    },
+    {
+      "X": 60415,
+      "Y": -1024,
+      "Z": 29184,
+      "Room": 0,
+      "Angle": -16384,
+      "EntityIndex": 0,
+      "TargetType": 26
+    },
+    {
+      "X": 60415,
+      "Y": -1024,
+      "Z": 29184,
+      "Room": 0,
+      "Angle": -16384,
+      "EntityIndex": 0,
+      "TargetType": 27
+    },
+    {
+      "X": 60415,
+      "Y": -1024,
+      "Z": 32256,
+      "Room": 0,
+      "Angle": -16384,
+      "EntityIndex": 1,
+      "TargetType": 26
+    },
+    {
+      "X": 60415,
+      "Y": -1024,
+      "Z": 32256,
+      "Room": 0,
+      "Angle": -16384,
+      "EntityIndex": 1,
+      "TargetType": 27
+    },
+    {
+      "X": 50688,
+      "Y": -2048,
+      "Z": 29184,
+      "Room": 4,
+      "Angle": -32768,
+      "EntityIndex": 7,
+      "TargetType": 26
+    },
+    {
+      "X": 50688,
+      "Y": -2048,
+      "Z": 29184,
+      "Room": 4,
+      "Angle": -32768,
+      "EntityIndex": 7,
+      "TargetType": 27
+    },
+    {
+      "X": 43009,
+      "Y": 1024,
+      "Z": 35328,
+      "Room": 22,
+      "EntityIndex": 25,
+      "TargetType": 26
+    },
+    {
+      "X": 43009,
+      "Y": 1024,
+      "Z": 35328,
+      "Room": 22,
+      "EntityIndex": 25,
+      "TargetType": 27
+    },
+    {
+      "X": 55295,
+      "Y": 1536,
+      "Z": 36352,
+      "Room": 22,
+      "Angle": -16384,
+      "EntityIndex": 24,
+      "TargetType": 26
+    },
+    {
+      "X": 55295,
+      "Y": 1536,
+      "Z": 36352,
+      "Room": 22,
+      "Angle": -16384,
+      "EntityIndex": 24,
+      "TargetType": 27
+    },
+    {
+      "X": 55295,
+      "Y": 1536,
+      "Z": 39424,
+      "Room": 22,
+      "Angle": -16384,
+      "EntityIndex": 23,
+      "TargetType": 26
+    },
+    {
+      "X": 55295,
+      "Y": 1536,
+      "Z": 39424,
+      "Room": 22,
+      "Angle": -16384,
+      "EntityIndex": 23,
+      "TargetType": 27
+    },
+    {
+      "X": 55295,
+      "Y": -4864,
+      "Z": 36352,
+      "Room": 29,
+      "Angle": -16384,
+      "EntityIndex": 30,
+      "TargetType": 26
+    },
+    {
+      "X": 55295,
+      "Y": -4864,
+      "Z": 36352,
+      "Room": 29,
+      "Angle": -16384,
+      "EntityIndex": 30,
+      "TargetType": 27
+    },
+    {
+      "X": 55295,
+      "Y": -4864,
+      "Z": 38400,
+      "Room": 29,
+      "Angle": -16384,
+      "EntityIndex": 31,
+      "TargetType": 26
+    },
+    {
+      "X": 55295,
+      "Y": -4864,
+      "Z": 38400,
+      "Room": 29,
+      "Angle": -16384,
+      "EntityIndex": 31,
+      "TargetType": 27
+    },
+    {
+      "X": 43009,
+      "Y": -4864,
+      "Z": 40448,
+      "Room": 29,
+      "EntityIndex": 32,
+      "TargetType": 26
+    },
+    {
+      "X": 43009,
+      "Y": -4864,
+      "Z": 40448,
+      "Room": 29,
+      "EntityIndex": 32,
+      "TargetType": 27
+    },
+    {
+      "X": 49664,
+      "Y": 1536,
+      "Z": 23552,
+      "Room": 79,
+      "Angle": -32768,
+      "EntityIndex": 83,
+      "TargetType": 26
+    },
+    {
+      "X": 49664,
+      "Y": 1536,
+      "Z": 23552,
+      "Room": 79,
+      "Angle": -32768,
+      "EntityIndex": 83,
+      "TargetType": 27
+    },
+    {
+      "X": 39935,
+      "Y": 3584,
+      "Z": 28160,
+      "Room": 43,
+      "EntityIndex": 56,
+      "TargetType": 26
+    },
+    {
+      "X": 39935,
+      "Y": 3584,
+      "Z": 28160,
+      "Room": 43,
+      "EntityIndex": 56,
+      "TargetType": 27
+    },
+    {
+      "X": 48640,
+      "Y": 1536,
+      "Z": 17408,
+      "Room": 79,
+      "Angle": 0,
+      "EntityIndex": 82,
+      "TargetType": 26
+    },
+    {
+      "X": 48640,
+      "Y": 1536,
+      "Z": 17408,
+      "Room": 79,
+      "Angle": 0,
+      "EntityIndex": 82,
+      "TargetType": 27
+    },
+    {
+      "X": 51712,
+      "Y": 3584,
+      "Z": 19456,
+      "Room": 62,
+      "Angle": 0,
+      "EntityIndex": 55,
+      "TargetType": 26
+    },
+    {
+      "X": 51712,
+      "Y": 3584,
+      "Z": 19456,
+      "Room": 62,
+      "Angle": 0,
+      "EntityIndex": 55,
+      "TargetType": 27
+    },
+    {
+      "X": 55808,
+      "Y": 3584,
+      "Z": 19456,
+      "Room": 62,
+      "Angle": 0,
+      "EntityIndex": 64,
+      "TargetType": 26
+    },
+    {
+      "X": 55808,
+      "Y": 3584,
+      "Z": 19456,
+      "Room": 62,
+      "Angle": 0,
+      "EntityIndex": 64,
+      "TargetType": 27
+    },
+    {
+      "X": 66559,
+      "Y": 3328,
+      "Z": 19968,
+      "Room": 86,
+      "Angle": -16384,
+      "EntityIndex": 86,
+      "TargetType": 26
+    },
+    {
+      "X": 66559,
+      "Y": 3328,
+      "Z": 19968,
+      "Room": 86,
+      "Angle": -16384,
+      "EntityIndex": 86,
+      "TargetType": 27
+    },
+    {
+      "X": 39935,
+      "Y": 3584,
+      "Z": 25088,
+      "Room": 43,
+      "EntityIndex": 70,
+      "TargetType": 26
+    },
+    {
+      "X": 39935,
+      "Y": 3584,
+      "Z": 25088,
+      "Room": 43,
+      "EntityIndex": 70,
+      "TargetType": 27
+    },
+    {
+      "X": 40448,
+      "Y": 3584,
+      "Z": 17408,
+      "Room": 70,
+      "Angle": 0,
+      "EntityIndex": 71,
+      "TargetType": 26
+    },
+    {
+      "X": 40448,
+      "Y": 3584,
+      "Z": 17408,
+      "Room": 70,
+      "Angle": 0,
+      "EntityIndex": 71,
+      "TargetType": 27
+    },
+    {
+      "X": 33791,
+      "Y": 3584,
+      "Z": 19968,
+      "Room": 73,
+      "EntityIndex": 74,
+      "TargetType": 26
+    },
+    {
+      "X": 33791,
+      "Y": 3584,
+      "Z": 19968,
+      "Room": 73,
+      "EntityIndex": 74,
+      "TargetType": 27
+    },
+    {
+      "X": 33791,
+      "Y": 1024,
+      "Z": 22016,
+      "Room": 130,
+      "EntityIndex": 124,
+      "TargetType": 26
+    },
+    {
+      "X": 33791,
+      "Y": 1024,
+      "Z": 22016,
+      "Room": 130,
+      "EntityIndex": 124,
+      "TargetType": 27
+    }
+  ],
+  "RIG.TR2": [
+    {
+      "X": 39424,
+      "Y": -2816,
+      "Z": 77824,
+      "Room": 0,
+      "Angle": 0,
+      "EntityIndex": 8,
+      "TargetType": 26
+    },
+    {
+      "X": 39424,
+      "Y": -2816,
+      "Z": 77824,
+      "Room": 0,
+      "Angle": 0,
+      "EntityIndex": 8,
+      "TargetType": 27
+    },
+    {
+      "X": 40448,
+      "Y": -3072,
+      "Z": 77824,
+      "Room": 0,
+      "Angle": 0,
+      "EntityIndex": 9,
+      "TargetType": 26
+    },
+    {
+      "X": 40448,
+      "Y": -3072,
+      "Z": 77824,
+      "Room": 0,
+      "Angle": 0,
+      "EntityIndex": 9,
+      "TargetType": 27
+    },
+    {
+      "X": 36352,
+      "Y": -3840,
+      "Z": 68608,
+      "Room": 15,
+      "Angle": 0,
+      "EntityIndex": 27,
+      "TargetType": 26
+    },
+    {
+      "X": 36352,
+      "Y": -3840,
+      "Z": 68608,
+      "Room": 15,
+      "Angle": 0,
+      "EntityIndex": 27,
+      "TargetType": 27
+    },
+    {
+      "X": 26112,
+      "Y": 0,
+      "Z": 63488,
+      "Room": 60,
+      "Angle": 0,
+      "EntityIndex": 36,
+      "TargetType": 26
+    },
+    {
+      "X": 26112,
+      "Y": 0,
+      "Z": 63488,
+      "Room": 60,
+      "Angle": 0,
+      "EntityIndex": 36,
+      "TargetType": 27
+    },
+    {
+      "X": 19968,
+      "Y": -4608,
+      "Z": 65536,
+      "Room": 27,
+      "Angle": 0,
+      "EntityIndex": 46,
+      "TargetType": 26
+    },
+    {
+      "X": 19968,
+      "Y": -4608,
+      "Z": 65536,
+      "Room": 27,
+      "Angle": 0,
+      "EntityIndex": 46,
+      "TargetType": 27
+    },
+    {
+      "X": 37376,
+      "Y": -5120,
+      "Z": 61440,
+      "Room": 30,
+      "Angle": 0,
+      "EntityIndex": 47,
+      "TargetType": 26
+    },
+    {
+      "X": 37376,
+      "Y": -5120,
+      "Z": 61440,
+      "Room": 30,
+      "Angle": 0,
+      "EntityIndex": 47,
+      "TargetType": 27
+    },
+    {
+      "X": 40448,
+      "Y": -5120,
+      "Z": 61440,
+      "Room": 30,
+      "Angle": 0,
+      "EntityIndex": 49,
+      "TargetType": 26
+    },
+    {
+      "X": 40448,
+      "Y": -5120,
+      "Z": 61440,
+      "Room": 30,
+      "Angle": 0,
+      "EntityIndex": 49,
+      "TargetType": 27
+    },
+    {
+      "X": 41983,
+      "Y": -5120,
+      "Z": 65024,
+      "Room": 30,
+      "Angle": -16384,
+      "EntityIndex": 48,
+      "TargetType": 26
+    },
+    {
+      "X": 41983,
+      "Y": -5120,
+      "Z": 65024,
+      "Room": 30,
+      "Angle": -16384,
+      "EntityIndex": 48,
+      "TargetType": 27
+    },
+    {
+      "X": 41983,
+      "Y": -6144,
+      "Z": 55808,
+      "Room": 33,
+      "EntityIndex": 57,
+      "TargetType": 26
+    },
+    {
+      "X": 41983,
+      "Y": -6144,
+      "Z": 55808,
+      "Room": 33,
+      "EntityIndex": 57,
+      "TargetType": 27
+    },
+    {
+      "X": 43007,
+      "Y": -6144,
+      "Z": 53760,
+      "Room": 34,
+      "EntityIndex": 63,
+      "TargetType": 26
+    },
+    {
+      "X": 43007,
+      "Y": -6144,
+      "Z": 53760,
+      "Room": 34,
+      "EntityIndex": 63,
+      "TargetType": 27
+    },
+    {
+      "X": 50175,
+      "Y": -6912,
+      "Z": 44544,
+      "Room": 34,
+      "Angle": -16384,
+      "EntityIndex": 69,
+      "TargetType": 26
+    },
+    {
+      "X": 50175,
+      "Y": -6912,
+      "Z": 44544,
+      "Room": 34,
+      "Angle": -16384,
+      "EntityIndex": 69,
+      "TargetType": 27
+    },
+    {
+      "X": 44544,
+      "Y": -2816,
+      "Z": 39936,
+      "Room": 35,
+      "Angle": 0,
+      "EntityIndex": 70,
+      "TargetType": 26
+    },
+    {
+      "X": 44544,
+      "Y": -2816,
+      "Z": 39936,
+      "Room": 35,
+      "Angle": 0,
+      "EntityIndex": 70,
+      "TargetType": 27
+    },
+    {
+      "X": 25599,
+      "Y": 1536,
+      "Z": 45568,
+      "Room": 48,
+      "EntityIndex": 75,
+      "TargetType": 26
+    },
+    {
+      "X": 25599,
+      "Y": 1536,
+      "Z": 45568,
+      "Room": 48,
+      "EntityIndex": 75,
+      "TargetType": 27
+    },
+    {
+      "X": 31232,
+      "Y": -5120,
+      "Z": 53760,
+      "Room": 51,
+      "EntityIndex": 80,
+      "TargetType": 26
+    },
+    {
+      "X": 31232,
+      "Y": -5120,
+      "Z": 53760,
+      "Room": 51,
+      "EntityIndex": 80,
+      "TargetType": 27
+    },
+    {
+      "X": 30208,
+      "Y": 1536,
+      "Z": 54272,
+      "Room": 101,
+      "Angle": 0,
+      "EntityIndex": 102,
+      "TargetType": 26
+    },
+    {
+      "X": 30208,
+      "Y": 1536,
+      "Z": 54272,
+      "Room": 101,
+      "Angle": 0,
+      "EntityIndex": 102,
+      "TargetType": 27
+    },
+    {
+      "X": 39424,
+      "Y": 1536,
+      "Z": 52736,
+      "Room": 102,
+      "EntityIndex": 104,
+      "TargetType": 26
+    },
+    {
+      "X": 39424,
+      "Y": 1536,
+      "Z": 52736,
+      "Room": 102,
+      "EntityIndex": 104,
+      "TargetType": 27
+    },
+    {
+      "X": 34304,
+      "Y": 7936,
+      "Z": 33792,
+      "Room": 103,
+      "Angle": 0,
+      "EntityIndex": 106,
+      "TargetType": 26
+    },
+    {
+      "X": 34304,
+      "Y": 7936,
+      "Z": 33792,
+      "Room": 103,
+      "Angle": 0,
+      "EntityIndex": 106,
+      "TargetType": 27
+    },
+    {
+      "X": 43007,
+      "Y": 5120,
+      "Z": 54784,
+      "Room": 110,
+      "Angle": -16384,
+      "EntityIndex": 109,
+      "TargetType": 26
+    },
+    {
+      "X": 43007,
+      "Y": 5120,
+      "Z": 54784,
+      "Room": 110,
+      "Angle": -16384,
+      "EntityIndex": 109,
+      "TargetType": 27
+    },
+    {
+      "X": 43007,
+      "Y": 5120,
+      "Z": 57856,
+      "Room": 110,
+      "Angle": -16384,
+      "EntityIndex": 110,
+      "TargetType": 26
+    },
+    {
+      "X": 43007,
+      "Y": 5120,
+      "Z": 57856,
+      "Room": 110,
+      "Angle": -16384,
+      "EntityIndex": 110,
+      "TargetType": 27
+    },
+    {
+      "X": 34304,
+      "Y": 7936,
+      "Z": 59392,
+      "Room": 105,
+      "Angle": -32768,
+      "EntityIndex": 107,
+      "TargetType": 26
+    },
+    {
+      "X": 34304,
+      "Y": 7936,
+      "Z": 59392,
+      "Room": 105,
+      "Angle": -32768,
+      "EntityIndex": 107,
+      "TargetType": 27
+    }
+  ],
+  "PLATFORM.TR2": [
+    {
+      "X": 45568,
+      "Y": -6144,
+      "Z": 72704,
+      "Room": 12,
+      "Angle": 0,
+      "EntityIndex": 10,
+      "TargetType": 26
+    },
+    {
+      "X": 45568,
+      "Y": -6144,
+      "Z": 72704,
+      "Room": 12,
+      "Angle": 0,
+      "EntityIndex": 10,
+      "TargetType": 27
+    },
+    {
+      "X": 50175,
+      "Y": -6144,
+      "Z": 77312,
+      "Room": 12,
+      "Angle": -16384,
+      "EntityIndex": 11,
+      "TargetType": 26
+    },
+    {
+      "X": 50175,
+      "Y": -6144,
+      "Z": 77312,
+      "Room": 12,
+      "Angle": -16384,
+      "EntityIndex": 11,
+      "TargetType": 27
+    },
+    {
+      "X": 37887,
+      "Y": -6144,
+      "Z": 71168,
+      "Room": 15,
+      "EntityIndex": 14,
+      "TargetType": 26
+    },
+    {
+      "X": 37887,
+      "Y": -6144,
+      "Z": 71168,
+      "Room": 15,
+      "EntityIndex": 14,
+      "TargetType": 27
+    },
+    {
+      "X": 37887,
+      "Y": -6144,
+      "Z": 70144,
+      "Room": 15,
+      "EntityIndex": 15,
+      "TargetType": 26
+    },
+    {
+      "X": 37887,
+      "Y": -6144,
+      "Z": 70144,
+      "Room": 15,
+      "EntityIndex": 15,
+      "TargetType": 27
+    },
+    {
+      "X": 37887,
+      "Y": -6144,
+      "Z": 83456,
+      "Room": 15,
+      "EntityIndex": 19,
+      "TargetType": 26
+    },
+    {
+      "X": 37887,
+      "Y": -6144,
+      "Z": 83456,
+      "Room": 15,
+      "EntityIndex": 19,
+      "TargetType": 27
+    },
+    {
+      "X": 37887,
+      "Y": -6144,
+      "Z": 84480,
+      "Room": 15,
+      "EntityIndex": 20,
+      "TargetType": 26
+    },
+    {
+      "X": 37887,
+      "Y": -6144,
+      "Z": 84480,
+      "Room": 15,
+      "EntityIndex": 20,
+      "TargetType": 27
+    },
+    {
+      "X": 51712,
+      "Y": -6144,
+      "Z": 84992,
+      "Room": 16,
+      "Angle": -32768,
+      "EntityIndex": 21,
+      "TargetType": 26
+    },
+    {
+      "X": 51712,
+      "Y": -6144,
+      "Z": 84992,
+      "Room": 16,
+      "Angle": -32768,
+      "EntityIndex": 21,
+      "TargetType": 27
+    },
+    {
+      "X": 48640,
+      "Y": -2048,
+      "Z": 71680,
+      "Room": 17,
+      "Angle": 0,
+      "EntityIndex": 28,
+      "TargetType": 26
+    },
+    {
+      "X": 48640,
+      "Y": -2048,
+      "Z": 71680,
+      "Room": 17,
+      "Angle": 0,
+      "EntityIndex": 28,
+      "TargetType": 27
+    },
+    {
+      "X": 39935,
+      "Y": -2048,
+      "Z": 81408,
+      "Room": 17,
+      "EntityIndex": 29,
+      "TargetType": 26
+    },
+    {
+      "X": 39935,
+      "Y": -2048,
+      "Z": 81408,
+      "Room": 17,
+      "EntityIndex": 29,
+      "TargetType": 27
+    },
+    {
+      "X": 49664,
+      "Y": -2048,
+      "Z": 82944,
+      "Room": 17,
+      "Angle": -32768,
+      "EntityIndex": 34,
+      "TargetType": 26
+    },
+    {
+      "X": 49664,
+      "Y": -2048,
+      "Z": 82944,
+      "Room": 17,
+      "Angle": -32768,
+      "EntityIndex": 34,
+      "TargetType": 27
+    },
+    {
+      "X": 43520,
+      "Y": -10240,
+      "Z": 81920,
+      "Room": 21,
+      "Angle": -32768,
+      "EntityIndex": 36,
+      "TargetType": 26
+    },
+    {
+      "X": 43520,
+      "Y": -10240,
+      "Z": 81920,
+      "Room": 21,
+      "Angle": -32768,
+      "EntityIndex": 36,
+      "TargetType": 27
+    },
+    {
+      "X": 47616,
+      "Y": -10240,
+      "Z": 81920,
+      "Room": 21,
+      "Angle": -32768,
+      "EntityIndex": 37,
+      "TargetType": 26
+    },
+    {
+      "X": 47616,
+      "Y": -10240,
+      "Z": 81920,
+      "Room": 21,
+      "Angle": -32768,
+      "EntityIndex": 37,
+      "TargetType": 27
+    },
+    {
+      "X": 45568,
+      "Y": -10496,
+      "Z": 81920,
+      "Room": 21,
+      "Angle": -32768,
+      "EntityIndex": 38,
+      "TargetType": 26
+    },
+    {
+      "X": 45568,
+      "Y": -10496,
+      "Z": 81920,
+      "Room": 21,
+      "Angle": -32768,
+      "EntityIndex": 38,
+      "TargetType": 27
+    },
+    {
+      "X": 47616,
+      "Y": -10240,
+      "Z": 72704,
+      "Room": 21,
+      "Angle": 0,
+      "EntityIndex": 39,
+      "TargetType": 26
+    },
+    {
+      "X": 47616,
+      "Y": -10240,
+      "Z": 72704,
+      "Room": 21,
+      "Angle": 0,
+      "EntityIndex": 39,
+      "TargetType": 27
+    },
+    {
+      "X": 43520,
+      "Y": -10240,
+      "Z": 72704,
+      "Room": 21,
+      "Angle": 0,
+      "EntityIndex": 40,
+      "TargetType": 26
+    },
+    {
+      "X": 43520,
+      "Y": -10240,
+      "Z": 72704,
+      "Room": 21,
+      "Angle": 0,
+      "EntityIndex": 40,
+      "TargetType": 27
+    },
+    {
+      "X": 45568,
+      "Y": -10496,
+      "Z": 72704,
+      "Room": 21,
+      "Angle": 0,
+      "EntityIndex": 48,
+      "TargetType": 26
+    },
+    {
+      "X": 45568,
+      "Y": -10496,
+      "Z": 72704,
+      "Room": 21,
+      "Angle": 0,
+      "EntityIndex": 48,
+      "TargetType": 27
+    },
+    {
+      "X": 59391,
+      "Y": -4864,
+      "Z": 77312,
+      "Room": 34,
+      "EntityIndex": 51,
+      "TargetType": 26
+    },
+    {
+      "X": 59391,
+      "Y": -4864,
+      "Z": 77312,
+      "Room": 34,
+      "EntityIndex": 51,
+      "TargetType": 27
+    },
+    {
+      "X": 59391,
+      "Y": -4864,
+      "Z": 76288,
+      "Room": 34,
+      "EntityIndex": 59,
+      "TargetType": 26
+    },
+    {
+      "X": 59391,
+      "Y": -4864,
+      "Z": 76288,
+      "Room": 34,
+      "EntityIndex": 59,
+      "TargetType": 27
+    },
+    {
+      "X": 65024,
+      "Y": -4864,
+      "Z": 66560,
+      "Room": 34,
+      "Angle": 0,
+      "EntityIndex": 61,
+      "TargetType": 26
+    },
+    {
+      "X": 65024,
+      "Y": -4864,
+      "Z": 66560,
+      "Room": 34,
+      "Angle": 0,
+      "EntityIndex": 61,
+      "TargetType": 27
+    },
+    {
+      "X": 61952,
+      "Y": -4864,
+      "Z": 66560,
+      "Room": 34,
+      "Angle": 0,
+      "EntityIndex": 62,
+      "TargetType": 26
+    },
+    {
+      "X": 61952,
+      "Y": -4864,
+      "Z": 66560,
+      "Room": 34,
+      "Angle": 0,
+      "EntityIndex": 62,
+      "TargetType": 27
+    },
+    {
+      "X": 32767,
+      "Y": 0,
+      "Z": 53760,
+      "Room": 42,
+      "EntityIndex": 74,
+      "TargetType": 26
+    },
+    {
+      "X": 32767,
+      "Y": 0,
+      "Z": 53760,
+      "Room": 42,
+      "EntityIndex": 74,
+      "TargetType": 27
+    },
+    {
+      "X": 32767,
+      "Y": 0,
+      "Z": 52736,
+      "Room": 42,
+      "EntityIndex": 75,
+      "TargetType": 26
+    },
+    {
+      "X": 32767,
+      "Y": 0,
+      "Z": 52736,
+      "Room": 42,
+      "EntityIndex": 75,
+      "TargetType": 27
+    },
+    {
+      "X": 40959,
+      "Y": 0,
+      "Z": 52736,
+      "Room": 42,
+      "Angle": -16384,
+      "EntityIndex": 79,
+      "TargetType": 26
+    },
+    {
+      "X": 40959,
+      "Y": 0,
+      "Z": 52736,
+      "Room": 42,
+      "Angle": -16384,
+      "EntityIndex": 79,
+      "TargetType": 27
+    },
+    {
+      "X": 40959,
+      "Y": 0,
+      "Z": 53760,
+      "Room": 42,
+      "Angle": -16384,
+      "EntityIndex": 81,
+      "TargetType": 26
+    },
+    {
+      "X": 40959,
+      "Y": 0,
+      "Z": 53760,
+      "Room": 42,
+      "Angle": -16384,
+      "EntityIndex": 81,
+      "TargetType": 27
+    },
+    {
+      "X": 40448,
+      "Y": 0,
+      "Z": 52224,
+      "Room": 42,
+      "Angle": 0,
+      "EntityIndex": 80,
+      "TargetType": 26
+    },
+    {
+      "X": 40448,
+      "Y": 0,
+      "Z": 52224,
+      "Room": 42,
+      "Angle": 0,
+      "EntityIndex": 80,
+      "TargetType": 27
+    },
+    {
+      "X": 32767,
+      "Y": -6144,
+      "Z": 77312,
+      "Room": 54,
+      "Angle": -16384,
+      "EntityIndex": 95,
+      "TargetType": 26
+    },
+    {
+      "X": 32767,
+      "Y": -6144,
+      "Z": 77312,
+      "Room": 54,
+      "Angle": -16384,
+      "EntityIndex": 95,
+      "TargetType": 27
+    },
+    {
+      "X": 57856,
+      "Y": -3840,
+      "Z": 83968,
+      "Room": 65,
+      "Angle": 0,
+      "EntityIndex": 101,
+      "TargetType": 26
+    },
+    {
+      "X": 57856,
+      "Y": -3840,
+      "Z": 83968,
+      "Room": 65,
+      "Angle": 0,
+      "EntityIndex": 101,
+      "TargetType": 27
+    },
+    {
+      "X": 59904,
+      "Y": -3840,
+      "Z": 83968,
+      "Room": 65,
+      "Angle": 0,
+      "EntityIndex": 102,
+      "TargetType": 26
+    },
+    {
+      "X": 59904,
+      "Y": -3840,
+      "Z": 83968,
+      "Room": 65,
+      "Angle": 0,
+      "EntityIndex": 102,
+      "TargetType": 27
+    },
+    {
+      "X": 44544,
+      "Y": 4096,
+      "Z": 80896,
+      "Room": 20,
+      "Angle": -32768,
+      "EntityIndex": 109,
+      "TargetType": 26
+    },
+    {
+      "X": 44544,
+      "Y": 4096,
+      "Z": 80896,
+      "Room": 20,
+      "Angle": -32768,
+      "EntityIndex": 109,
+      "TargetType": 27
+    },
+    {
+      "X": 46592,
+      "Y": 4096,
+      "Z": 80896,
+      "Room": 20,
+      "Angle": -32768,
+      "EntityIndex": 110,
+      "TargetType": 26
+    },
+    {
+      "X": 46592,
+      "Y": 4096,
+      "Z": 80896,
+      "Room": 20,
+      "Angle": -32768,
+      "EntityIndex": 110,
+      "TargetType": 27
+    },
+    {
+      "X": 45568,
+      "Y": 2048,
+      "Z": 73728,
+      "Room": 20,
+      "Angle": 0,
+      "EntityIndex": 111,
+      "TargetType": 26
+    },
+    {
+      "X": 45568,
+      "Y": 2048,
+      "Z": 73728,
+      "Room": 20,
+      "Angle": 0,
+      "EntityIndex": 111,
+      "TargetType": 27
+    },
+    {
+      "X": 66559,
+      "Y": -1536,
+      "Z": 71168,
+      "Room": 32,
+      "Angle": -16384,
+      "EntityIndex": 125,
+      "TargetType": 26
+    },
+    {
+      "X": 66559,
+      "Y": -1536,
+      "Z": 71168,
+      "Room": 32,
+      "Angle": -16384,
+      "EntityIndex": 125,
+      "TargetType": 27
+    }
+  ],
+  "UNWATER.TR2": [
+    {
+      "X": 46592,
+      "Y": 0,
+      "Z": 67584,
+      "Room": 2,
+      "Angle": -32768,
+      "EntityIndex": 2,
+      "TargetType": 26
+    },
+    {
+      "X": 46592,
+      "Y": 0,
+      "Z": 67584,
+      "Room": 2,
+      "Angle": -32768,
+      "EntityIndex": 2,
+      "TargetType": 27
+    },
+    {
+      "X": 56319,
+      "Y": -6656,
+      "Z": 68096,
+      "Room": 2,
+      "Angle": -16384,
+      "EntityIndex": 3,
+      "TargetType": 26
+    },
+    {
+      "X": 56319,
+      "Y": -6656,
+      "Z": 68096,
+      "Room": 2,
+      "Angle": -16384,
+      "EntityIndex": 3,
+      "TargetType": 27
+    },
+    {
+      "X": 68096,
+      "Y": -7936,
+      "Z": 71680,
+      "Room": 20,
+      "Angle": 0,
+      "EntityIndex": 12,
+      "TargetType": 26
+    },
+    {
+      "X": 68096,
+      "Y": -7936,
+      "Z": 71680,
+      "Room": 20,
+      "Angle": 0,
+      "EntityIndex": 12,
+      "TargetType": 27
+    },
+    {
+      "X": 84991,
+      "Y": -10240,
+      "Z": 45568,
+      "Room": 36,
+      "Angle": -16384,
+      "EntityIndex": 32,
+      "TargetType": 26
+    },
+    {
+      "X": 84991,
+      "Y": -10240,
+      "Z": 45568,
+      "Room": 36,
+      "Angle": -16384,
+      "EntityIndex": 32,
+      "TargetType": 27
+    },
+    {
+      "X": 78847,
+      "Y": -10240,
+      "Z": 45568,
+      "Room": 36,
+      "EntityIndex": 35,
+      "TargetType": 26
+    },
+    {
+      "X": 78847,
+      "Y": -10240,
+      "Z": 45568,
+      "Room": 36,
+      "EntityIndex": 35,
+      "TargetType": 27
+    },
+    {
+      "X": 78847,
+      "Y": -10240,
+      "Z": 46592,
+      "Room": 37,
+      "EntityIndex": 36,
+      "TargetType": 26
+    },
+    {
+      "X": 78847,
+      "Y": -10240,
+      "Z": 46592,
+      "Room": 37,
+      "EntityIndex": 36,
+      "TargetType": 27
+    },
+    {
+      "X": 62463,
+      "Y": -2304,
+      "Z": 77312,
+      "Room": 21,
+      "EntityIndex": 61,
+      "TargetType": 26
+    },
+    {
+      "X": 62463,
+      "Y": -2304,
+      "Z": 77312,
+      "Room": 21,
+      "EntityIndex": 61,
+      "TargetType": 27
+    },
+    {
+      "X": 68607,
+      "Y": -2304,
+      "Z": 77312,
+      "Room": 21,
+      "Angle": -16384,
+      "EntityIndex": 62,
+      "TargetType": 26
+    },
+    {
+      "X": 68607,
+      "Y": -2304,
+      "Z": 77312,
+      "Room": 21,
+      "Angle": -16384,
+      "EntityIndex": 62,
+      "TargetType": 27
+    },
+    {
+      "X": 82432,
+      "Y": -3072,
+      "Z": 33792,
+      "Room": 44,
+      "Angle": -32768,
+      "EntityIndex": 68,
+      "TargetType": 26
+    },
+    {
+      "X": 82432,
+      "Y": -3072,
+      "Z": 33792,
+      "Room": 44,
+      "Angle": -32768,
+      "EntityIndex": 68,
+      "TargetType": 27
+    }
+  ],
+  "KEEL.TR2": [
+    {
+      "X": 75264,
+      "Y": 11008,
+      "Z": 17920,
+      "Room": 88,
+      "Angle": 0,
+      "EntityIndex": 0,
+      "TargetType": 26
+    },
+    {
+      "X": 75264,
+      "Y": 11008,
+      "Z": 17920,
+      "Room": 88,
+      "Angle": 0,
+      "EntityIndex": 0,
+      "TargetType": 27
+    },
+    {
+      "X": 77312,
+      "Y": 11008,
+      "Z": 15872,
+      "Room": 88,
+      "Angle": 0,
+      "EntityIndex": 2,
+      "TargetType": 26
+    },
+    {
+      "X": 77312,
+      "Y": 11008,
+      "Z": 15872,
+      "Room": 88,
+      "Angle": 0,
+      "EntityIndex": 2,
+      "TargetType": 27
+    },
+    {
+      "X": 79360,
+      "Y": 11008,
+      "Z": 15872,
+      "Room": 88,
+      "Angle": 0,
+      "EntityIndex": 3,
+      "TargetType": 26
+    },
+    {
+      "X": 79360,
+      "Y": 11008,
+      "Z": 15872,
+      "Room": 88,
+      "Angle": 0,
+      "EntityIndex": 3,
+      "TargetType": 27
+    },
+    {
+      "X": 67072,
+      "Y": 2560,
+      "Z": 41472,
+      "Room": 15,
+      "EntityIndex": 10,
+      "TargetType": 26
+    },
+    {
+      "X": 67072,
+      "Y": 2560,
+      "Z": 41472,
+      "Room": 15,
+      "EntityIndex": 10,
+      "TargetType": 27
+    },
+    {
+      "X": 66048,
+      "Y": 2560,
+      "Z": 52736,
+      "Room": 12,
+      "Angle": 0,
+      "EntityIndex": 7,
+      "TargetType": 26
+    },
+    {
+      "X": 66048,
+      "Y": 2560,
+      "Z": 52736,
+      "Room": 12,
+      "Angle": 0,
+      "EntityIndex": 7,
+      "TargetType": 27
+    },
+    {
+      "X": 53760,
+      "Y": -5632,
+      "Z": 26624,
+      "Room": 23,
+      "Angle": 0,
+      "EntityIndex": 22,
+      "TargetType": 26
+    },
+    {
+      "X": 53760,
+      "Y": -5632,
+      "Z": 26624,
+      "Room": 23,
+      "Angle": 0,
+      "EntityIndex": 22,
+      "TargetType": 27
+    },
+    {
+      "X": 58880,
+      "Y": -5632,
+      "Z": 26624,
+      "Room": 23,
+      "Angle": 0,
+      "EntityIndex": 23,
+      "TargetType": 26
+    },
+    {
+      "X": 58880,
+      "Y": -5632,
+      "Z": 26624,
+      "Room": 23,
+      "Angle": 0,
+      "EntityIndex": 23,
+      "TargetType": 27
+    },
+    {
+      "X": 53760,
+      "Y": -5632,
+      "Z": 20480,
+      "Room": 25,
+      "Angle": 0,
+      "EntityIndex": 26,
+      "TargetType": 26
+    },
+    {
+      "X": 53760,
+      "Y": -5632,
+      "Z": 20480,
+      "Room": 25,
+      "Angle": 0,
+      "EntityIndex": 26,
+      "TargetType": 27
+    },
+    {
+      "X": 58880,
+      "Y": -5632,
+      "Z": 20480,
+      "Room": 25,
+      "Angle": 0,
+      "EntityIndex": 30,
+      "TargetType": 26
+    },
+    {
+      "X": 58880,
+      "Y": -5632,
+      "Z": 20480,
+      "Room": 25,
+      "Angle": 0,
+      "EntityIndex": 30,
+      "TargetType": 27
+    },
+    {
+      "X": 51712,
+      "Y": 1792,
+      "Z": 37888,
+      "Room": 41,
+      "Angle": 0,
+      "EntityIndex": 46,
+      "TargetType": 26
+    },
+    {
+      "X": 51712,
+      "Y": 1792,
+      "Z": 37888,
+      "Room": 41,
+      "Angle": 0,
+      "EntityIndex": 46,
+      "TargetType": 27
+    },
+    {
+      "X": 46592,
+      "Y": 1792,
+      "Z": 37888,
+      "Room": 41,
+      "Angle": 0,
+      "EntityIndex": 57,
+      "TargetType": 26
+    },
+    {
+      "X": 46592,
+      "Y": 1792,
+      "Z": 37888,
+      "Room": 41,
+      "Angle": 0,
+      "EntityIndex": 57,
+      "TargetType": 27
+    },
+    {
+      "X": 45568,
+      "Y": 1792,
+      "Z": 37888,
+      "Room": 41,
+      "Angle": 0,
+      "EntityIndex": 58,
+      "TargetType": 26
+    },
+    {
+      "X": 45568,
+      "Y": 1792,
+      "Z": 37888,
+      "Room": 41,
+      "Angle": 0,
+      "EntityIndex": 58,
+      "TargetType": 27
+    },
+    {
+      "X": 53760,
+      "Y": 3072,
+      "Z": 48128,
+      "Room": 41,
+      "Angle": -32768,
+      "EntityIndex": 59,
+      "TargetType": 26
+    },
+    {
+      "X": 53760,
+      "Y": 3072,
+      "Z": 48128,
+      "Room": 41,
+      "Angle": -32768,
+      "EntityIndex": 59,
+      "TargetType": 27
+    },
+    {
+      "X": 60415,
+      "Y": 3328,
+      "Z": 54784,
+      "Room": 47,
+      "EntityIndex": 69,
+      "TargetType": 26
+    },
+    {
+      "X": 60415,
+      "Y": 3328,
+      "Z": 54784,
+      "Room": 47,
+      "EntityIndex": 69,
+      "TargetType": 27
+    },
+    {
+      "X": 60415,
+      "Y": 3328,
+      "Z": 55808,
+      "Room": 47,
+      "EntityIndex": 70,
+      "TargetType": 26
+    },
+    {
+      "X": 60415,
+      "Y": 3328,
+      "Z": 55808,
+      "Room": 47,
+      "EntityIndex": 70,
+      "TargetType": 27
+    },
+    {
+      "X": 65024,
+      "Y": 3328,
+      "Z": 52224,
+      "Room": 47,
+      "Angle": 0,
+      "EntityIndex": 71,
+      "TargetType": 26
+    },
+    {
+      "X": 65024,
+      "Y": 3328,
+      "Z": 52224,
+      "Room": 47,
+      "Angle": 0,
+      "EntityIndex": 71,
+      "TargetType": 27
+    },
+    {
+      "X": 64000,
+      "Y": 3328,
+      "Z": 52224,
+      "Room": 47,
+      "Angle": 0,
+      "EntityIndex": 72,
+      "TargetType": 26
+    },
+    {
+      "X": 64000,
+      "Y": 3328,
+      "Z": 52224,
+      "Room": 47,
+      "Angle": 0,
+      "EntityIndex": 72,
+      "TargetType": 27
+    },
+    {
+      "X": 60415,
+      "Y": 3840,
+      "Z": 66048,
+      "Room": 49,
+      "EntityIndex": 86,
+      "TargetType": 26
+    },
+    {
+      "X": 60415,
+      "Y": 3840,
+      "Z": 66048,
+      "Room": 49,
+      "EntityIndex": 86,
+      "TargetType": 27
+    },
+    {
+      "X": 76288,
+      "Y": 4096,
+      "Z": 61440,
+      "Room": 55,
+      "Angle": 0,
+      "EntityIndex": 88,
+      "TargetType": 26
+    },
+    {
+      "X": 76288,
+      "Y": 4096,
+      "Z": 61440,
+      "Room": 55,
+      "Angle": 0,
+      "EntityIndex": 88,
+      "TargetType": 27
+    },
+    {
+      "X": 73216,
+      "Y": 4096,
+      "Z": 61440,
+      "Room": 55,
+      "Angle": 0,
+      "EntityIndex": 92,
+      "TargetType": 26
+    },
+    {
+      "X": 73216,
+      "Y": 4096,
+      "Z": 61440,
+      "Room": 55,
+      "Angle": 0,
+      "EntityIndex": 92,
+      "TargetType": 27
+    },
+    {
+      "X": 67583,
+      "Y": 2048,
+      "Z": 70144,
+      "Room": 56,
+      "EntityIndex": 93,
+      "TargetType": 26
+    },
+    {
+      "X": 67583,
+      "Y": 2048,
+      "Z": 70144,
+      "Room": 56,
+      "EntityIndex": 93,
+      "TargetType": 27
+    },
+    {
+      "X": 81919,
+      "Y": 2048,
+      "Z": 70144,
+      "Room": 56,
+      "Angle": -16384,
+      "EntityIndex": 98,
+      "TargetType": 26
+    },
+    {
+      "X": 81919,
+      "Y": 2048,
+      "Z": 70144,
+      "Room": 56,
+      "Angle": -16384,
+      "EntityIndex": 98,
+      "TargetType": 27
+    },
+    {
+      "X": 60928,
+      "Y": 2304,
+      "Z": 79872,
+      "Room": 63,
+      "Angle": 0,
+      "EntityIndex": 118,
+      "TargetType": 26
+    },
+    {
+      "X": 60928,
+      "Y": 2304,
+      "Z": 79872,
+      "Room": 63,
+      "Angle": 0,
+      "EntityIndex": 118,
+      "TargetType": 27
+    },
+    {
+      "X": 55808,
+      "Y": 3328,
+      "Z": 84992,
+      "Room": 71,
+      "Angle": 0,
+      "EntityIndex": 131,
+      "TargetType": 26
+    },
+    {
+      "X": 55808,
+      "Y": 3328,
+      "Z": 84992,
+      "Room": 71,
+      "Angle": 0,
+      "EntityIndex": 131,
+      "TargetType": 27
+    },
+    {
+      "X": 48128,
+      "Y": 6400,
+      "Z": 82432,
+      "Room": 76,
+      "Angle": -16384,
+      "EntityIndex": 152,
+      "TargetType": 26
+    },
+    {
+      "X": 48128,
+      "Y": 6400,
+      "Z": 82432,
+      "Room": 76,
+      "Angle": -16384,
+      "EntityIndex": 152,
+      "TargetType": 27
+    },
+    {
+      "X": 48128,
+      "Y": 6400,
+      "Z": 81408,
+      "Room": 76,
+      "Angle": -16384,
+      "EntityIndex": 153,
+      "TargetType": 26
+    },
+    {
+      "X": 48128,
+      "Y": 6400,
+      "Z": 81408,
+      "Room": 76,
+      "Angle": -16384,
+      "EntityIndex": 153,
+      "TargetType": 27
+    },
+    {
+      "X": 49152,
+      "Y": 2560,
+      "Z": 85504,
+      "Room": 80,
+      "Angle": -16384,
+      "EntityIndex": 158,
+      "TargetType": 26
+    },
+    {
+      "X": 49152,
+      "Y": 2560,
+      "Z": 85504,
+      "Room": 80,
+      "Angle": -16384,
+      "EntityIndex": 158,
+      "TargetType": 27
+    },
+    {
+      "X": 42496,
+      "Y": 1536,
+      "Z": 12288,
+      "Room": 82,
+      "Angle": 0,
+      "EntityIndex": 168,
+      "TargetType": 26
+    },
+    {
+      "X": 42496,
+      "Y": 1536,
+      "Z": 12288,
+      "Room": 82,
+      "Angle": 0,
+      "EntityIndex": 168,
+      "TargetType": 27
+    },
+    {
+      "X": 52736,
+      "Y": 1536,
+      "Z": 12288,
+      "Room": 82,
+      "Angle": 0,
+      "EntityIndex": 169,
+      "TargetType": 26
+    },
+    {
+      "X": 52736,
+      "Y": 1536,
+      "Z": 12288,
+      "Room": 82,
+      "Angle": 0,
+      "EntityIndex": 169,
+      "TargetType": 27
+    },
+    {
+      "X": 80384,
+      "Y": 11008,
+      "Z": 17920,
+      "Room": 88,
+      "Angle": 0,
+      "EntityIndex": 175,
+      "TargetType": 26
+    },
+    {
+      "X": 80384,
+      "Y": 11008,
+      "Z": 17920,
+      "Room": 88,
+      "Angle": 0,
+      "EntityIndex": 175,
+      "TargetType": 27
+    },
+    {
+      "X": 37376,
+      "Y": 2944,
+      "Z": 26624,
+      "Room": 37,
+      "Angle": 0,
+      "EntityIndex": 184,
+      "TargetType": 26
+    },
+    {
+      "X": 37376,
+      "Y": 2944,
+      "Z": 26624,
+      "Room": 37,
+      "Angle": 0,
+      "EntityIndex": 184,
+      "TargetType": 27
+    },
+    {
+      "X": 41472,
+      "Y": 9088,
+      "Z": 82432,
+      "Room": 98,
+      "EntityIndex": 190,
+      "TargetType": 26
+    },
+    {
+      "X": 41472,
+      "Y": 9088,
+      "Z": 82432,
+      "Room": 98,
+      "EntityIndex": 190,
+      "TargetType": 27
+    },
+    {
+      "X": 48127,
+      "Y": 6400,
+      "Z": 12800,
+      "Room": 102,
+      "Angle": -16384,
+      "EntityIndex": 191,
+      "TargetType": 26
+    },
+    {
+      "X": 48127,
+      "Y": 6400,
+      "Z": 12800,
+      "Room": 102,
+      "Angle": -16384,
+      "EntityIndex": 191,
+      "TargetType": 27
+    },
+    {
+      "X": 37888,
+      "Y": 7680,
+      "Z": 17920,
+      "Room": 100,
+      "EntityIndex": 192,
+      "TargetType": 26
+    },
+    {
+      "X": 37888,
+      "Y": 7680,
+      "Z": 17920,
+      "Room": 100,
+      "EntityIndex": 192,
+      "TargetType": 27
+    },
+    {
+      "X": 44544,
+      "Y": 1792,
+      "Z": 37888,
+      "Room": 41,
+      "Angle": 0,
+      "EntityIndex": 194,
+      "TargetType": 26
+    },
+    {
+      "X": 44544,
+      "Y": 1792,
+      "Z": 37888,
+      "Room": 41,
+      "Angle": 0,
+      "EntityIndex": 194,
+      "TargetType": 27
+    },
+    {
+      "X": 52736,
+      "Y": 1792,
+      "Z": 37888,
+      "Room": 41,
+      "Angle": 0,
+      "EntityIndex": 195,
+      "TargetType": 26
+    },
+    {
+      "X": 52736,
+      "Y": 1792,
+      "Z": 37888,
+      "Room": 41,
+      "Angle": 0,
+      "EntityIndex": 195,
+      "TargetType": 27
+    },
+    {
+      "X": 61952,
+      "Y": -1792,
+      "Z": 31744,
+      "Room": 19,
+      "Angle": -32768,
+      "EntityIndex": 196,
+      "TargetType": 26
+    },
+    {
+      "X": 61952,
+      "Y": -1792,
+      "Z": 31744,
+      "Room": 19,
+      "Angle": -32768,
+      "EntityIndex": 196,
+      "TargetType": 27
+    }
+  ],
+  "LIVING.TR2": [
+    {
+      "X": 76288,
+      "Y": -1024,
+      "Z": 91136,
+      "Room": 0,
+      "Angle": -32768,
+      "EntityIndex": 3,
+      "TargetType": 26
+    },
+    {
+      "X": 76288,
+      "Y": -1024,
+      "Z": 91136,
+      "Room": 0,
+      "Angle": -32768,
+      "EntityIndex": 3,
+      "TargetType": 27
+    },
+    {
+      "X": 64000,
+      "Y": -256,
+      "Z": 64512,
+      "Room": 6,
+      "Angle": 0,
+      "EntityIndex": 17,
+      "TargetType": 26
+    },
+    {
+      "X": 64000,
+      "Y": -256,
+      "Z": 64512,
+      "Room": 6,
+      "Angle": 0,
+      "EntityIndex": 17,
+      "TargetType": 27
+    },
+    {
+      "X": 62976,
+      "Y": -256,
+      "Z": 64512,
+      "Room": 6,
+      "Angle": 0,
+      "EntityIndex": 18,
+      "TargetType": 26
+    },
+    {
+      "X": 62976,
+      "Y": -256,
+      "Z": 64512,
+      "Room": 6,
+      "Angle": 0,
+      "EntityIndex": 18,
+      "TargetType": 27
+    },
+    {
+      "X": 61952,
+      "Y": 256,
+      "Z": 72704,
+      "Room": 6,
+      "Angle": -32768,
+      "EntityIndex": 21,
+      "TargetType": 26
+    },
+    {
+      "X": 61952,
+      "Y": 256,
+      "Z": 72704,
+      "Room": 6,
+      "Angle": -32768,
+      "EntityIndex": 21,
+      "TargetType": 27
+    },
+    {
+      "X": 73727,
+      "Y": -5376,
+      "Z": 92672,
+      "Room": 12,
+      "Angle": -16384,
+      "EntityIndex": 31,
+      "TargetType": 26
+    },
+    {
+      "X": 73727,
+      "Y": -5376,
+      "Z": 92672,
+      "Room": 12,
+      "Angle": -16384,
+      "EntityIndex": 31,
+      "TargetType": 27
+    },
+    {
+      "X": 66559,
+      "Y": 3328,
+      "Z": 58880,
+      "Room": 15,
+      "Angle": -16384,
+      "EntityIndex": 34,
+      "TargetType": 26
+    },
+    {
+      "X": 66559,
+      "Y": 3328,
+      "Z": 58880,
+      "Room": 15,
+      "Angle": -16384,
+      "EntityIndex": 34,
+      "TargetType": 27
+    },
+    {
+      "X": 73216,
+      "Y": -2560,
+      "Z": 59392,
+      "Room": 18,
+      "Angle": -32768,
+      "EntityIndex": 41,
+      "TargetType": 26
+    },
+    {
+      "X": 73216,
+      "Y": -2560,
+      "Z": 59392,
+      "Room": 18,
+      "Angle": -32768,
+      "EntityIndex": 41,
+      "TargetType": 27
+    },
+    {
+      "X": 61952,
+      "Y": -3328,
+      "Z": 50176,
+      "Room": 20,
+      "Angle": -32768,
+      "EntityIndex": 43,
+      "TargetType": 26
+    },
+    {
+      "X": 61952,
+      "Y": -3328,
+      "Z": 50176,
+      "Room": 20,
+      "Angle": -32768,
+      "EntityIndex": 43,
+      "TargetType": 27
+    },
+    {
+      "X": 59391,
+      "Y": -3072,
+      "Z": 41472,
+      "Room": 21,
+      "Angle": -16384,
+      "EntityIndex": 45,
+      "TargetType": 26
+    },
+    {
+      "X": 59391,
+      "Y": -3072,
+      "Z": 41472,
+      "Room": 21,
+      "Angle": -16384,
+      "EntityIndex": 45,
+      "TargetType": 27
+    },
+    {
+      "X": 55295,
+      "Y": -3072,
+      "Z": 38400,
+      "Room": 34,
+      "EntityIndex": 46,
+      "TargetType": 26
+    },
+    {
+      "X": 55295,
+      "Y": -3072,
+      "Z": 38400,
+      "Room": 34,
+      "EntityIndex": 46,
+      "TargetType": 27
+    },
+    {
+      "X": 50688,
+      "Y": 512,
+      "Z": 63488,
+      "Room": 26,
+      "Angle": 0,
+      "EntityIndex": 52,
+      "TargetType": 26
+    },
+    {
+      "X": 50688,
+      "Y": 512,
+      "Z": 63488,
+      "Room": 26,
+      "Angle": 0,
+      "EntityIndex": 52,
+      "TargetType": 27
+    },
+    {
+      "X": 55808,
+      "Y": -1792,
+      "Z": 72704,
+      "Room": 29,
+      "Angle": -32768,
+      "EntityIndex": 54,
+      "TargetType": 26
+    },
+    {
+      "X": 55808,
+      "Y": -1792,
+      "Z": 72704,
+      "Room": 29,
+      "Angle": -32768,
+      "EntityIndex": 54,
+      "TargetType": 27
+    },
+    {
+      "X": 45568,
+      "Y": 1280,
+      "Z": 69632,
+      "Room": 32,
+      "Angle": 0,
+      "EntityIndex": 55,
+      "TargetType": 26
+    },
+    {
+      "X": 45568,
+      "Y": 1280,
+      "Z": 69632,
+      "Room": 32,
+      "Angle": 0,
+      "EntityIndex": 55,
+      "TargetType": 27
+    },
+    {
+      "X": 59904,
+      "Y": -3072,
+      "Z": 40960,
+      "Room": 34,
+      "Angle": -32768,
+      "EntityIndex": 57,
+      "TargetType": 26
+    },
+    {
+      "X": 59904,
+      "Y": -3072,
+      "Z": 40960,
+      "Room": 34,
+      "Angle": -32768,
+      "EntityIndex": 57,
+      "TargetType": 27
+    },
+    {
+      "X": 71679,
+      "Y": -3584,
+      "Z": 35328,
+      "Room": 42,
+      "Angle": -16384,
+      "EntityIndex": 60,
+      "TargetType": 26
+    },
+    {
+      "X": 71679,
+      "Y": -3584,
+      "Z": 35328,
+      "Room": 42,
+      "Angle": -16384,
+      "EntityIndex": 60,
+      "TargetType": 27
+    },
+    {
+      "X": 45055,
+      "Y": -3072,
+      "Z": 31232,
+      "Room": 37,
+      "EntityIndex": 65,
+      "TargetType": 26
+    },
+    {
+      "X": 45055,
+      "Y": -3072,
+      "Z": 31232,
+      "Room": 37,
+      "EntityIndex": 65,
+      "TargetType": 27
+    },
+    {
+      "X": 43011,
+      "Y": -2560,
+      "Z": 34304,
+      "Room": 37,
+      "EntityIndex": 70,
+      "TargetType": 26
+    },
+    {
+      "X": 43011,
+      "Y": -2560,
+      "Z": 34304,
+      "Room": 37,
+      "EntityIndex": 70,
+      "TargetType": 27
+    },
+    {
+      "X": 54784,
+      "Y": -2560,
+      "Z": 30720,
+      "Room": 37,
+      "Angle": 0,
+      "EntityIndex": 66,
+      "TargetType": 26
+    },
+    {
+      "X": 54784,
+      "Y": -2560,
+      "Z": 30720,
+      "Room": 37,
+      "Angle": 0,
+      "EntityIndex": 66,
+      "TargetType": 27
+    },
+    {
+      "X": 43007,
+      "Y": -4864,
+      "Z": 41472,
+      "Room": 37,
+      "EntityIndex": 67,
+      "TargetType": 26
+    },
+    {
+      "X": 43007,
+      "Y": -4864,
+      "Z": 41472,
+      "Room": 37,
+      "EntityIndex": 67,
+      "TargetType": 27
+    },
+    {
+      "X": 40448,
+      "Y": -5120,
+      "Z": 39936,
+      "Room": 38,
+      "Angle": -32768,
+      "EntityIndex": 71,
+      "TargetType": 26
+    },
+    {
+      "X": 40448,
+      "Y": -5120,
+      "Z": 39936,
+      "Room": 38,
+      "Angle": -32768,
+      "EntityIndex": 71,
+      "TargetType": 27
+    }
+  ],
+  "DECK.TR2": [
+    {
+      "X": 51199,
+      "Y": 4864,
+      "Z": 51712,
+      "Room": 12,
+      "EntityIndex": 11,
+      "TargetType": 26
+    },
+    {
+      "X": 51199,
+      "Y": 4864,
+      "Z": 51712,
+      "Room": 12,
+      "EntityIndex": 11,
+      "TargetType": 27
+    },
+    {
+      "X": 37376,
+      "Y": -3072,
+      "Z": 45056,
+      "Room": 30,
+      "Angle": -32768,
+      "EntityIndex": 14,
+      "TargetType": 26
+    },
+    {
+      "X": 37376,
+      "Y": -3072,
+      "Z": 45056,
+      "Room": 30,
+      "Angle": -32768,
+      "EntityIndex": 14,
+      "TargetType": 27
+    },
+    {
+      "X": 42496,
+      "Y": -3072,
+      "Z": 45056,
+      "Room": 20,
+      "Angle": -32768,
+      "EntityIndex": 15,
+      "TargetType": 26
+    },
+    {
+      "X": 42496,
+      "Y": -3072,
+      "Z": 45056,
+      "Room": 20,
+      "Angle": -32768,
+      "EntityIndex": 15,
+      "TargetType": 27
+    },
+    {
+      "X": 52736,
+      "Y": 8832,
+      "Z": 65536,
+      "Room": 23,
+      "Angle": 0,
+      "EntityIndex": 19,
+      "TargetType": 26
+    },
+    {
+      "X": 52736,
+      "Y": 8832,
+      "Z": 65536,
+      "Room": 23,
+      "Angle": 0,
+      "EntityIndex": 19,
+      "TargetType": 27
+    },
+    {
+      "X": 66048,
+      "Y": 7424,
+      "Z": 69632,
+      "Room": 24,
+      "Angle": -32768,
+      "EntityIndex": 20,
+      "TargetType": 26
+    },
+    {
+      "X": 66048,
+      "Y": 7424,
+      "Z": 69632,
+      "Room": 24,
+      "Angle": -32768,
+      "EntityIndex": 20,
+      "TargetType": 27
+    },
+    {
+      "X": 61952,
+      "Y": 7424,
+      "Z": 63488,
+      "Room": 24,
+      "Angle": -32768,
+      "EntityIndex": 21,
+      "TargetType": 26
+    },
+    {
+      "X": 61952,
+      "Y": 7424,
+      "Z": 63488,
+      "Room": 24,
+      "Angle": -32768,
+      "EntityIndex": 21,
+      "TargetType": 27
+    },
+    {
+      "X": 55808,
+      "Y": 7680,
+      "Z": 60416,
+      "Room": 25,
+      "Angle": -32768,
+      "EntityIndex": 23,
+      "TargetType": 26
+    },
+    {
+      "X": 55808,
+      "Y": 7680,
+      "Z": 60416,
+      "Room": 25,
+      "Angle": -32768,
+      "EntityIndex": 23,
+      "TargetType": 27
+    },
+    {
+      "X": 57856,
+      "Y": 8576,
+      "Z": 69632,
+      "Room": 25,
+      "Angle": -32768,
+      "EntityIndex": 24,
+      "TargetType": 26
+    },
+    {
+      "X": 57856,
+      "Y": 8576,
+      "Z": 69632,
+      "Room": 25,
+      "Angle": -32768,
+      "EntityIndex": 24,
+      "TargetType": 27
+    },
+    {
+      "X": 58367,
+      "Y": 7424,
+      "Z": 41472,
+      "Room": 29,
+      "EntityIndex": 25,
+      "TargetType": 26
+    },
+    {
+      "X": 58367,
+      "Y": 7424,
+      "Z": 41472,
+      "Room": 29,
+      "EntityIndex": 25,
+      "TargetType": 27
+    },
+    {
+      "X": 43520,
+      "Y": -5376,
+      "Z": 50176,
+      "Room": 41,
+      "Angle": -32768,
+      "EntityIndex": 29,
+      "TargetType": 26
+    },
+    {
+      "X": 43520,
+      "Y": -5376,
+      "Z": 50176,
+      "Room": 41,
+      "Angle": -32768,
+      "EntityIndex": 29,
+      "TargetType": 27
+    },
+    {
+      "X": 43520,
+      "Y": -7680,
+      "Z": 60416,
+      "Room": 47,
+      "Angle": -32768,
+      "EntityIndex": 32,
+      "TargetType": 26
+    },
+    {
+      "X": 43520,
+      "Y": -7680,
+      "Z": 60416,
+      "Room": 47,
+      "Angle": -32768,
+      "EntityIndex": 32,
+      "TargetType": 27
+    },
+    {
+      "X": 45568,
+      "Y": -7680,
+      "Z": 60416,
+      "Room": 47,
+      "Angle": -32768,
+      "EntityIndex": 33,
+      "TargetType": 26
+    },
+    {
+      "X": 45568,
+      "Y": -7680,
+      "Z": 60416,
+      "Room": 47,
+      "Angle": -32768,
+      "EntityIndex": 33,
+      "TargetType": 27
+    },
+    {
+      "X": 34304,
+      "Y": -7680,
+      "Z": 60416,
+      "Room": 48,
+      "Angle": -32768,
+      "EntityIndex": 36,
+      "TargetType": 26
+    },
+    {
+      "X": 34304,
+      "Y": -7680,
+      "Z": 60416,
+      "Room": 48,
+      "Angle": -32768,
+      "EntityIndex": 36,
+      "TargetType": 27
+    },
+    {
+      "X": 36352,
+      "Y": -7680,
+      "Z": 60416,
+      "Room": 48,
+      "Angle": -32768,
+      "EntityIndex": 39,
+      "TargetType": 26
+    },
+    {
+      "X": 36352,
+      "Y": -7680,
+      "Z": 60416,
+      "Room": 48,
+      "Angle": -32768,
+      "EntityIndex": 39,
+      "TargetType": 27
+    },
+    {
+      "X": 32256,
+      "Y": 256,
+      "Z": 18432,
+      "Room": 60,
+      "Angle": 0,
+      "EntityIndex": 43,
+      "TargetType": 26
+    },
+    {
+      "X": 32256,
+      "Y": 256,
+      "Z": 18432,
+      "Room": 60,
+      "Angle": 0,
+      "EntityIndex": 43,
+      "TargetType": 27
+    },
+    {
+      "X": 33280,
+      "Y": 0,
+      "Z": 26624,
+      "Room": 60,
+      "Angle": -32768,
+      "EntityIndex": 44,
+      "TargetType": 26
+    },
+    {
+      "X": 33280,
+      "Y": 0,
+      "Z": 26624,
+      "Room": 60,
+      "Angle": -32768,
+      "EntityIndex": 44,
+      "TargetType": 27
+    },
+    {
+      "X": 28671,
+      "Y": -11264,
+      "Z": 76288,
+      "Room": 63,
+      "EntityIndex": 46,
+      "TargetType": 26
+    },
+    {
+      "X": 28671,
+      "Y": -11264,
+      "Z": 76288,
+      "Room": 63,
+      "EntityIndex": 46,
+      "TargetType": 27
+    },
+    {
+      "X": 34815,
+      "Y": -11264,
+      "Z": 70144,
+      "Room": 63,
+      "Angle": -16384,
+      "EntityIndex": 47,
+      "TargetType": 26
+    },
+    {
+      "X": 34815,
+      "Y": -11264,
+      "Z": 70144,
+      "Room": 63,
+      "Angle": -16384,
+      "EntityIndex": 47,
+      "TargetType": 27
+    },
+    {
+      "X": 35839,
+      "Y": -11264,
+      "Z": 67072,
+      "Room": 63,
+      "Angle": -16384,
+      "EntityIndex": 56,
+      "TargetType": 26
+    },
+    {
+      "X": 35839,
+      "Y": -11264,
+      "Z": 67072,
+      "Room": 63,
+      "Angle": -16384,
+      "EntityIndex": 56,
+      "TargetType": 27
+    },
+    {
+      "X": 34304,
+      "Y": 768,
+      "Z": 39936,
+      "Room": 77,
+      "Angle": -32768,
+      "EntityIndex": 69,
+      "TargetType": 26
+    },
+    {
+      "X": 34304,
+      "Y": 768,
+      "Z": 39936,
+      "Room": 77,
+      "Angle": -32768,
+      "EntityIndex": 69,
+      "TargetType": 27
+    },
+    {
+      "X": 33280,
+      "Y": 768,
+      "Z": 39936,
+      "Room": 77,
+      "Angle": -32768,
+      "EntityIndex": 70,
+      "TargetType": 26
+    },
+    {
+      "X": 33280,
+      "Y": 768,
+      "Z": 39936,
+      "Room": 77,
+      "Angle": -32768,
+      "EntityIndex": 70,
+      "TargetType": 27
+    },
+    {
+      "X": 52736,
+      "Y": 8704,
+      "Z": 54272,
+      "Room": 80,
+      "Angle": 0,
+      "EntityIndex": 73,
+      "TargetType": 26
+    },
+    {
+      "X": 52736,
+      "Y": 8704,
+      "Z": 54272,
+      "Room": 80,
+      "Angle": 0,
+      "EntityIndex": 73,
+      "TargetType": 27
+    },
+    {
+      "X": 51712,
+      "Y": 8704,
+      "Z": 54272,
+      "Room": 80,
+      "Angle": 0,
+      "EntityIndex": 74,
+      "TargetType": 26
+    },
+    {
+      "X": 51712,
+      "Y": 8704,
+      "Z": 54272,
+      "Room": 80,
+      "Angle": 0,
+      "EntityIndex": 74,
+      "TargetType": 27
+    },
+    {
+      "X": 35328,
+      "Y": 768,
+      "Z": 39936,
+      "Room": 77,
+      "Angle": -32768,
+      "EntityIndex": 83,
+      "TargetType": 26
+    },
+    {
+      "X": 35328,
+      "Y": 768,
+      "Z": 39936,
+      "Room": 77,
+      "Angle": -32768,
+      "EntityIndex": 83,
+      "TargetType": 27
+    },
+    {
+      "X": 63487,
+      "Y": -512,
+      "Z": 65024,
+      "Room": 53,
+      "Angle": -16384,
+      "EntityIndex": 87,
+      "TargetType": 26
+    },
+    {
+      "X": 63487,
+      "Y": -512,
+      "Z": 65024,
+      "Room": 53,
+      "Angle": -16384,
+      "EntityIndex": 87,
+      "TargetType": 27
+    },
+    {
+      "X": 39424,
+      "Y": -7680,
+      "Z": 60416,
+      "Room": 48,
+      "Angle": -32768,
+      "EntityIndex": 89,
+      "TargetType": 26
+    },
+    {
+      "X": 39424,
+      "Y": -7680,
+      "Z": 60416,
+      "Room": 48,
+      "Angle": -32768,
+      "EntityIndex": 89,
+      "TargetType": 27
+    },
+    {
+      "X": 26623,
+      "Y": -12544,
+      "Z": 60928,
+      "Room": 97,
+      "Angle": -16384,
+      "EntityIndex": 91,
+      "TargetType": 26
+    },
+    {
+      "X": 26623,
+      "Y": -12544,
+      "Z": 60928,
+      "Room": 97,
+      "Angle": -16384,
+      "EntityIndex": 91,
+      "TargetType": 27
+    },
+    {
+      "X": 21503,
+      "Y": -13056,
+      "Z": 61952,
+      "Room": 97,
+      "EntityIndex": 92,
+      "TargetType": 26
+    },
+    {
+      "X": 21503,
+      "Y": -13056,
+      "Z": 61952,
+      "Room": 97,
+      "EntityIndex": 92,
+      "TargetType": 27
+    },
+    {
+      "X": 45568,
+      "Y": -11520,
+      "Z": 64512,
+      "Room": 68,
+      "Angle": 0,
+      "EntityIndex": 103,
+      "TargetType": 26
+    },
+    {
+      "X": 45568,
+      "Y": -11520,
+      "Z": 64512,
+      "Room": 68,
+      "Angle": 0,
+      "EntityIndex": 103,
+      "TargetType": 27
+    },
+    {
+      "X": 44544,
+      "Y": -11776,
+      "Z": 69632,
+      "Room": 68,
+      "Angle": -32768,
+      "EntityIndex": 104,
+      "TargetType": 26
+    },
+    {
+      "X": 44544,
+      "Y": -11776,
+      "Z": 69632,
+      "Room": 68,
+      "Angle": -32768,
+      "EntityIndex": 104,
+      "TargetType": 27
+    }
+  ],
+  "SKIDOO.TR2": [
+    {
+      "X": 72192,
+      "Y": -1792,
+      "Z": 27648,
+      "Room": 10,
+      "Angle": 0,
+      "EntityIndex": 1,
+      "TargetType": 26
+    },
+    {
+      "X": 72192,
+      "Y": -1792,
+      "Z": 27648,
+      "Room": 10,
+      "Angle": 0,
+      "EntityIndex": 1,
+      "TargetType": 27
+    },
+    {
+      "X": 66048,
+      "Y": -2048,
+      "Z": 27648,
+      "Room": 10,
+      "Angle": 0,
+      "EntityIndex": 2,
+      "TargetType": 26
+    },
+    {
+      "X": 66048,
+      "Y": -2048,
+      "Z": 27648,
+      "Room": 10,
+      "Angle": 0,
+      "EntityIndex": 2,
+      "TargetType": 27
+    },
+    {
+      "X": 63487,
+      "Y": -1024,
+      "Z": 38400,
+      "Room": 11,
+      "EntityIndex": 4,
+      "TargetType": 26
+    },
+    {
+      "X": 63487,
+      "Y": -1024,
+      "Z": 38400,
+      "Room": 11,
+      "EntityIndex": 4,
+      "TargetType": 27
+    },
+    {
+      "X": 77823,
+      "Y": -512,
+      "Z": 40448,
+      "Room": 12,
+      "Angle": -16384,
+      "EntityIndex": 5,
+      "TargetType": 26
+    },
+    {
+      "X": 77823,
+      "Y": -512,
+      "Z": 40448,
+      "Room": 12,
+      "Angle": -16384,
+      "EntityIndex": 5,
+      "TargetType": 27
+    },
+    {
+      "X": 79871,
+      "Y": -2048,
+      "Z": 32256,
+      "Room": 23,
+      "Angle": -16384,
+      "EntityIndex": 14,
+      "TargetType": 26
+    },
+    {
+      "X": 79871,
+      "Y": -2048,
+      "Z": 32256,
+      "Room": 23,
+      "Angle": -16384,
+      "EntityIndex": 14,
+      "TargetType": 27
+    },
+    {
+      "X": 84992,
+      "Y": -2816,
+      "Z": 84480,
+      "Room": 41,
+      "EntityIndex": 20,
+      "TargetType": 26
+    },
+    {
+      "X": 84992,
+      "Y": -2816,
+      "Z": 84480,
+      "Room": 41,
+      "EntityIndex": 20,
+      "TargetType": 27
+    },
+    {
+      "X": 92672,
+      "Y": -2304,
+      "Z": 71680,
+      "Room": 41,
+      "Angle": 0,
+      "EntityIndex": 21,
+      "TargetType": 26
+    },
+    {
+      "X": 92672,
+      "Y": -2304,
+      "Z": 71680,
+      "Room": 41,
+      "Angle": 0,
+      "EntityIndex": 21,
+      "TargetType": 27
+    },
+    {
+      "X": 76288,
+      "Y": -2560,
+      "Z": 57344,
+      "Room": 47,
+      "Angle": -32768,
+      "EntityIndex": 26,
+      "TargetType": 26
+    },
+    {
+      "X": 76288,
+      "Y": -2560,
+      "Z": 57344,
+      "Room": 47,
+      "Angle": -32768,
+      "EntityIndex": 26,
+      "TargetType": 27
+    },
+    {
+      "X": 77312,
+      "Y": -2560,
+      "Z": 53248,
+      "Room": 47,
+      "Angle": 0,
+      "EntityIndex": 27,
+      "TargetType": 26
+    },
+    {
+      "X": 77312,
+      "Y": -2560,
+      "Z": 53248,
+      "Room": 47,
+      "Angle": 0,
+      "EntityIndex": 27,
+      "TargetType": 27
+    },
+    {
+      "X": 38911,
+      "Y": -512,
+      "Z": 45568,
+      "Room": 51,
+      "EntityIndex": 28,
+      "TargetType": 26
+    },
+    {
+      "X": 38911,
+      "Y": -512,
+      "Z": 45568,
+      "Room": 51,
+      "EntityIndex": 28,
+      "TargetType": 27
+    },
+    {
+      "X": 51199,
+      "Y": -2304,
+      "Z": 59904,
+      "Room": 62,
+      "EntityIndex": 29,
+      "TargetType": 26
+    },
+    {
+      "X": 51199,
+      "Y": -2304,
+      "Z": 59904,
+      "Room": 62,
+      "EntityIndex": 29,
+      "TargetType": 27
+    },
+    {
+      "X": 69631,
+      "Y": -1024,
+      "Z": 61952,
+      "Room": 138,
+      "Angle": -16384,
+      "EntityIndex": 32,
+      "TargetType": 26
+    },
+    {
+      "X": 69631,
+      "Y": -1024,
+      "Z": 61952,
+      "Room": 138,
+      "Angle": -16384,
+      "EntityIndex": 32,
+      "TargetType": 27
+    },
+    {
+      "X": 46079,
+      "Y": -2816,
+      "Z": 95744,
+      "Room": 66,
+      "Angle": -16384,
+      "EntityIndex": 35,
+      "TargetType": 26
+    },
+    {
+      "X": 46079,
+      "Y": -2816,
+      "Z": 95744,
+      "Room": 66,
+      "Angle": -16384,
+      "EntityIndex": 35,
+      "TargetType": 27
+    },
+    {
+      "X": 20992,
+      "Y": 5888,
+      "Z": 87040,
+      "Room": 61,
+      "Angle": 0,
+      "EntityIndex": 36,
+      "TargetType": 26
+    },
+    {
+      "X": 20992,
+      "Y": 5888,
+      "Z": 87040,
+      "Room": 61,
+      "Angle": 0,
+      "EntityIndex": 36,
+      "TargetType": 27
+    },
+    {
+      "X": 32767,
+      "Y": -2560,
+      "Z": 91648,
+      "Room": 14,
+      "Angle": -16384,
+      "EntityIndex": 40,
+      "TargetType": 26
+    },
+    {
+      "X": 32767,
+      "Y": -2560,
+      "Z": 91648,
+      "Room": 14,
+      "Angle": -16384,
+      "EntityIndex": 40,
+      "TargetType": 27
+    },
+    {
+      "X": 32767,
+      "Y": -3584,
+      "Z": 91648,
+      "Room": 14,
+      "Angle": -16384,
+      "EntityIndex": 41,
+      "TargetType": 26
+    },
+    {
+      "X": 32767,
+      "Y": -3584,
+      "Z": 91648,
+      "Room": 14,
+      "Angle": -16384,
+      "EntityIndex": 41,
+      "TargetType": 27
+    },
+    {
+      "X": 40959,
+      "Y": -3072,
+      "Z": 94720,
+      "Room": 66,
+      "Angle": -16384,
+      "EntityIndex": 42,
+      "TargetType": 26
+    },
+    {
+      "X": 40959,
+      "Y": -3072,
+      "Z": 94720,
+      "Room": 66,
+      "Angle": -16384,
+      "EntityIndex": 42,
+      "TargetType": 27
+    },
+    {
+      "X": 37887,
+      "Y": -3072,
+      "Z": 96768,
+      "Room": 66,
+      "EntityIndex": 43,
+      "TargetType": 26
+    },
+    {
+      "X": 37887,
+      "Y": -3072,
+      "Z": 96768,
+      "Room": 66,
+      "EntityIndex": 43,
+      "TargetType": 27
+    },
+    {
+      "X": 7680,
+      "Y": -1536,
+      "Z": 76800,
+      "Room": 74,
+      "Angle": 0,
+      "EntityIndex": 52,
+      "TargetType": 26
+    },
+    {
+      "X": 7680,
+      "Y": -1536,
+      "Z": 76800,
+      "Room": 74,
+      "Angle": 0,
+      "EntityIndex": 52,
+      "TargetType": 27
+    },
+    {
+      "X": 96768,
+      "Y": -2560,
+      "Z": 9216,
+      "Room": 77,
+      "Angle": 0,
+      "EntityIndex": 54,
+      "TargetType": 26
+    },
+    {
+      "X": 96768,
+      "Y": -2560,
+      "Z": 9216,
+      "Room": 77,
+      "Angle": 0,
+      "EntityIndex": 54,
+      "TargetType": 27
+    },
+    {
+      "X": 72703,
+      "Y": -3328,
+      "Z": 11776,
+      "Room": 78,
+      "EntityIndex": 57,
+      "TargetType": 26
+    },
+    {
+      "X": 72703,
+      "Y": -3328,
+      "Z": 11776,
+      "Room": 78,
+      "EntityIndex": 57,
+      "TargetType": 27
+    },
+    {
+      "X": 15360,
+      "Y": 0,
+      "Z": 89600,
+      "Room": 61,
+      "EntityIndex": 73,
+      "TargetType": 26
+    },
+    {
+      "X": 15360,
+      "Y": 0,
+      "Z": 89600,
+      "Room": 61,
+      "EntityIndex": 73,
+      "TargetType": 27
+    },
+    {
+      "X": 89600,
+      "Y": 2816,
+      "Z": 36864,
+      "Room": 99,
+      "Angle": -32768,
+      "EntityIndex": 77,
+      "TargetType": 26
+    },
+    {
+      "X": 89600,
+      "Y": 2816,
+      "Z": 36864,
+      "Room": 99,
+      "Angle": -32768,
+      "EntityIndex": 77,
+      "TargetType": 27
+    },
+    {
+      "X": 90624,
+      "Y": 2816,
+      "Z": 36864,
+      "Room": 99,
+      "Angle": -32768,
+      "EntityIndex": 78,
+      "TargetType": 26
+    },
+    {
+      "X": 90624,
+      "Y": 2816,
+      "Z": 36864,
+      "Room": 99,
+      "Angle": -32768,
+      "EntityIndex": 78,
+      "TargetType": 27
+    },
+    {
+      "X": 84993,
+      "Y": 2048,
+      "Z": 28160,
+      "Room": 99,
+      "EntityIndex": 79,
+      "TargetType": 26
+    },
+    {
+      "X": 84993,
+      "Y": 2048,
+      "Z": 28160,
+      "Room": 99,
+      "EntityIndex": 79,
+      "TargetType": 27
+    },
+    {
+      "X": 94720,
+      "Y": 2560,
+      "Z": 36864,
+      "Room": 99,
+      "Angle": -32768,
+      "EntityIndex": 83,
+      "TargetType": 26
+    },
+    {
+      "X": 94720,
+      "Y": 2560,
+      "Z": 36864,
+      "Room": 99,
+      "Angle": -32768,
+      "EntityIndex": 83,
+      "TargetType": 27
+    },
+    {
+      "X": 31743,
+      "Y": -768,
+      "Z": 14848,
+      "Room": 104,
+      "EntityIndex": 84,
+      "TargetType": 26
+    },
+    {
+      "X": 31743,
+      "Y": -768,
+      "Z": 14848,
+      "Room": 104,
+      "EntityIndex": 84,
+      "TargetType": 27
+    },
+    {
+      "X": 25599,
+      "Y": 2048,
+      "Z": 20992,
+      "Room": 112,
+      "Angle": -16384,
+      "EntityIndex": 86,
+      "TargetType": 26
+    },
+    {
+      "X": 25599,
+      "Y": 2048,
+      "Z": 20992,
+      "Room": 112,
+      "Angle": -16384,
+      "EntityIndex": 86,
+      "TargetType": 27
+    },
+    {
+      "X": 19968,
+      "Y": 4096,
+      "Z": 21504,
+      "Room": 123,
+      "Angle": 0,
+      "EntityIndex": 87,
+      "TargetType": 26
+    },
+    {
+      "X": 19968,
+      "Y": 4096,
+      "Z": 21504,
+      "Room": 123,
+      "Angle": 0,
+      "EntityIndex": 87,
+      "TargetType": 27
+    },
+    {
+      "X": 31232,
+      "Y": 0,
+      "Z": 16384,
+      "Room": 115,
+      "Angle": 0,
+      "EntityIndex": 88,
+      "TargetType": 26
+    },
+    {
+      "X": 31232,
+      "Y": 0,
+      "Z": 16384,
+      "Room": 115,
+      "Angle": 0,
+      "EntityIndex": 88,
+      "TargetType": 27
+    },
+    {
+      "X": 25599,
+      "Y": 9728,
+      "Z": 28160,
+      "Room": 128,
+      "Angle": -16384,
+      "EntityIndex": 89,
+      "TargetType": 26
+    },
+    {
+      "X": 25599,
+      "Y": 9728,
+      "Z": 28160,
+      "Room": 128,
+      "Angle": -16384,
+      "EntityIndex": 89,
+      "TargetType": 27
+    },
+    {
+      "X": 16383,
+      "Y": 5888,
+      "Z": 94720,
+      "Room": 132,
+      "EntityIndex": 99,
+      "TargetType": 26
+    },
+    {
+      "X": 16383,
+      "Y": 5888,
+      "Z": 94720,
+      "Room": 132,
+      "EntityIndex": 99,
+      "TargetType": 27
+    },
+    {
+      "X": 16383,
+      "Y": 5888,
+      "Z": 95744,
+      "Room": 132,
+      "EntityIndex": 100,
+      "TargetType": 26
+    },
+    {
+      "X": 16383,
+      "Y": 5888,
+      "Z": 95744,
+      "Room": 132,
+      "EntityIndex": 100,
+      "TargetType": 27
+    }
+  ],
+  "MONASTRY.TR2": [
+    {
+      "X": 90624,
+      "Y": 0,
+      "Z": 16896,
+      "Room": 23,
+      "EntityIndex": 54,
+      "TargetType": 34
+    }
+  ],
+  "CATACOMB.TR2": [
+    {
+      "X": 19455,
+      "Y": 1024,
+      "Z": 42496,
+      "Room": 1,
+      "EntityIndex": 10,
+      "TargetType": 26
+    },
+    {
+      "X": 19455,
+      "Y": 1024,
+      "Z": 42496,
+      "Room": 1,
+      "EntityIndex": 10,
+      "TargetType": 27
+    },
+    {
+      "X": 22527,
+      "Y": 4096,
+      "Z": 37376,
+      "Room": 98,
+      "EntityIndex": 14,
+      "TargetType": 26
+    },
+    {
+      "X": 22527,
+      "Y": 4096,
+      "Z": 37376,
+      "Room": 98,
+      "EntityIndex": 14,
+      "TargetType": 27
+    },
+    {
+      "X": 22527,
+      "Y": 3840,
+      "Z": 38400,
+      "Room": 98,
+      "EntityIndex": 15,
+      "TargetType": 26
+    },
+    {
+      "X": 22527,
+      "Y": 3840,
+      "Z": 38400,
+      "Room": 98,
+      "EntityIndex": 15,
+      "TargetType": 27
+    },
+    {
+      "X": 49151,
+      "Y": 7168,
+      "Z": 62976,
+      "Room": 8,
+      "Angle": -16384,
+      "EntityIndex": 22,
+      "TargetType": 26
+    },
+    {
+      "X": 49151,
+      "Y": 7168,
+      "Z": 62976,
+      "Room": 8,
+      "Angle": -16384,
+      "EntityIndex": 22,
+      "TargetType": 27
+    },
+    {
+      "X": 37887,
+      "Y": 7168,
+      "Z": 61952,
+      "Room": 8,
+      "EntityIndex": 23,
+      "TargetType": 26
+    },
+    {
+      "X": 37887,
+      "Y": 7168,
+      "Z": 61952,
+      "Room": 8,
+      "EntityIndex": 23,
+      "TargetType": 27
+    },
+    {
+      "X": 49151,
+      "Y": 7168,
+      "Z": 64000,
+      "Room": 8,
+      "Angle": -16384,
+      "EntityIndex": 25,
+      "TargetType": 26
+    },
+    {
+      "X": 49151,
+      "Y": 7168,
+      "Z": 64000,
+      "Room": 8,
+      "Angle": -16384,
+      "EntityIndex": 25,
+      "TargetType": 27
+    },
+    {
+      "X": 43007,
+      "Y": 10496,
+      "Z": 49664,
+      "Room": 34,
+      "EntityIndex": 26,
+      "TargetType": 26
+    },
+    {
+      "X": 43007,
+      "Y": 10496,
+      "Z": 49664,
+      "Room": 34,
+      "EntityIndex": 26,
+      "TargetType": 27
+    },
+    {
+      "X": 43007,
+      "Y": 10496,
+      "Z": 50688,
+      "Room": 34,
+      "EntityIndex": 27,
+      "TargetType": 26
+    },
+    {
+      "X": 43007,
+      "Y": 10496,
+      "Z": 50688,
+      "Room": 34,
+      "EntityIndex": 27,
+      "TargetType": 27
+    },
+    {
+      "X": 48640,
+      "Y": 8192,
+      "Z": 60416,
+      "Room": 79,
+      "Angle": -32768,
+      "EntityIndex": 42,
+      "TargetType": 26
+    },
+    {
+      "X": 48640,
+      "Y": 8192,
+      "Z": 60416,
+      "Room": 79,
+      "Angle": -32768,
+      "EntityIndex": 42,
+      "TargetType": 27
+    },
+    {
+      "X": 53760,
+      "Y": 8192,
+      "Z": 60416,
+      "Room": 11,
+      "Angle": -32768,
+      "EntityIndex": 43,
+      "TargetType": 26
+    },
+    {
+      "X": 53760,
+      "Y": 8192,
+      "Z": 60416,
+      "Room": 11,
+      "Angle": -32768,
+      "EntityIndex": 43,
+      "TargetType": 27
+    },
+    {
+      "X": 36352,
+      "Y": 6400,
+      "Z": 46080,
+      "Room": 18,
+      "Angle": 0,
+      "EntityIndex": 53,
+      "TargetType": 26
+    },
+    {
+      "X": 36352,
+      "Y": 6400,
+      "Z": 46080,
+      "Room": 18,
+      "Angle": 0,
+      "EntityIndex": 53,
+      "TargetType": 27
+    },
+    {
+      "X": 33280,
+      "Y": 6400,
+      "Z": 46080,
+      "Room": 18,
+      "Angle": 0,
+      "EntityIndex": 54,
+      "TargetType": 26
+    },
+    {
+      "X": 33280,
+      "Y": 6400,
+      "Z": 46080,
+      "Room": 18,
+      "Angle": 0,
+      "EntityIndex": 54,
+      "TargetType": 27
+    },
+    {
+      "X": 9728,
+      "Y": 4608,
+      "Z": 63488,
+      "Room": 22,
+      "Angle": 0,
+      "EntityIndex": 61,
+      "TargetType": 26
+    },
+    {
+      "X": 9728,
+      "Y": 4608,
+      "Z": 63488,
+      "Room": 22,
+      "Angle": 0,
+      "EntityIndex": 61,
+      "TargetType": 27
+    },
+    {
+      "X": 22528,
+      "Y": 7168,
+      "Z": 62976,
+      "Room": 28,
+      "Angle": -16384,
+      "EntityIndex": 62,
+      "TargetType": 26
+    },
+    {
+      "X": 22528,
+      "Y": 7168,
+      "Z": 62976,
+      "Room": 28,
+      "Angle": -16384,
+      "EntityIndex": 62,
+      "TargetType": 27
+    },
+    {
+      "X": 15360,
+      "Y": 2560,
+      "Z": 47616,
+      "Room": 23,
+      "Angle": -16384,
+      "EntityIndex": 66,
+      "TargetType": 26
+    },
+    {
+      "X": 15360,
+      "Y": 2560,
+      "Z": 47616,
+      "Room": 23,
+      "Angle": -16384,
+      "EntityIndex": 66,
+      "TargetType": 27
+    },
+    {
+      "X": 18431,
+      "Y": 4864,
+      "Z": 55808,
+      "Room": 29,
+      "EntityIndex": 67,
+      "TargetType": 26
+    },
+    {
+      "X": 18431,
+      "Y": 4864,
+      "Z": 55808,
+      "Room": 29,
+      "EntityIndex": 67,
+      "TargetType": 27
+    },
+    {
+      "X": 23551,
+      "Y": 7168,
+      "Z": 57856,
+      "Room": 29,
+      "Angle": -16384,
+      "EntityIndex": 68,
+      "TargetType": 26
+    },
+    {
+      "X": 23551,
+      "Y": 7168,
+      "Z": 57856,
+      "Room": 29,
+      "Angle": -16384,
+      "EntityIndex": 68,
+      "TargetType": 27
+    },
+    {
+      "X": 20992,
+      "Y": 6656,
+      "Z": 51200,
+      "Room": 60,
+      "Angle": -32768,
+      "EntityIndex": 69,
+      "TargetType": 26
+    },
+    {
+      "X": 20992,
+      "Y": 6656,
+      "Z": 51200,
+      "Room": 60,
+      "Angle": -32768,
+      "EntityIndex": 69,
+      "TargetType": 27
+    },
+    {
+      "X": 22016,
+      "Y": 6656,
+      "Z": 51200,
+      "Room": 60,
+      "Angle": -32768,
+      "EntityIndex": 70,
+      "TargetType": 26
+    },
+    {
+      "X": 22016,
+      "Y": 6656,
+      "Z": 51200,
+      "Room": 60,
+      "Angle": -32768,
+      "EntityIndex": 70,
+      "TargetType": 27
+    },
+    {
+      "X": 36352,
+      "Y": 7168,
+      "Z": 61440,
+      "Room": 71,
+      "Angle": 0,
+      "EntityIndex": 102,
+      "TargetType": 26
+    },
+    {
+      "X": 36352,
+      "Y": 7168,
+      "Z": 61440,
+      "Room": 71,
+      "Angle": 0,
+      "EntityIndex": 102,
+      "TargetType": 27
+    },
+    {
+      "X": 41983,
+      "Y": 6912,
+      "Z": 53760,
+      "Room": 62,
+      "Angle": -16384,
+      "EntityIndex": 103,
+      "TargetType": 26
+    },
+    {
+      "X": 41983,
+      "Y": 6912,
+      "Z": 53760,
+      "Room": 62,
+      "Angle": -16384,
+      "EntityIndex": 103,
+      "TargetType": 27
+    },
+    {
+      "X": 33280,
+      "Y": 4608,
+      "Z": 61440,
+      "Room": 39,
+      "Angle": -32768,
+      "EntityIndex": 105,
+      "TargetType": 26
+    },
+    {
+      "X": 33280,
+      "Y": 4608,
+      "Z": 61440,
+      "Room": 39,
+      "Angle": -32768,
+      "EntityIndex": 105,
+      "TargetType": 27
+    },
+    {
+      "X": 33280,
+      "Y": 7168,
+      "Z": 69632,
+      "Room": 70,
+      "Angle": -32768,
+      "EntityIndex": 120,
+      "TargetType": 26
+    },
+    {
+      "X": 33280,
+      "Y": 7168,
+      "Z": 69632,
+      "Room": 70,
+      "Angle": -32768,
+      "EntityIndex": 120,
+      "TargetType": 27
+    },
+    {
+      "X": 34304,
+      "Y": 7168,
+      "Z": 69632,
+      "Room": 70,
+      "Angle": -32768,
+      "EntityIndex": 121,
+      "TargetType": 26
+    },
+    {
+      "X": 34304,
+      "Y": 7168,
+      "Z": 69632,
+      "Room": 70,
+      "Angle": -32768,
+      "EntityIndex": 121,
+      "TargetType": 27
+    },
+    {
+      "X": 35328,
+      "Y": 7168,
+      "Z": 69632,
+      "Room": 70,
+      "Angle": -32768,
+      "EntityIndex": 122,
+      "TargetType": 26
+    },
+    {
+      "X": 35328,
+      "Y": 7168,
+      "Z": 69632,
+      "Room": 70,
+      "Angle": -32768,
+      "EntityIndex": 122,
+      "TargetType": 27
+    },
+    {
+      "X": 17407,
+      "Y": 2560,
+      "Z": 41472,
+      "Room": 74,
+      "Angle": -16384,
+      "EntityIndex": 127,
+      "TargetType": 26
+    },
+    {
+      "X": 17407,
+      "Y": 2560,
+      "Z": 41472,
+      "Room": 74,
+      "Angle": -16384,
+      "EntityIndex": 127,
+      "TargetType": 27
+    },
+    {
+      "X": 15872,
+      "Y": 4352,
+      "Z": 59392,
+      "Room": 82,
+      "Angle": -32768,
+      "EntityIndex": 135,
+      "TargetType": 26
+    },
+    {
+      "X": 15872,
+      "Y": 4352,
+      "Z": 59392,
+      "Room": 82,
+      "Angle": -32768,
+      "EntityIndex": 135,
+      "TargetType": 27
+    },
+    {
+      "X": 36863,
+      "Y": 4352,
+      "Z": 40448,
+      "Room": 98,
+      "Angle": -16384,
+      "EntityIndex": 144,
+      "TargetType": 26
+    },
+    {
+      "X": 36863,
+      "Y": 4352,
+      "Z": 40448,
+      "Room": 98,
+      "Angle": -16384,
+      "EntityIndex": 144,
+      "TargetType": 27
+    },
+    {
+      "X": 36863,
+      "Y": 4096,
+      "Z": 39424,
+      "Room": 98,
+      "Angle": -16384,
+      "EntityIndex": 145,
+      "TargetType": 26
+    },
+    {
+      "X": 36863,
+      "Y": 4096,
+      "Z": 39424,
+      "Room": 98,
+      "Angle": -16384,
+      "EntityIndex": 145,
+      "TargetType": 27
+    },
+    {
+      "X": 28160,
+      "Y": 7168,
+      "Z": 46080,
+      "Room": 108,
+      "Angle": 0,
+      "EntityIndex": 149,
+      "TargetType": 26
+    },
+    {
+      "X": 28160,
+      "Y": 7168,
+      "Z": 46080,
+      "Room": 108,
+      "Angle": 0,
+      "EntityIndex": 149,
+      "TargetType": 27
+    },
+    {
+      "X": 29184,
+      "Y": 6912,
+      "Z": 46080,
+      "Room": 108,
+      "Angle": 0,
+      "EntityIndex": 150,
+      "TargetType": 26
+    },
+    {
+      "X": 29184,
+      "Y": 6912,
+      "Z": 46080,
+      "Room": 108,
+      "Angle": 0,
+      "EntityIndex": 150,
+      "TargetType": 27
+    },
+    {
+      "X": 30719,
+      "Y": 7168,
+      "Z": 49664,
+      "Room": 108,
+      "Angle": -16384,
+      "EntityIndex": 151,
+      "TargetType": 26
+    },
+    {
+      "X": 30719,
+      "Y": 7168,
+      "Z": 49664,
+      "Room": 108,
+      "Angle": -16384,
+      "EntityIndex": 151,
+      "TargetType": 27
+    },
+    {
+      "X": 30719,
+      "Y": 7168,
+      "Z": 48640,
+      "Room": 108,
+      "Angle": -16384,
+      "EntityIndex": 154,
+      "TargetType": 26
+    },
+    {
+      "X": 30719,
+      "Y": 7168,
+      "Z": 48640,
+      "Room": 108,
+      "Angle": -16384,
+      "EntityIndex": 154,
+      "TargetType": 27
+    }
+  ],
+  "ICECAVE.TR2": [
+    {
+      "X": 28671,
+      "Y": 4864,
+      "Z": 58880,
+      "Room": 22,
+      "EntityIndex": 20,
+      "TargetType": 26
+    },
+    {
+      "X": 28671,
+      "Y": 4864,
+      "Z": 58880,
+      "Room": 22,
+      "EntityIndex": 20,
+      "TargetType": 27
+    },
+    {
+      "X": 33791,
+      "Y": 7168,
+      "Z": 61952,
+      "Room": 22,
+      "Angle": -16384,
+      "EntityIndex": 21,
+      "TargetType": 26
+    },
+    {
+      "X": 33791,
+      "Y": 7168,
+      "Z": 61952,
+      "Room": 22,
+      "Angle": -16384,
+      "EntityIndex": 21,
+      "TargetType": 27
+    },
+    {
+      "X": 32256,
+      "Y": 6144,
+      "Z": 24576,
+      "Room": 11,
+      "Angle": 0,
+      "EntityIndex": 24,
+      "TargetType": 26
+    },
+    {
+      "X": 32256,
+      "Y": 6144,
+      "Z": 24576,
+      "Room": 11,
+      "Angle": 0,
+      "EntityIndex": 24,
+      "TargetType": 27
+    },
+    {
+      "X": 30719,
+      "Y": 8192,
+      "Z": 42496,
+      "Room": 25,
+      "EntityIndex": 25,
+      "TargetType": 26
+    },
+    {
+      "X": 30719,
+      "Y": 8192,
+      "Z": 42496,
+      "Room": 25,
+      "EntityIndex": 25,
+      "TargetType": 27
+    },
+    {
+      "X": 28671,
+      "Y": 7168,
+      "Z": 38400,
+      "Room": 25,
+      "EntityIndex": 26,
+      "TargetType": 26
+    },
+    {
+      "X": 28671,
+      "Y": 7168,
+      "Z": 38400,
+      "Room": 25,
+      "EntityIndex": 26,
+      "TargetType": 27
+    },
+    {
+      "X": 28671,
+      "Y": 7168,
+      "Z": 37376,
+      "Room": 25,
+      "EntityIndex": 27,
+      "TargetType": 26
+    },
+    {
+      "X": 28671,
+      "Y": 7168,
+      "Z": 37376,
+      "Room": 25,
+      "EntityIndex": 27,
+      "TargetType": 27
+    },
+    {
+      "X": 62976,
+      "Y": 5888,
+      "Z": 76800,
+      "Room": 40,
+      "Angle": -32768,
+      "EntityIndex": 31,
+      "TargetType": 26
+    },
+    {
+      "X": 62976,
+      "Y": 5888,
+      "Z": 76800,
+      "Room": 40,
+      "Angle": -32768,
+      "EntityIndex": 31,
+      "TargetType": 27
+    },
+    {
+      "X": 64000,
+      "Y": 5888,
+      "Z": 76800,
+      "Room": 40,
+      "Angle": -32768,
+      "EntityIndex": 32,
+      "TargetType": 26
+    },
+    {
+      "X": 64000,
+      "Y": 5888,
+      "Z": 76800,
+      "Room": 40,
+      "Angle": -32768,
+      "EntityIndex": 32,
+      "TargetType": 27
+    },
+    {
+      "X": 65024,
+      "Y": 5888,
+      "Z": 76800,
+      "Room": 40,
+      "Angle": -32768,
+      "EntityIndex": 33,
+      "TargetType": 26
+    },
+    {
+      "X": 65024,
+      "Y": 5888,
+      "Z": 76800,
+      "Room": 40,
+      "Angle": -32768,
+      "EntityIndex": 33,
+      "TargetType": 27
+    },
+    {
+      "X": 52223,
+      "Y": 6912,
+      "Z": 56832,
+      "Room": 64,
+      "Angle": -16384,
+      "EntityIndex": 55,
+      "TargetType": 26
+    },
+    {
+      "X": 52223,
+      "Y": 6912,
+      "Z": 56832,
+      "Room": 64,
+      "Angle": -16384,
+      "EntityIndex": 55,
+      "TargetType": 27
+    },
+    {
+      "X": 33280,
+      "Y": 5376,
+      "Z": 24576,
+      "Room": 11,
+      "Angle": 0,
+      "EntityIndex": 70,
+      "TargetType": 26
+    },
+    {
+      "X": 33280,
+      "Y": 5376,
+      "Z": 24576,
+      "Room": 11,
+      "Angle": 0,
+      "EntityIndex": 70,
+      "TargetType": 27
+    },
+    {
+      "X": 28671,
+      "Y": 6144,
+      "Z": 33280,
+      "Room": 25,
+      "EntityIndex": 84,
+      "TargetType": 26
+    },
+    {
+      "X": 28671,
+      "Y": 6144,
+      "Z": 33280,
+      "Room": 25,
+      "EntityIndex": 84,
+      "TargetType": 27
+    },
+    {
+      "X": 38400,
+      "Y": 5120,
+      "Z": 30720,
+      "Room": 61,
+      "Angle": -32768,
+      "EntityIndex": 85,
+      "TargetType": 26
+    },
+    {
+      "X": 38400,
+      "Y": 5120,
+      "Z": 30720,
+      "Room": 61,
+      "Angle": -32768,
+      "EntityIndex": 85,
+      "TargetType": 27
+    },
+    {
+      "X": 44544,
+      "Y": 4096,
+      "Z": 21504,
+      "Room": 73,
+      "Angle": -32768,
+      "EntityIndex": 116,
+      "TargetType": 26
+    },
+    {
+      "X": 44544,
+      "Y": 4096,
+      "Z": 21504,
+      "Room": 73,
+      "Angle": -32768,
+      "EntityIndex": 116,
+      "TargetType": 27
+    },
+    {
+      "X": 73216,
+      "Y": 2048,
+      "Z": 67584,
+      "Room": 72,
+      "Angle": 0,
+      "EntityIndex": 119,
+      "TargetType": 26
+    },
+    {
+      "X": 73216,
+      "Y": 2048,
+      "Z": 67584,
+      "Room": 72,
+      "Angle": 0,
+      "EntityIndex": 119,
+      "TargetType": 27
+    },
+    {
+      "X": 58367,
+      "Y": 2304,
+      "Z": 59904,
+      "Room": 90,
+      "Angle": -16384,
+      "EntityIndex": 126,
+      "TargetType": 26
+    },
+    {
+      "X": 58367,
+      "Y": 2304,
+      "Z": 59904,
+      "Room": 90,
+      "Angle": -16384,
+      "EntityIndex": 126,
+      "TargetType": 27
+    },
+    {
+      "X": 72403,
+      "Y": -2048,
+      "Z": 65024,
+      "Room": 98,
+      "Angle": -16384,
+      "EntityIndex": 132,
+      "TargetType": 26
+    },
+    {
+      "X": 72403,
+      "Y": -2048,
+      "Z": 65024,
+      "Room": 98,
+      "Angle": -16384,
+      "EntityIndex": 132,
+      "TargetType": 27
+    },
+    {
+      "X": 64511,
+      "Y": -256,
+      "Z": 62976,
+      "Room": 100,
+      "Angle": -16384,
+      "EntityIndex": 134,
+      "TargetType": 26
+    },
+    {
+      "X": 64511,
+      "Y": -256,
+      "Z": 62976,
+      "Room": 100,
+      "Angle": -16384,
+      "EntityIndex": 134,
+      "TargetType": 27
+    },
+    {
+      "X": 59391,
+      "Y": -1024,
+      "Z": 64000,
+      "Room": 101,
+      "EntityIndex": 135,
+      "TargetType": 26
+    },
+    {
+      "X": 59391,
+      "Y": -1024,
+      "Z": 64000,
+      "Room": 101,
+      "EntityIndex": 135,
+      "TargetType": 27
+    },
+    {
+      "X": 61952,
+      "Y": 0,
+      "Z": 51200,
+      "Room": 100,
+      "Angle": 0,
+      "EntityIndex": 136,
+      "TargetType": 26
+    },
+    {
+      "X": 61952,
+      "Y": 0,
+      "Z": 51200,
+      "Room": 100,
+      "Angle": 0,
+      "EntityIndex": 136,
+      "TargetType": 27
+    },
+    {
+      "X": 59904,
+      "Y": 0,
+      "Z": 51200,
+      "Room": 100,
+      "Angle": 0,
+      "EntityIndex": 137,
+      "TargetType": 26
+    },
+    {
+      "X": 59904,
+      "Y": 0,
+      "Z": 51200,
+      "Room": 100,
+      "Angle": 0,
+      "EntityIndex": 137,
+      "TargetType": 27
+    }
+  ],
+  "EMPRTOMB.TR2": [
+    {
+      "X": 19968,
+      "Y": 18688,
+      "Z": 30720,
+      "Room": 6,
+      "Angle": -32768,
+      "EntityIndex": 1,
+      "TargetType": 26
+    },
+    {
+      "X": 19968,
+      "Y": 18688,
+      "Z": 30720,
+      "Room": 6,
+      "Angle": -32768,
+      "EntityIndex": 1,
+      "TargetType": 27
+    },
+    {
+      "X": 14335,
+      "Y": 18944,
+      "Z": 24064,
+      "Room": 6,
+      "EntityIndex": 5,
+      "TargetType": 26
+    },
+    {
+      "X": 14335,
+      "Y": 18944,
+      "Z": 24064,
+      "Room": 6,
+      "EntityIndex": 5,
+      "TargetType": 27
+    },
+    {
+      "X": 24255,
+      "Y": 11008,
+      "Z": 51712,
+      "Room": 8,
+      "Angle": -16384,
+      "EntityIndex": 7,
+      "TargetType": 26
+    },
+    {
+      "X": 24255,
+      "Y": 11008,
+      "Z": 51712,
+      "Room": 8,
+      "Angle": -16384,
+      "EntityIndex": 7,
+      "TargetType": 27
+    },
+    {
+      "X": 43520,
+      "Y": 20480,
+      "Z": 51200,
+      "Room": 14,
+      "Angle": -32768,
+      "EntityIndex": 11,
+      "TargetType": 26
+    },
+    {
+      "X": 43520,
+      "Y": 20480,
+      "Z": 51200,
+      "Room": 14,
+      "Angle": -32768,
+      "EntityIndex": 11,
+      "TargetType": 27
+    },
+    {
+      "X": 43520,
+      "Y": 20480,
+      "Z": 38912,
+      "Room": 14,
+      "Angle": 0,
+      "EntityIndex": 12,
+      "TargetType": 26
+    },
+    {
+      "X": 43520,
+      "Y": 20480,
+      "Z": 38912,
+      "Room": 14,
+      "Angle": 0,
+      "EntityIndex": 12,
+      "TargetType": 27
+    },
+    {
+      "X": 19455,
+      "Y": 24320,
+      "Z": 45568,
+      "Room": 13,
+      "EntityIndex": 19,
+      "TargetType": 26
+    },
+    {
+      "X": 19455,
+      "Y": 24320,
+      "Z": 45568,
+      "Room": 13,
+      "EntityIndex": 19,
+      "TargetType": 27
+    },
+    {
+      "X": 21503,
+      "Y": 20992,
+      "Z": 34304,
+      "Room": 22,
+      "Angle": -16384,
+      "EntityIndex": 29,
+      "TargetType": 26
+    },
+    {
+      "X": 21503,
+      "Y": 20992,
+      "Z": 34304,
+      "Room": 22,
+      "Angle": -16384,
+      "EntityIndex": 29,
+      "TargetType": 27
+    },
+    {
+      "X": 21503,
+      "Y": 19968,
+      "Z": 34304,
+      "Room": 22,
+      "Angle": -16384,
+      "EntityIndex": 32,
+      "TargetType": 26
+    },
+    {
+      "X": 21503,
+      "Y": 19968,
+      "Z": 34304,
+      "Room": 22,
+      "Angle": -16384,
+      "EntityIndex": 32,
+      "TargetType": 27
+    },
+    {
+      "X": 25088,
+      "Y": -3328,
+      "Z": 67584,
+      "Room": 90,
+      "Angle": -32768,
+      "EntityIndex": 48,
+      "TargetType": 26
+    },
+    {
+      "X": 25088,
+      "Y": -3328,
+      "Z": 67584,
+      "Room": 90,
+      "Angle": -32768,
+      "EntityIndex": 48,
+      "TargetType": 27
+    },
+    {
+      "X": 49664,
+      "Y": 13824,
+      "Z": 11264,
+      "Room": 62,
+      "Angle": 0,
+      "EntityIndex": 50,
+      "TargetType": 26
+    },
+    {
+      "X": 49664,
+      "Y": 13824,
+      "Z": 11264,
+      "Room": 62,
+      "Angle": 0,
+      "EntityIndex": 50,
+      "TargetType": 27
+    },
+    {
+      "X": 47616,
+      "Y": 13824,
+      "Z": 11264,
+      "Room": 62,
+      "Angle": 0,
+      "EntityIndex": 51,
+      "TargetType": 26
+    },
+    {
+      "X": 47616,
+      "Y": 13824,
+      "Z": 11264,
+      "Room": 62,
+      "Angle": 0,
+      "EntityIndex": 51,
+      "TargetType": 27
+    },
+    {
+      "X": 45055,
+      "Y": 12288,
+      "Z": 31232,
+      "Room": 122,
+      "EntityIndex": 56,
+      "TargetType": 26
+    },
+    {
+      "X": 45055,
+      "Y": 12288,
+      "Z": 31232,
+      "Room": 122,
+      "EntityIndex": 56,
+      "TargetType": 27
+    },
+    {
+      "X": 42496,
+      "Y": 18176,
+      "Z": 49152,
+      "Room": 38,
+      "Angle": -32768,
+      "EntityIndex": 60,
+      "TargetType": 26
+    },
+    {
+      "X": 42496,
+      "Y": 18176,
+      "Z": 49152,
+      "Room": 38,
+      "Angle": -32768,
+      "EntityIndex": 60,
+      "TargetType": 27
+    },
+    {
+      "X": 25599,
+      "Y": 25600,
+      "Z": 42496,
+      "Room": 13,
+      "Angle": -16384,
+      "EntityIndex": 61,
+      "TargetType": 26
+    },
+    {
+      "X": 25599,
+      "Y": 25600,
+      "Z": 42496,
+      "Room": 13,
+      "Angle": -16384,
+      "EntityIndex": 61,
+      "TargetType": 27
+    },
+    {
+      "X": 25599,
+      "Y": 26112,
+      "Z": 45568,
+      "Room": 13,
+      "Angle": -16384,
+      "EntityIndex": 62,
+      "TargetType": 26
+    },
+    {
+      "X": 25599,
+      "Y": 26112,
+      "Z": 45568,
+      "Room": 13,
+      "Angle": -16384,
+      "EntityIndex": 62,
+      "TargetType": 27
+    },
+    {
+      "X": 73216,
+      "Y": 24320,
+      "Z": 34816,
+      "Room": 83,
+      "Angle": 0,
+      "EntityIndex": 92,
+      "TargetType": 26
+    },
+    {
+      "X": 73216,
+      "Y": 24320,
+      "Z": 34816,
+      "Room": 83,
+      "Angle": 0,
+      "EntityIndex": 92,
+      "TargetType": 27
+    },
+    {
+      "X": 62463,
+      "Y": 17664,
+      "Z": 45568,
+      "Room": 66,
+      "Angle": -16384,
+      "EntityIndex": 106,
+      "TargetType": 26
+    },
+    {
+      "X": 62463,
+      "Y": 17664,
+      "Z": 45568,
+      "Room": 66,
+      "Angle": -16384,
+      "EntityIndex": 106,
+      "TargetType": 27
+    },
+    {
+      "X": 62463,
+      "Y": 17664,
+      "Z": 44544,
+      "Room": 66,
+      "Angle": -16384,
+      "EntityIndex": 111,
+      "TargetType": 26
+    },
+    {
+      "X": 62463,
+      "Y": 17664,
+      "Z": 44544,
+      "Room": 66,
+      "Angle": -16384,
+      "EntityIndex": 111,
+      "TargetType": 27
+    },
+    {
+      "X": 69631,
+      "Y": 14848,
+      "Z": 53760,
+      "Room": 80,
+      "Angle": -16384,
+      "EntityIndex": 122,
+      "TargetType": 26
+    },
+    {
+      "X": 69631,
+      "Y": 14848,
+      "Z": 53760,
+      "Room": 80,
+      "Angle": -16384,
+      "EntityIndex": 122,
+      "TargetType": 27
+    },
+    {
+      "X": 74751,
+      "Y": 29440,
+      "Z": 44544,
+      "Room": 101,
+      "EntityIndex": 172,
+      "TargetType": 26
+    },
+    {
+      "X": 74751,
+      "Y": 29440,
+      "Z": 44544,
+      "Room": 101,
+      "EntityIndex": 172,
+      "TargetType": 27
+    },
+    {
+      "X": 34815,
+      "Y": 17152,
+      "Z": 53760,
+      "Room": 104,
+      "EntityIndex": 173,
+      "TargetType": 26
+    },
+    {
+      "X": 34815,
+      "Y": 17152,
+      "Z": 53760,
+      "Room": 104,
+      "EntityIndex": 173,
+      "TargetType": 27
+    },
+    {
+      "X": 34815,
+      "Y": 17152,
+      "Z": 51712,
+      "Room": 104,
+      "EntityIndex": 174,
+      "TargetType": 26
+    },
+    {
+      "X": 34815,
+      "Y": 17152,
+      "Z": 51712,
+      "Room": 104,
+      "EntityIndex": 174,
+      "TargetType": 27
+    },
+    {
+      "X": 48640,
+      "Y": 15616,
+      "Z": 41984,
+      "Room": 143,
+      "Angle": -32768,
+      "EntityIndex": 207,
+      "TargetType": 26
+    },
+    {
+      "X": 48640,
+      "Y": 15616,
+      "Z": 41984,
+      "Room": 143,
+      "Angle": -32768,
+      "EntityIndex": 207,
+      "TargetType": 27
+    },
+    {
+      "X": 15359,
+      "Y": 19968,
+      "Z": 7680,
+      "Room": 155,
+      "Angle": -16384,
+      "EntityIndex": 214,
+      "TargetType": 26
+    },
+    {
+      "X": 15359,
+      "Y": 19968,
+      "Z": 7680,
+      "Room": 155,
+      "Angle": -16384,
+      "EntityIndex": 214,
+      "TargetType": 27
+    },
+    {
+      "X": 15872,
+      "Y": 16384,
+      "Z": 13312,
+      "Room": 148,
+      "Angle": -32768,
+      "EntityIndex": 215,
+      "TargetType": 26
+    },
+    {
+      "X": 15872,
+      "Y": 16384,
+      "Z": 13312,
+      "Room": 148,
+      "Angle": -32768,
+      "EntityIndex": 215,
+      "TargetType": 27
+    },
+    {
+      "X": 18944,
+      "Y": 16384,
+      "Z": 13312,
+      "Room": 148,
+      "Angle": -32768,
+      "EntityIndex": 216,
+      "TargetType": 26
+    },
+    {
+      "X": 18944,
+      "Y": 16384,
+      "Z": 13312,
+      "Room": 148,
+      "Angle": -32768,
+      "EntityIndex": 216,
+      "TargetType": 27
+    },
+    {
+      "X": 51199,
+      "Y": 20736,
+      "Z": 43520,
+      "Room": 41,
+      "EntityIndex": 225,
+      "TargetType": 26
+    },
+    {
+      "X": 51199,
+      "Y": 20736,
+      "Z": 43520,
+      "Room": 41,
+      "EntityIndex": 225,
+      "TargetType": 27
+    },
+    {
+      "X": 51199,
+      "Y": 20736,
+      "Z": 46592,
+      "Room": 41,
+      "EntityIndex": 226,
+      "TargetType": 26
+    },
+    {
+      "X": 51199,
+      "Y": 20736,
+      "Z": 46592,
+      "Room": 41,
+      "EntityIndex": 226,
+      "TargetType": 27
+    }
+  ],
+  "FLOATING.TR2": [
+    {
+      "X": 74240,
+      "Y": -4096,
+      "Z": 52224,
+      "Room": 1,
+      "Angle": -32768,
+      "EntityIndex": 2,
+      "TargetType": 26
+    },
+    {
+      "X": 74240,
+      "Y": -4096,
+      "Z": 52224,
+      "Room": 1,
+      "Angle": -32768,
+      "EntityIndex": 2,
+      "TargetType": 27
+    },
+    {
+      "X": 50175,
+      "Y": -8192,
+      "Z": 54784,
+      "Room": 21,
+      "EntityIndex": 17,
+      "TargetType": 26
+    },
+    {
+      "X": 50175,
+      "Y": -8192,
+      "Z": 54784,
+      "Room": 21,
+      "EntityIndex": 17,
+      "TargetType": 27
+    },
+    {
+      "X": 50175,
+      "Y": -8192,
+      "Z": 59904,
+      "Room": 21,
+      "EntityIndex": 18,
+      "TargetType": 26
+    },
+    {
+      "X": 50175,
+      "Y": -8192,
+      "Z": 59904,
+      "Room": 21,
+      "EntityIndex": 18,
+      "TargetType": 27
+    },
+    {
+      "X": 25599,
+      "Y": 1280,
+      "Z": 96768,
+      "Room": 129,
+      "EntityIndex": 25,
+      "TargetType": 26
+    },
+    {
+      "X": 25599,
+      "Y": 1280,
+      "Z": 96768,
+      "Room": 129,
+      "EntityIndex": 25,
+      "TargetType": 27
+    },
+    {
+      "X": 47616,
+      "Y": -3584,
+      "Z": 64512,
+      "Room": 29,
+      "Angle": -32768,
+      "EntityIndex": 33,
+      "TargetType": 26
+    },
+    {
+      "X": 47616,
+      "Y": -3584,
+      "Z": 64512,
+      "Room": 29,
+      "Angle": -32768,
+      "EntityIndex": 33,
+      "TargetType": 27
+    },
+    {
+      "X": 46592,
+      "Y": -3584,
+      "Z": 64512,
+      "Room": 29,
+      "Angle": -32768,
+      "EntityIndex": 34,
+      "TargetType": 26
+    },
+    {
+      "X": 46592,
+      "Y": -3584,
+      "Z": 64512,
+      "Room": 29,
+      "Angle": -32768,
+      "EntityIndex": 34,
+      "TargetType": 27
+    },
+    {
+      "X": 48640,
+      "Y": -3584,
+      "Z": 64512,
+      "Room": 29,
+      "Angle": -32768,
+      "EntityIndex": 35,
+      "TargetType": 26
+    },
+    {
+      "X": 48640,
+      "Y": -3584,
+      "Z": 64512,
+      "Room": 29,
+      "Angle": -32768,
+      "EntityIndex": 35,
+      "TargetType": 27
+    },
+    {
+      "X": 35839,
+      "Y": -8704,
+      "Z": 46592,
+      "Room": 60,
+      "EntityIndex": 43,
+      "TargetType": 26
+    },
+    {
+      "X": 35839,
+      "Y": -8704,
+      "Z": 46592,
+      "Room": 60,
+      "EntityIndex": 43,
+      "TargetType": 27
+    },
+    {
+      "X": 26623,
+      "Y": -2304,
+      "Z": 82432,
+      "Room": 86,
+      "EntityIndex": 70,
+      "TargetType": 26
+    },
+    {
+      "X": 26623,
+      "Y": -2304,
+      "Z": 82432,
+      "Room": 86,
+      "EntityIndex": 70,
+      "TargetType": 27
+    },
+    {
+      "X": 36863,
+      "Y": -2304,
+      "Z": 82432,
+      "Room": 86,
+      "Angle": -16384,
+      "EntityIndex": 71,
+      "TargetType": 26
+    },
+    {
+      "X": 36863,
+      "Y": -2304,
+      "Z": 82432,
+      "Room": 86,
+      "Angle": -16384,
+      "EntityIndex": 71,
+      "TargetType": 27
+    },
+    {
+      "X": 22016,
+      "Y": -7680,
+      "Z": 73728,
+      "Room": 124,
+      "Angle": -32768,
+      "EntityIndex": 75,
+      "TargetType": 26
+    },
+    {
+      "X": 22016,
+      "Y": -7680,
+      "Z": 73728,
+      "Room": 124,
+      "Angle": -32768,
+      "EntityIndex": 75,
+      "TargetType": 27
+    },
+    {
+      "X": 74240,
+      "Y": -5376,
+      "Z": 64512,
+      "Room": 105,
+      "Angle": -32768,
+      "EntityIndex": 85,
+      "TargetType": 26
+    },
+    {
+      "X": 74240,
+      "Y": -5376,
+      "Z": 64512,
+      "Room": 105,
+      "Angle": -32768,
+      "EntityIndex": 85,
+      "TargetType": 27
+    },
+    {
+      "X": 73216,
+      "Y": -5376,
+      "Z": 64512,
+      "Room": 105,
+      "Angle": -32768,
+      "EntityIndex": 87,
+      "TargetType": 26
+    },
+    {
+      "X": 73216,
+      "Y": -5376,
+      "Z": 64512,
+      "Room": 105,
+      "Angle": -32768,
+      "EntityIndex": 87,
+      "TargetType": 27
+    },
+    {
+      "X": 72192,
+      "Y": -5376,
+      "Z": 64512,
+      "Room": 105,
+      "Angle": -32768,
+      "EntityIndex": 88,
+      "TargetType": 26
+    },
+    {
+      "X": 72192,
+      "Y": -5376,
+      "Z": 64512,
+      "Room": 105,
+      "Angle": -32768,
+      "EntityIndex": 88,
+      "TargetType": 27
+    },
+    {
+      "X": 71168,
+      "Y": -5376,
+      "Z": 64512,
+      "Room": 105,
+      "Angle": -32768,
+      "EntityIndex": 86,
+      "TargetType": 26
+    },
+    {
+      "X": 71168,
+      "Y": -5376,
+      "Z": 64512,
+      "Room": 105,
+      "Angle": -32768,
+      "EntityIndex": 86,
+      "TargetType": 27
+    },
+    {
+      "X": 38911,
+      "Y": 3584,
+      "Z": 81408,
+      "Room": 145,
+      "Angle": -16384,
+      "EntityIndex": 108,
+      "TargetType": 26
+    },
+    {
+      "X": 38911,
+      "Y": 3584,
+      "Z": 81408,
+      "Room": 145,
+      "Angle": -16384,
+      "EntityIndex": 108,
+      "TargetType": 27
+    },
+    {
+      "X": 38400,
+      "Y": 3584,
+      "Z": 82944,
+      "Room": 145,
+      "Angle": 0,
+      "EntityIndex": 110,
+      "TargetType": 26
+    },
+    {
+      "X": 38400,
+      "Y": 3584,
+      "Z": 82944,
+      "Room": 145,
+      "Angle": 0,
+      "EntityIndex": 110,
+      "TargetType": 27
+    },
+    {
+      "X": 36352,
+      "Y": 3584,
+      "Z": 75776,
+      "Room": 145,
+      "Angle": 0,
+      "EntityIndex": 111,
+      "TargetType": 26
+    },
+    {
+      "X": 36352,
+      "Y": 3584,
+      "Z": 75776,
+      "Room": 145,
+      "Angle": 0,
+      "EntityIndex": 111,
+      "TargetType": 27
+    },
+    {
+      "X": 26112,
+      "Y": 3584,
+      "Z": 81920,
+      "Room": 146,
+      "Angle": 0,
+      "EntityIndex": 115,
+      "TargetType": 26
+    },
+    {
+      "X": 26112,
+      "Y": 3584,
+      "Z": 81920,
+      "Room": 146,
+      "Angle": 0,
+      "EntityIndex": 115,
+      "TargetType": 27
+    },
+    {
+      "X": 25599,
+      "Y": 3584,
+      "Z": 80384,
+      "Room": 146,
+      "EntityIndex": 116,
+      "TargetType": 26
+    },
+    {
+      "X": 25599,
+      "Y": 3584,
+      "Z": 80384,
+      "Room": 146,
+      "EntityIndex": 116,
+      "TargetType": 27
+    },
+    {
+      "X": 31232,
+      "Y": 3328,
+      "Z": 88064,
+      "Room": 147,
+      "Angle": -32768,
+      "EntityIndex": 120,
+      "TargetType": 26
+    },
+    {
+      "X": 31232,
+      "Y": 3328,
+      "Z": 88064,
+      "Room": 147,
+      "Angle": -32768,
+      "EntityIndex": 120,
+      "TargetType": 27
+    },
+    {
+      "X": 33280,
+      "Y": 3328,
+      "Z": 88064,
+      "Room": 147,
+      "Angle": -32768,
+      "EntityIndex": 121,
+      "TargetType": 26
+    },
+    {
+      "X": 33280,
+      "Y": 3328,
+      "Z": 88064,
+      "Room": 147,
+      "Angle": -32768,
+      "EntityIndex": 121,
+      "TargetType": 27
+    },
+    {
+      "X": 32256,
+      "Y": 3584,
+      "Z": 83968,
+      "Room": 147,
+      "Angle": 0,
+      "EntityIndex": 122,
+      "TargetType": 26
+    },
+    {
+      "X": 32256,
+      "Y": 3584,
+      "Z": 83968,
+      "Room": 147,
+      "Angle": 0,
+      "EntityIndex": 122,
+      "TargetType": 27
+    }
+  ],
+  "XIAN.TR2": [
+    {
+      "X": 54784,
+      "Y": -9984,
+      "Z": 72704,
+      "Room": 1,
+      "Angle": -32768,
+      "EntityIndex": 7,
+      "TargetType": 26
+    },
+    {
+      "X": 54784,
+      "Y": -9984,
+      "Z": 72704,
+      "Room": 1,
+      "Angle": -32768,
+      "EntityIndex": 7,
+      "TargetType": 27
+    },
+    {
+      "X": 54784,
+      "Y": -9984,
+      "Z": 59392,
+      "Room": 1,
+      "Angle": 0,
+      "EntityIndex": 8,
+      "TargetType": 26
+    },
+    {
+      "X": 54784,
+      "Y": -9984,
+      "Z": 59392,
+      "Room": 1,
+      "Angle": 0,
+      "EntityIndex": 8,
+      "TargetType": 27
+    },
+    {
+      "X": 57856,
+      "Y": -9984,
+      "Z": 59392,
+      "Room": 1,
+      "Angle": 0,
+      "EntityIndex": 9,
+      "TargetType": 26
+    },
+    {
+      "X": 57856,
+      "Y": -9984,
+      "Z": 59392,
+      "Room": 1,
+      "Angle": 0,
+      "EntityIndex": 9,
+      "TargetType": 27
+    },
+    {
+      "X": 57856,
+      "Y": -9984,
+      "Z": 72704,
+      "Room": 1,
+      "Angle": -32768,
+      "EntityIndex": 10,
+      "TargetType": 26
+    },
+    {
+      "X": 57856,
+      "Y": -9984,
+      "Z": 72704,
+      "Room": 1,
+      "Angle": -32768,
+      "EntityIndex": 10,
+      "TargetType": 27
+    },
+    {
+      "X": 65024,
+      "Y": -9984,
+      "Z": 72704,
+      "Room": 1,
+      "Angle": -32768,
+      "EntityIndex": 11,
+      "TargetType": 26
+    },
+    {
+      "X": 65024,
+      "Y": -9984,
+      "Z": 72704,
+      "Room": 1,
+      "Angle": -32768,
+      "EntityIndex": 11,
+      "TargetType": 27
+    },
+    {
+      "X": 65024,
+      "Y": -9984,
+      "Z": 59392,
+      "Room": 1,
+      "Angle": 0,
+      "EntityIndex": 12,
+      "TargetType": 26
+    },
+    {
+      "X": 65024,
+      "Y": -9984,
+      "Z": 59392,
+      "Room": 1,
+      "Angle": 0,
+      "EntityIndex": 12,
+      "TargetType": 27
+    },
+    {
+      "X": 78847,
+      "Y": -9984,
+      "Z": 70144,
+      "Room": 3,
+      "Angle": -16384,
+      "EntityIndex": 25,
+      "TargetType": 26
+    },
+    {
+      "X": 78847,
+      "Y": -9984,
+      "Z": 70144,
+      "Room": 3,
+      "Angle": -16384,
+      "EntityIndex": 25,
+      "TargetType": 27
+    },
+    {
+      "X": 73216,
+      "Y": -9984,
+      "Z": 64512,
+      "Room": 3,
+      "Angle": 0,
+      "EntityIndex": 26,
+      "TargetType": 26
+    },
+    {
+      "X": 73216,
+      "Y": -9984,
+      "Z": 64512,
+      "Room": 3,
+      "Angle": 0,
+      "EntityIndex": 26,
+      "TargetType": 27
+    },
+    {
+      "X": 68096,
+      "Y": -9984,
+      "Z": 70144,
+      "Room": 3,
+      "EntityIndex": 27,
+      "TargetType": 26
+    },
+    {
+      "X": 68096,
+      "Y": -9984,
+      "Z": 70144,
+      "Room": 3,
+      "EntityIndex": 27,
+      "TargetType": 27
+    },
+    {
+      "X": 73216,
+      "Y": -9984,
+      "Z": 75264,
+      "Room": 3,
+      "Angle": -32768,
+      "EntityIndex": 28,
+      "TargetType": 26
+    },
+    {
+      "X": 73216,
+      "Y": -9984,
+      "Z": 75264,
+      "Room": 3,
+      "Angle": -32768,
+      "EntityIndex": 28,
+      "TargetType": 27
+    }
+  ]
+}

--- a/TRRandomizerCore/Resources/TR3/Locations/enemy_relocations.json
+++ b/TRRandomizerCore/Resources/TR3/Locations/enemy_relocations.json
@@ -1,0 +1,1206 @@
+{
+  "JUNGLE.TR2": [
+    {
+      "X": 88576,
+      "Y": 26624,
+      "Z": 60928,
+      "Room": 71,
+      "Angle": 0,
+      "EntityIndex": 69,
+      "TargetType": 287
+    },
+    {
+      "X": 18944,
+      "Y": 23808,
+      "Z": 71168,
+      "Room": 126,
+      "Angle": 0,
+      "EntityIndex": 116,
+      "TargetType": 287
+    }
+  ],
+  "TEMPLE.TR2": [
+    {
+      "X": 86528,
+      "Y": -256,
+      "Z": 37376,
+      "Room": 16,
+      "EntityIndex": 14,
+      "TargetType": 287
+    },
+    {
+      "X": 80384,
+      "Y": -3328,
+      "Z": 34304,
+      "Room": 27,
+      "Angle": -32768,
+      "EntityIndex": 24,
+      "TargetType": 287
+    },
+    {
+      "X": 77312,
+      "Y": -3584,
+      "Z": 45568,
+      "Room": 38,
+      "Angle": -16384,
+      "EntityIndex": 30,
+      "TargetType": 287
+    },
+    {
+      "X": 86528,
+      "Y": -3328,
+      "Z": 33280,
+      "Room": 19,
+      "Angle": -16384,
+      "EntityIndex": 33,
+      "TargetType": 287
+    },
+    {
+      "X": 86528,
+      "Y": -768,
+      "Z": 52736,
+      "Room": 10,
+      "EntityIndex": 36,
+      "TargetType": 287
+    },
+    {
+      "X": 65024,
+      "Y": 7040,
+      "Z": 52736,
+      "Room": 77,
+      "Angle": -16384,
+      "EntityIndex": 41,
+      "TargetType": 287
+    },
+    {
+      "X": 48640,
+      "Y": 3968,
+      "Z": 23040,
+      "Room": 175,
+      "EntityIndex": 149,
+      "TargetType": 287
+    },
+    {
+      "X": 48640,
+      "Y": 1280,
+      "Z": 59904,
+      "Room": 196,
+      "Angle": -32768,
+      "EntityIndex": 176,
+      "TargetType": 287
+    },
+    {
+      "X": 48640,
+      "Y": 1280,
+      "Z": 56832,
+      "Room": 196,
+      "Angle": 0,
+      "EntityIndex": 177,
+      "TargetType": 287
+    },
+    {
+      "X": 61952,
+      "Y": 7168,
+      "Z": 61952,
+      "Room": 81,
+      "Angle": -32768,
+      "EntityIndex": 181,
+      "TargetType": 287
+    },
+    {
+      "X": 64000,
+      "Y": 7040,
+      "Z": 61952,
+      "Room": 81,
+      "Angle": -32768,
+      "EntityIndex": 182,
+      "TargetType": 287
+    }
+  ],
+  "QUADCHAS.TR2": [
+    {
+      "X": 93696,
+      "Y": 512,
+      "Z": 26112,
+      "Room": 41,
+      "Angle": -32768,
+      "EntityIndex": 14,
+      "TargetType": 287
+    },
+    {
+      "X": 77312,
+      "Y": -384,
+      "Z": 13824,
+      "Room": 51,
+      "EntityIndex": 15,
+      "TargetType": 287
+    },
+    {
+      "X": 69120,
+      "Y": 768,
+      "Z": 38400,
+      "Room": 63,
+      "Angle": -32768,
+      "EntityIndex": 29,
+      "TargetType": 287
+    },
+    {
+      "X": 72192,
+      "Y": 768,
+      "Z": 37376,
+      "Room": 78,
+      "Angle": 0,
+      "EntityIndex": 32,
+      "TargetType": 287
+    },
+    {
+      "X": 53760,
+      "Y": -2560,
+      "Z": 42496,
+      "Room": 91,
+      "EntityIndex": 56,
+      "TargetType": 287
+    },
+    {
+      "X": 55808,
+      "Y": -2560,
+      "Z": 44544,
+      "Room": 91,
+      "EntityIndex": 57,
+      "TargetType": 287
+    },
+    {
+      "X": 31232,
+      "Y": -5504,
+      "Z": 47616,
+      "Room": 155,
+      "EntityIndex": 83,
+      "TargetType": 287
+    }
+  ],
+  "SHORE.TR2": [
+    {
+      "X": 37376,
+      "Y": -6912,
+      "Z": 80384,
+      "Room": 40,
+      "Angle": -16384,
+      "EntityIndex": 75,
+      "TargetType": 287
+    },
+    {
+      "X": 33280,
+      "Y": -512,
+      "Z": 70144,
+      "Room": 144,
+      "EntityIndex": 165,
+      "TargetType": 287
+    },
+    {
+      "X": 46592,
+      "Y": -5376,
+      "Z": 71168,
+      "Room": 50,
+      "EntityIndex": 173,
+      "TargetType": 287
+    },
+    {
+      "X": 29184,
+      "Y": -4096,
+      "Z": 70144,
+      "Room": 76,
+      "EntityIndex": 92,
+      "TargetType": 287
+    },
+    {
+      "X": 34304,
+      "Y": -1024,
+      "Z": 89600,
+      "Room": 121,
+      "EntityIndex": 135,
+      "TargetType": 287
+    },
+    {
+      "X": 31232,
+      "Y": -4608,
+      "Z": 55808,
+      "Room": 143,
+      "EntityIndex": 145,
+      "TargetType": 287
+    },
+    {
+      "X": 34304,
+      "Y": -512,
+      "Z": 69120,
+      "Room": 144,
+      "EntityIndex": 159,
+      "TargetType": 287
+    },
+    {
+      "X": 26112,
+      "Y": -512,
+      "Z": 64000,
+      "Room": 145,
+      "EntityIndex": 162,
+      "TargetType": 287
+    },
+    {
+      "X": 79360,
+      "Y": -1280,
+      "Z": 80384,
+      "Room": 188,
+      "EntityIndex": 177,
+      "TargetType": 287
+    }
+  ],
+  "CRASH.TR2": [
+    {
+      "X": 64000,
+      "Y": -4096,
+      "Z": 49664,
+      "Room": 11,
+      "EntityIndex": 11,
+      "TargetType": 287
+    },
+    {
+      "X": 67072,
+      "Y": -128,
+      "Z": 46592,
+      "Room": 1,
+      "EntityIndex": 45,
+      "TargetType": 287
+    },
+    {
+      "X": 67072,
+      "Y": -128,
+      "Z": 46592,
+      "Room": 1,
+      "EntityIndex": 46,
+      "TargetType": 287
+    },
+    {
+      "X": 67072,
+      "Y": -128,
+      "Z": 46592,
+      "Room": 1,
+      "EntityIndex": 47,
+      "TargetType": 287
+    },
+    {
+      "X": 67072,
+      "Y": -128,
+      "Z": 46592,
+      "Room": 1,
+      "EntityIndex": 48,
+      "TargetType": 287
+    },
+    {
+      "X": 67072,
+      "Y": -128,
+      "Z": 46592,
+      "Room": 1,
+      "EntityIndex": 49,
+      "TargetType": 287
+    },
+    {
+      "X": 67072,
+      "Y": -128,
+      "Z": 46592,
+      "Room": 1,
+      "EntityIndex": 50,
+      "TargetType": 287
+    },
+    {
+      "X": 67072,
+      "Y": -128,
+      "Z": 46592,
+      "Room": 1,
+      "EntityIndex": 51,
+      "TargetType": 287
+    },
+    {
+      "X": 67072,
+      "Y": 0,
+      "Z": 23040,
+      "Room": 57,
+      "EntityIndex": 60,
+      "TargetType": 287
+    },
+    {
+      "X": 64000,
+      "Y": -6144,
+      "Z": 25088,
+      "Room": 60,
+      "EntityIndex": 109,
+      "TargetType": 287
+    },
+    {
+      "X": 64000,
+      "Y": 0,
+      "Z": 30208,
+      "Room": 57,
+      "EntityIndex": 121,
+      "TargetType": 287
+    },
+    {
+      "X": 65024,
+      "Y": 0,
+      "Z": 30208,
+      "Room": 57,
+      "EntityIndex": 124,
+      "TargetType": 287
+    },
+    {
+      "X": 66048,
+      "Y": 0,
+      "Z": 30208,
+      "Room": 57,
+      "EntityIndex": 128,
+      "TargetType": 287
+    },
+    {
+      "X": 67072,
+      "Y": 0,
+      "Z": 30208,
+      "Room": 57,
+      "EntityIndex": 130,
+      "TargetType": 287
+    },
+    {
+      "X": 66048,
+      "Y": 0,
+      "Z": 31232,
+      "Room": 57,
+      "EntityIndex": 131,
+      "TargetType": 287
+    },
+    {
+      "X": 26112,
+      "Y": 2048,
+      "Z": 50688,
+      "Room": 45,
+      "EntityIndex": 138,
+      "TargetType": 287
+    }
+  ],
+  "RAPIDS.TR2": [
+    {
+      "X": 86528,
+      "Y": -18432,
+      "Z": 38400,
+      "Room": 77,
+      "EntityIndex": 14,
+      "TargetType": 287
+    },
+    {
+      "X": 72192,
+      "Y": -23040,
+      "Z": 23040,
+      "Room": 14,
+      "EntityIndex": 32,
+      "TargetType": 287
+    },
+    {
+      "X": 52736,
+      "Y": -17792,
+      "Z": 17920,
+      "Room": 7,
+      "EntityIndex": 36,
+      "TargetType": 287
+    },
+    {
+      "X": 59904,
+      "Y": -19072,
+      "Z": 28160,
+      "Room": 39,
+      "EntityIndex": 42,
+      "TargetType": 287
+    },
+    {
+      "X": 66048,
+      "Y": -22528,
+      "Z": 43520,
+      "Room": 45,
+      "EntityIndex": 43,
+      "TargetType": 287
+    },
+    {
+      "X": 36352,
+      "Y": 4608,
+      "Z": 55808,
+      "Room": 81,
+      "EntityIndex": 104,
+      "TargetType": 287
+    },
+    {
+      "X": 47616,
+      "Y": 2816,
+      "Z": 83456,
+      "Room": 101,
+      "EntityIndex": 128,
+      "TargetType": 287
+    }
+  ],
+  "ROOFS.TR2": [
+    {
+      "X": 50688,
+      "Y": -13312,
+      "Z": 30208,
+      "Room": 148,
+      "EntityIndex": 30,
+      "TargetType": 287
+    },
+    {
+      "X": 48640,
+      "Y": -18944,
+      "Z": 30208,
+      "Room": 129,
+      "EntityIndex": 31,
+      "TargetType": 287
+    },
+    {
+      "X": 51712,
+      "Y": -14848,
+      "Z": 36352,
+      "Room": 108,
+      "EntityIndex": 46,
+      "TargetType": 287
+    },
+    {
+      "X": 27136,
+      "Y": -8704,
+      "Z": 31232,
+      "Room": 27,
+      "EntityIndex": 52,
+      "TargetType": 287
+    },
+    {
+      "X": 19968,
+      "Y": -8192,
+      "Z": 40448,
+      "Room": 17,
+      "EntityIndex": 81,
+      "TargetType": 287
+    },
+    {
+      "X": 19968,
+      "Y": -8192,
+      "Z": 47616,
+      "Room": 17,
+      "EntityIndex": 85,
+      "TargetType": 287
+    },
+    {
+      "X": 27136,
+      "Y": -8192,
+      "Z": 40448,
+      "Room": 17,
+      "EntityIndex": 86,
+      "TargetType": 287
+    },
+    {
+      "X": 19968,
+      "Y": -8192,
+      "Z": 56832,
+      "Room": 16,
+      "EntityIndex": 100,
+      "TargetType": 287
+    },
+    {
+      "X": 19968,
+      "Y": -8192,
+      "Z": 49664,
+      "Room": 16,
+      "EntityIndex": 101,
+      "TargetType": 287
+    },
+    {
+      "X": 39424,
+      "Y": -8704,
+      "Z": 49664,
+      "Room": 174,
+      "EntityIndex": 113,
+      "TargetType": 287
+    },
+    {
+      "X": 27136,
+      "Y": -8192,
+      "Z": 47616,
+      "Room": 17,
+      "EntityIndex": 147,
+      "TargetType": 287
+    },
+    {
+      "X": 27136,
+      "Y": -8192,
+      "Z": 49664,
+      "Room": 16,
+      "EntityIndex": 148,
+      "TargetType": 287
+    },
+    {
+      "X": 40448,
+      "Y": -8704,
+      "Z": 51712,
+      "Room": 174,
+      "EntityIndex": 176,
+      "TargetType": 287
+    },
+    {
+      "X": 39424,
+      "Y": -8704,
+      "Z": 51712,
+      "Room": 174,
+      "EntityIndex": 177,
+      "TargetType": 287
+    },
+    {
+      "X": 40448,
+      "Y": -8704,
+      "Z": 50688,
+      "Room": 174,
+      "EntityIndex": 191,
+      "TargetType": 287
+    },
+    {
+      "X": 27136,
+      "Y": -8192,
+      "Z": 56832,
+      "Room": 16,
+      "EntityIndex": 207,
+      "TargetType": 287
+    },
+    {
+      "X": 19968,
+      "Y": -8192,
+      "Z": 40448,
+      "Room": 17,
+      "EntityIndex": 208,
+      "TargetType": 287
+    },
+    {
+      "X": 19968,
+      "Y": -8192,
+      "Z": 56832,
+      "Room": 16,
+      "EntityIndex": 212,
+      "TargetType": 287
+    }
+  ],
+  "SEWER.TR2": [
+    {
+      "X": 49664,
+      "Y": 3584,
+      "Z": 71168,
+      "Room": 70,
+      "EntityIndex": 29,
+      "TargetType": 287
+    },
+    {
+      "X": 57856,
+      "Y": 1280,
+      "Z": 47616,
+      "Room": 75,
+      "EntityIndex": 55,
+      "TargetType": 287
+    },
+    {
+      "X": 50688,
+      "Y": 768,
+      "Z": 62976,
+      "Room": 41,
+      "EntityIndex": 102,
+      "TargetType": 287
+    },
+    {
+      "X": 41472,
+      "Y": -3328,
+      "Z": 67072,
+      "Room": 55,
+      "EntityIndex": 117,
+      "TargetType": 287
+    },
+    {
+      "X": 57856,
+      "Y": 1280,
+      "Z": 48640,
+      "Room": 75,
+      "EntityIndex": 141,
+      "TargetType": 287
+    },
+    {
+      "X": 50688,
+      "Y": 768,
+      "Z": 61952,
+      "Room": 41,
+      "EntityIndex": 152,
+      "TargetType": 287
+    },
+    {
+      "X": 61952,
+      "Y": 1280,
+      "Z": 48640,
+      "Room": 75,
+      "EntityIndex": 170,
+      "TargetType": 287
+    },
+    {
+      "X": 62976,
+      "Y": 1280,
+      "Z": 47616,
+      "Room": 75,
+      "EntityIndex": 181,
+      "TargetType": 287
+    },
+    {
+      "X": 61952,
+      "Y": 1280,
+      "Z": 47616,
+      "Room": 75,
+      "EntityIndex": 182,
+      "TargetType": 287
+    },
+    {
+      "X": 55808,
+      "Y": 2560,
+      "Z": 41472,
+      "Room": 104,
+      "EntityIndex": 199,
+      "TargetType": 287
+    },
+    {
+      "X": 49664,
+      "Y": 3584,
+      "Z": 70144,
+      "Room": 70,
+      "EntityIndex": 204,
+      "TargetType": 287
+    },
+    {
+      "X": 69120,
+      "Y": -5888,
+      "Z": 82432,
+      "Room": 37,
+      "EntityIndex": 216,
+      "TargetType": 287
+    }
+  ],
+  "TOWER.TR2": [
+    {
+      "X": 57856,
+      "Y": -4096,
+      "Z": 22016,
+      "Room": 29,
+      "EntityIndex": 22,
+      "TargetType": 287
+    },
+    {
+      "X": 71168,
+      "Y": -15616,
+      "Z": 34304,
+      "Room": 141,
+      "EntityIndex": 32,
+      "TargetType": 287
+    },
+    {
+      "X": 71168,
+      "Y": -15616,
+      "Z": 30208,
+      "Room": 141,
+      "EntityIndex": 44,
+      "TargetType": 287
+    },
+    {
+      "X": 73216,
+      "Y": -15616,
+      "Z": 30208,
+      "Room": 141,
+      "EntityIndex": 45,
+      "TargetType": 287
+    },
+    {
+      "X": 33280,
+      "Y": -26368,
+      "Z": 44544,
+      "Room": 155,
+      "EntityIndex": 51,
+      "TargetType": 287
+    },
+    {
+      "X": 52736,
+      "Y": -18688,
+      "Z": 30208,
+      "Room": 18,
+      "EntityIndex": 119,
+      "TargetType": 287
+    },
+    {
+      "X": 50688,
+      "Y": -18688,
+      "Z": 30208,
+      "Room": 18,
+      "EntityIndex": 133,
+      "TargetType": 287
+    },
+    {
+      "X": 51712,
+      "Y": -18688,
+      "Z": 29184,
+      "Room": 18,
+      "EntityIndex": 156,
+      "TargetType": 287
+    },
+    {
+      "X": 51712,
+      "Y": -18688,
+      "Z": 31232,
+      "Room": 18,
+      "EntityIndex": 179,
+      "TargetType": 287
+    }
+  ],
+  "NEVADA.TR2": [
+    {
+      "X": 27136,
+      "Y": 0,
+      "Z": 23040,
+      "Room": 4,
+      "EntityIndex": 18,
+      "TargetType": 287
+    },
+    {
+      "X": 26112,
+      "Y": 0,
+      "Z": 23040,
+      "Room": 4,
+      "EntityIndex": 19,
+      "TargetType": 287
+    },
+    {
+      "X": 25088,
+      "Y": 0,
+      "Z": 23040,
+      "Room": 4,
+      "EntityIndex": 20,
+      "TargetType": 287
+    },
+    {
+      "X": 12800,
+      "Y": -3328,
+      "Z": 56832,
+      "Room": 48,
+      "EntityIndex": 43,
+      "TargetType": 287
+    },
+    {
+      "X": 17920,
+      "Y": -3200,
+      "Z": 55808,
+      "Room": 48,
+      "EntityIndex": 59,
+      "TargetType": 287
+    },
+    {
+      "X": 51712,
+      "Y": -2944,
+      "Z": 71168,
+      "Room": 149,
+      "EntityIndex": 141,
+      "TargetType": 287
+    },
+    {
+      "X": 49664,
+      "Y": -6656,
+      "Z": 77312,
+      "Room": 154,
+      "EntityIndex": 145,
+      "TargetType": 287
+    }
+  ],
+  "COMPOUND.TR2": [
+    {
+      "X": 13824,
+      "Y": 2048,
+      "Z": 31232,
+      "Room": 7,
+      "EntityIndex": 17,
+      "TargetType": 287
+    },
+    {
+      "X": 95744,
+      "Y": -4864,
+      "Z": 79360,
+      "Room": 74,
+      "EntityIndex": 100,
+      "TargetType": 287
+    },
+    {
+      "X": 38400,
+      "Y": 1792,
+      "Z": 32256,
+      "Room": 19,
+      "EntityIndex": 126,
+      "TargetType": 287
+    },
+    {
+      "X": 55808,
+      "Y": -4608,
+      "Z": 22016,
+      "Room": 160,
+      "EntityIndex": 147,
+      "TargetType": 287
+    },
+    {
+      "X": 56832,
+      "Y": -4608,
+      "Z": 22016,
+      "Room": 160,
+      "EntityIndex": 148,
+      "TargetType": 287
+    },
+    {
+      "X": 57856,
+      "Y": -4608,
+      "Z": 22016,
+      "Room": 160,
+      "EntityIndex": 149,
+      "TargetType": 287
+    },
+    {
+      "X": 5632,
+      "Y": 2304,
+      "Z": 33280,
+      "Room": 7,
+      "EntityIndex": 165,
+      "TargetType": 287
+    },
+    {
+      "X": 71168,
+      "Y": 8704,
+      "Z": 17920,
+      "Room": 118,
+      "EntityIndex": 219,
+      "TargetType": 287
+    }
+  ],
+  "AREA51.TR2": [
+    {
+      "X": 35328,
+      "Y": 256,
+      "Z": 62976,
+      "Room": 0,
+      "EntityIndex": 9,
+      "TargetType": 287
+    },
+    {
+      "X": 46592,
+      "Y": 256,
+      "Z": 65024,
+      "Room": 0,
+      "EntityIndex": 38,
+      "TargetType": 287
+    },
+    {
+      "X": 14848,
+      "Y": -4864,
+      "Z": 45568,
+      "Room": 127,
+      "EntityIndex": 50,
+      "TargetType": 287
+    },
+    {
+      "X": 40448,
+      "Y": 256,
+      "Z": 69120,
+      "Room": 0,
+      "EntityIndex": 59,
+      "TargetType": 287
+    },
+    {
+      "X": 23040,
+      "Y": 1536,
+      "Z": 62976,
+      "Room": 148,
+      "EntityIndex": 76,
+      "TargetType": 287
+    },
+    {
+      "X": 38400,
+      "Y": 2048,
+      "Z": 60928,
+      "Room": 44,
+      "EntityIndex": 94,
+      "TargetType": 287
+    },
+    {
+      "X": 34304,
+      "Y": 5632,
+      "Z": 41472,
+      "Room": 69,
+      "EntityIndex": 106,
+      "TargetType": 287
+    },
+    {
+      "X": 34304,
+      "Y": 3584,
+      "Z": 72192,
+      "Room": 82,
+      "EntityIndex": 140,
+      "TargetType": 287
+    }
+  ],
+  "ANTARC.TR2": [
+    {
+      "X": 44544,
+      "Y": -2816,
+      "Z": 68096,
+      "Room": 187,
+      "EntityIndex": 8,
+      "TargetType": 287
+    },
+    {
+      "X": 45568,
+      "Y": -2816,
+      "Z": 68096,
+      "Room": 187,
+      "EntityIndex": 9,
+      "TargetType": 287
+    },
+    {
+      "X": 61952,
+      "Y": -6400,
+      "Z": 75264,
+      "Room": 55,
+      "EntityIndex": 14,
+      "TargetType": 287
+    },
+    {
+      "X": 27136,
+      "Y": -6400,
+      "Z": 39424,
+      "Room": 7,
+      "EntityIndex": 20,
+      "TargetType": 287
+    },
+    {
+      "X": 27136,
+      "Y": -6400,
+      "Z": 12800,
+      "Room": 39,
+      "EntityIndex": 28,
+      "TargetType": 287
+    },
+    {
+      "X": 25088,
+      "Y": -6400,
+      "Z": 39424,
+      "Room": 7,
+      "EntityIndex": 79,
+      "TargetType": 287
+    },
+    {
+      "X": 74240,
+      "Y": -2944,
+      "Z": 71168,
+      "Room": 69,
+      "EntityIndex": 81,
+      "TargetType": 287
+    },
+    {
+      "X": 23040,
+      "Y": -6144,
+      "Z": 29184,
+      "Room": 7,
+      "EntityIndex": 89,
+      "TargetType": 287
+    },
+    {
+      "X": 60928,
+      "Y": -2944,
+      "Z": 56832,
+      "Room": 119,
+      "EntityIndex": 92,
+      "TargetType": 287
+    },
+    {
+      "X": 45568,
+      "Y": -2688,
+      "Z": 64000,
+      "Room": 187,
+      "EntityIndex": 94,
+      "TargetType": 287
+    },
+    {
+      "X": 24064,
+      "Y": -6400,
+      "Z": 12800,
+      "Room": 39,
+      "EntityIndex": 105,
+      "TargetType": 287
+    },
+    {
+      "X": 27136,
+      "Y": -8960,
+      "Z": 22016,
+      "Room": 56,
+      "EntityIndex": 107,
+      "TargetType": 287
+    },
+    {
+      "X": 53760,
+      "Y": -2816,
+      "Z": 66048,
+      "Room": 117,
+      "EntityIndex": 115,
+      "TargetType": 287
+    },
+    {
+      "X": 53760,
+      "Y": -2816,
+      "Z": 65024,
+      "Room": 117,
+      "EntityIndex": 116,
+      "TargetType": 287
+    },
+    {
+      "X": 40448,
+      "Y": -6400,
+      "Z": 22016,
+      "Room": 19,
+      "EntityIndex": 150,
+      "TargetType": 287
+    },
+    {
+      "X": 46592,
+      "Y": -3584,
+      "Z": 40448,
+      "Room": 70,
+      "EntityIndex": 151,
+      "TargetType": 287
+    }
+  ],
+  "MINES.TR2": [
+    {
+      "X": 55808,
+      "Y": 8064,
+      "Z": 62976,
+      "Room": 18,
+      "EntityIndex": 26,
+      "TargetType": 287
+    },
+    {
+      "X": 54784,
+      "Y": 8192,
+      "Z": 62976,
+      "Room": 18,
+      "EntityIndex": 37,
+      "TargetType": 287
+    },
+    {
+      "X": 54784,
+      "Y": 9088,
+      "Z": 44544,
+      "Room": 69,
+      "EntityIndex": 47,
+      "TargetType": 287
+    },
+    {
+      "X": 54784,
+      "Y": 8960,
+      "Z": 43520,
+      "Room": 69,
+      "EntityIndex": 48,
+      "TargetType": 287
+    },
+    {
+      "X": 65024,
+      "Y": 5888,
+      "Z": 49664,
+      "Room": 104,
+      "EntityIndex": 71,
+      "TargetType": 287
+    },
+    {
+      "X": 49664,
+      "Y": 5888,
+      "Z": 41472,
+      "Room": 70,
+      "EntityIndex": 74,
+      "TargetType": 287
+    },
+    {
+      "X": 38400,
+      "Y": 8192,
+      "Z": 53760,
+      "Room": 11,
+      "EntityIndex": 95,
+      "TargetType": 287
+    },
+    {
+      "X": 11776,
+      "Y": 7424,
+      "Z": 69120,
+      "Room": 125,
+      "EntityIndex": 117,
+      "TargetType": 287
+    },
+    {
+      "X": 73216,
+      "Y": 24320,
+      "Z": 61952,
+      "Room": 160,
+      "EntityIndex": 147,
+      "TargetType": 287
+    },
+    {
+      "X": 58880,
+      "Y": 26624,
+      "Z": 57856,
+      "Room": 160,
+      "EntityIndex": 148,
+      "TargetType": 287
+    },
+    {
+      "X": 69120,
+      "Y": 26624,
+      "Z": 56832,
+      "Room": 160,
+      "EntityIndex": 164,
+      "TargetType": 287
+    },
+    {
+      "X": 55808,
+      "Y": 8192,
+      "Z": 65024,
+      "Room": 18,
+      "EntityIndex": 171,
+      "TargetType": 287
+    },
+    {
+      "X": 72192,
+      "Y": 24320,
+      "Z": 61952,
+      "Room": 160,
+      "EntityIndex": 173,
+      "TargetType": 287
+    }
+  ],
+  "CHAMBER.TR2": [
+    {
+      "X": 28160,
+      "Y": 0,
+      "Z": 27136,
+      "Room": 28,
+      "EntityIndex": 48,
+      "TargetType": 287
+    },
+    {
+      "X": 49664,
+      "Y": 0,
+      "Z": 35328,
+      "Room": 23,
+      "EntityIndex": 50,
+      "TargetType": 287
+    }
+  ]
+}

--- a/TRRandomizerCore/TRRandomizerController.cs
+++ b/TRRandomizerCore/TRRandomizerController.cs
@@ -1232,6 +1232,12 @@ public class TRRandomizerController
         set => LevelRandomizer.DocileWillard = value;
     }
 
+    public bool RelocateAwkwardEnemies
+    {
+        get => LevelRandomizer.RelocateAwkwardEnemies;
+        set => LevelRandomizer.RelocateAwkwardEnemies = value;
+    }
+
     public BirdMonsterBehaviour BirdMonsterBehaviour
     {
         get => LevelRandomizer.BirdMonsterBehaviour;

--- a/TRRandomizerCore/Utilities/TR3EnemyUtilities.cs
+++ b/TRRandomizerCore/Utilities/TR3EnemyUtilities.cs
@@ -292,8 +292,8 @@ public static class TR3EnemyUtilities
 
     private static readonly Dictionary<string, List<TR3Type>> _unsupportedEnemiesDefault = new()
     {
-        [TR3LevelNames.HALLOWS] =
-            new List<TR3Type> { TR3Type.Willie }
+        [TR3LevelNames.CAVES] = new() { TR3Type.Tyrannosaur },
+        [TR3LevelNames.HALLOWS] = new() { TR3Type.Willie },
     };
 
     // Any enemies that must remain untouched in a given level

--- a/TRRandomizerView/Model/ControllerOptions.cs
+++ b/TRRandomizerView/Model/ControllerOptions.cs
@@ -38,7 +38,7 @@ public class ControllerOptions : INotifyPropertyChanged
     private bool _useRewardRoomCameras;
     private uint _minSecretCount, _maxSecretCount;
     private BoolItemControlClass _includeKeyItems, _allowReturnPathLocations, _includeExtraPickups, _randomizeItemTypes, _randomizeItemLocations, _allowEnemyKeyDrops, _maintainKeyContinuity, _oneItemDifficulty;
-    private BoolItemControlClass _crossLevelEnemies, _protectMonks, _docileWillard, _swapEnemyAppearance, _allowEmptyEggs, _hideEnemies, _removeLevelEndingLarson, _giveUnarmedItems, _unrestrictedEnemyDifficulty;
+    private BoolItemControlClass _crossLevelEnemies, _protectMonks, _docileWillard, _swapEnemyAppearance, _allowEmptyEggs, _hideEnemies, _removeLevelEndingLarson, _giveUnarmedItems, _relocateAwkwardEnemies, _unrestrictedEnemyDifficulty;
     private BoolItemControlClass _persistTextures, _randomizeWaterColour, _retainLevelTextures, _retainKeySpriteTextures, _retainSecretSpriteTextures, _retainEnemyTextures, _retainLaraTextures;
     private BoolItemControlClass _changeAmbientTracks, _includeBlankTracks, _changeTriggerTracks, _separateSecretTracks, _changeWeaponSFX, _changeCrashSFX, _changeEnemySFX, _changeDoorSFX, _linkCreatureSFX, _randomizeWibble;
     private BoolItemControlClass _persistOutfits, _removeRobeDagger, _allowGymOutfit;
@@ -2507,6 +2507,16 @@ public class ControllerOptions : INotifyPropertyChanged
         }
     }
 
+    public BoolItemControlClass RelocateAwkwardEnemies
+    {
+        get => _relocateAwkwardEnemies;
+        set
+        {
+            _relocateAwkwardEnemies = value;
+            FirePropertyChanged();
+        }
+    }
+
     public BirdMonsterBehaviour BirdMonsterBehaviour
     {
         get => _birdMonsterBehaviour;
@@ -3145,6 +3155,13 @@ public class ControllerOptions : INotifyPropertyChanged
             Description = "Willard can appear in levels other than Meteorite Cavern but will not attack Lara unless she gets too close."
         };
         BindingOperations.SetBinding(DocileWillard, BoolItemControlClass.IsActiveProperty, randomizeEnemiesBinding);
+        RelocateAwkwardEnemies = new BoolItemControlClass()
+        {
+            Title = "Move awkward enemies",
+            Description = "Some enemies will be moved to avoid forced damage or overly difficult situations.",
+            HelpURL = "https://github.com/LostArtefacts/TR-Rando/blob/master/Resources/Documentation/ENEMIES.md#awkward-enemies",
+        };
+        BindingOperations.SetBinding(RelocateAwkwardEnemies, BoolItemControlClass.IsActiveProperty, randomizeEnemiesBinding);
         ProtectMonks = new BoolItemControlClass()
         {
             Title = "Avoid having to kill allies",
@@ -3450,7 +3467,7 @@ public class ControllerOptions : INotifyPropertyChanged
         };
         EnemyBoolItemControls = new()
         {
-            _crossLevelEnemies, _docileWillard, _protectMonks, _swapEnemyAppearance, _allowEmptyEggs, _hideEnemies, _removeLevelEndingLarson, _giveUnarmedItems,_allowEnemyKeyDrops, _unrestrictedEnemyDifficulty
+            _crossLevelEnemies, _docileWillard, _protectMonks, _swapEnemyAppearance, _allowEmptyEggs, _hideEnemies, _relocateAwkwardEnemies, _removeLevelEndingLarson, _giveUnarmedItems,_allowEnemyKeyDrops, _unrestrictedEnemyDifficulty
         };
         TextureBoolItemControls = new()
         {
@@ -3676,6 +3693,7 @@ public class ControllerOptions : INotifyPropertyChanged
         CrossLevelEnemies.Value = _controller.CrossLevelEnemies;
         ProtectMonks.Value = _controller.ProtectMonks;
         DocileWillard.Value = _controller.DocileWillard;
+        RelocateAwkwardEnemies.Value = _controller.RelocateAwkwardEnemies;
         BirdMonsterBehaviours = Enum.GetValues<BirdMonsterBehaviour>();
         BirdMonsterBehaviour = _controller.BirdMonsterBehaviour;
         DragonSpawnTypes = Enum.GetValues<DragonSpawnType>();
@@ -3991,6 +4009,7 @@ public class ControllerOptions : INotifyPropertyChanged
         _controller.CrossLevelEnemies = CrossLevelEnemies.Value;
         _controller.ProtectMonks = ProtectMonks.Value;
         _controller.DocileWillard = DocileWillard.Value;
+        _controller.RelocateAwkwardEnemies = RelocateAwkwardEnemies.Value;
         _controller.BirdMonsterBehaviour = BirdMonsterBehaviour;
         _controller.DragonSpawnType = DragonSpawnType;
         _controller.SwapEnemyAppearance = SwapEnemyAppearance.Value;


### PR DESCRIPTION
Resolves #311.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Adds an option to shift awkward enemies to avoid forced damage or difficult situations in tight corridors e.g. being unable to target the T-rex with no room to move around in. Some cases may remain, but for those there should be a "way out" as it were e.g. The Deck room 65, where you can lure the enemy outside.

The biggest update is related to the eels in TR2. These have always been an issue as they don't just cover one tile so can interfere with levers, pickups etc. They will always be off the ground now when on land, and when underwater they will be positioned higher to allow any pickups to be had.

The location files (the bulk of this change) are trview-generated, so can be skipped over.
