### PR TITLE
Add option to hide dead T-rexes

### DIFF
--- a/TRRandomizerCore/Editors/RandomizerSettings.cs
+++ b/TRRandomizerCore/Editors/RandomizerSettings.cs
@@ -73,6 +73,7 @@ public class RandomizerSettings
     public bool ProtectMonks { get; set; }
     public bool DocileWillard { get; set; }
     public bool RelocateAwkwardEnemies { get; set; }
+    public bool HideDeadTrexes { get; set; }
     public BirdMonsterBehaviour BirdMonsterBehaviour { get; set; }
     public bool DefaultChickens => BirdMonsterBehaviour == BirdMonsterBehaviour.Default;
     public bool DocileChickens => BirdMonsterBehaviour == BirdMonsterBehaviour.Docile;
@@ -233,6 +234,7 @@ public class RandomizerSettings
         ProtectMonks = config.GetBool(nameof(ProtectMonks), true);
         DocileWillard = config.GetBool(nameof(DocileWillard));
         RelocateAwkwardEnemies = config.GetBool(nameof(RelocateAwkwardEnemies), true);
+        HideDeadTrexes = config.GetBool(nameof(HideDeadTrexes), true);
         BirdMonsterBehaviour = (BirdMonsterBehaviour)config.GetEnum(nameof(BirdMonsterBehaviour), typeof(BirdMonsterBehaviour), BirdMonsterBehaviour.Default);
         RandoEnemyDifficulty = (RandoDifficulty)config.GetEnum(nameof(RandoEnemyDifficulty), typeof(RandoDifficulty), RandoDifficulty.Default);
         DragonSpawnType = (DragonSpawnType)config.GetEnum(nameof(DragonSpawnType), typeof(DragonSpawnType), DragonSpawnType.Default);
@@ -407,6 +409,7 @@ public class RandomizerSettings
         config[nameof(ProtectMonks)] = ProtectMonks;
         config[nameof(DocileWillard)] = DocileWillard;
         config[nameof(RelocateAwkwardEnemies)] = RelocateAwkwardEnemies;
+        config[nameof(HideDeadTrexes)] = HideDeadTrexes;
         config[nameof(BirdMonsterBehaviour)] = BirdMonsterBehaviour;
         config[nameof(RandoEnemyDifficulty)] = RandoEnemyDifficulty;
         config[nameof(DragonSpawnType)] = DragonSpawnType;

--- a/TRRandomizerCore/Randomizers/TR1/Remastered/TR1REnemyRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Remastered/TR1REnemyRandomizer.cs
@@ -115,6 +115,7 @@ public class TR1REnemyRandomizer : BaseTR1RRandomizer
         UpdateAtlanteanPDP(level, enemies);
         HideTrexDeath(level);
         AdjustTihocanEnding(level);
+        AdjustScionEnding(level);
         AddUnarmedLevelAmmo(level);
     }
 
@@ -155,6 +156,17 @@ public class TR1REnemyRandomizer : BaseTR1RRandomizer
 
         // Add Pierre's pickups in a default place. Allows pacifist runs effectively.
         level.Data.Entities.AddRange(TR1ItemAllocator.TihocanEndItems);
+    }
+
+    private static void AdjustScionEnding(TR1RCombinedLevel level)
+    {
+        if (level.Data.Models.ContainsKey(TR1Type.ScionPiece4_S_P)
+            && (level.Data.Models.ContainsKey(TR1Type.TRex) || level.Data.Models.ContainsKey(TR1Type.Adam)))
+        {
+            // Ensure the scion is shootable in Atlantis. This is handled in OG with an environment condition,
+            // but support for PDP isn't there yet.
+            level.PDPData.ChangeKey(TR1Type.ScionPiece4_S_P, TR1Type.ScionPiece3_S_P);
+        }
     }
 
     private void AddUnarmedLevelAmmo(TR1RCombinedLevel level)

--- a/TRRandomizerCore/Randomizers/TR1/Remastered/TR1REnemyRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Remastered/TR1REnemyRandomizer.cs
@@ -1,5 +1,6 @@
 ﻿using TRDataControl;
 using TRGE.Core;
+using TRLevelControl;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRRandomizerCore.Helpers;
@@ -12,6 +13,7 @@ namespace TRRandomizerCore.Randomizers;
 public class TR1REnemyRandomizer : BaseTR1RRandomizer
 {
     private static readonly List<int> _tihocanEndEnemies = new() { 73, 74, 82 };
+    private const int _trexDeathAnimation = 10;
 
     private TR1EnemyAllocator _allocator;
 
@@ -111,6 +113,7 @@ public class TR1REnemyRandomizer : BaseTR1RRandomizer
     private void ApplyPostRandomization(TR1RCombinedLevel level, EnemyRandomizationCollection<TR1Type> enemies)
     {
         UpdateAtlanteanPDP(level, enemies);
+        HideTrexDeath(level);
         AdjustTihocanEnding(level);
         AddUnarmedLevelAmmo(level);
     }
@@ -124,6 +127,21 @@ public class TR1REnemyRandomizer : BaseTR1RRandomizer
 
         // The allocator may have cloned non-shooters, so copy into the PDP as well
         DataCache.SetPDPData(level.PDPData, TR1Type.ShootingAtlantean_N, TR1Type.ShootingAtlantean_N);
+    }
+
+    private void HideTrexDeath(TR1RCombinedLevel level)
+    {
+        if (!Settings.HideDeadTrexes || !level.Data.Models.ContainsKey(TR1Type.TRex))
+        {
+            return;
+        }
+
+        TRSetPositionCommand cmd = new()
+        {
+            Y = TRConsts.NoHeight,
+        };
+        level.Data.Models[TR1Type.TRex].Animations[_trexDeathAnimation].Commands.Add(cmd);
+        level.PDPData[TR1Type.TRex].Animations[_trexDeathAnimation].Commands.Add(cmd);
     }
 
     private void AdjustTihocanEnding(TR1RCombinedLevel level)

--- a/TRRandomizerCore/Randomizers/TR1/Remastered/TR1REnemyRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Remastered/TR1REnemyRandomizer.cs
@@ -137,12 +137,22 @@ public class TR1REnemyRandomizer : BaseTR1RRandomizer
             return;
         }
 
+        // Push T-rexes down on death, which ultimately disables their collision. Shift the final frame
+        // to the absolute maximum so it's not visible.
         TRSetPositionCommand cmd = new()
         {
-            Y = TRConsts.NoHeight,
+            Y = (short)level.Data.Rooms.Max(r => Math.Abs(r.Info.YBottom - r.Info.YTop)),
         };
-        level.Data.Models[TR1Type.TRex].Animations[_trexDeathAnimation].Commands.Add(cmd);
-        level.PDPData[TR1Type.TRex].Animations[_trexDeathAnimation].Commands.Add(cmd);
+
+        void UpdateModel(TRModel model)
+        {
+            TRAnimation deathAnimation = model.Animations[_trexDeathAnimation];
+            deathAnimation.Commands.Add(cmd);
+            deathAnimation.Frames[^1].OffsetY = short.MaxValue;
+        }
+
+        UpdateModel(level.Data.Models[TR1Type.TRex]);
+        UpdateModel(level.PDPData[TR1Type.TRex]);
     }
 
     private void AdjustTihocanEnding(TR1RCombinedLevel level)

--- a/TRRandomizerCore/Resources/TR1/Locations/enemy_relocations.json
+++ b/TRRandomizerCore/Resources/TR1/Locations/enemy_relocations.json
@@ -10,13 +10,39 @@
       "TargetType": 18
     }
   ],
+  "LEVEL6.PHD": [
+    {
+      "X": 36352,
+      "Y": -4352,
+      "Z": 37376,
+      "Room": 27,
+      "EntityIndex": 67,
+      "TargetType": 18
+    },
+    {
+      "X": 81408,
+      "Y": -4096,
+      "Z": 39424,
+      "Room": 6,
+      "Angle": 0,
+      "EntityIndex": 21,
+      "TargetType": 18
+    },
+    {
+      "X": 50688,
+      "Y": -2048,
+      "Z": 32256,
+      "Room": 19,
+      "EntityIndex": 26,
+      "TargetType": 18
+    }
+  ],
   "LEVEL7A.PHD": [
     {
-      "X": 42496,
-      "Y": -8448,
-      "Z": 40448,
-      "Room": 15,
-      "Angle": -32768,
+      "X": 40448,
+      "Y": -5632,
+      "Z": 42496,
+      "Room": 14,
       "EntityIndex": 21,
       "TargetType": 18
     },

--- a/TRRandomizerCore/TRRandomizerController.cs
+++ b/TRRandomizerCore/TRRandomizerController.cs
@@ -1238,6 +1238,12 @@ public class TRRandomizerController
         set => LevelRandomizer.RelocateAwkwardEnemies = value;
     }
 
+    public bool HideDeadTrexes
+    {
+        get => LevelRandomizer.HideDeadTrexes;
+        set => LevelRandomizer.HideDeadTrexes = value;
+    }
+
     public BirdMonsterBehaviour BirdMonsterBehaviour
     {
         get => LevelRandomizer.BirdMonsterBehaviour;

--- a/TRRandomizerCore/TRRandomizerType.cs
+++ b/TRRandomizerCore/TRRandomizerType.cs
@@ -69,4 +69,5 @@ public enum TRRandomizerType
     BlankTracks,
     TextureSwap,
     Wireframe,
+    HideDeadTrexes,
 }

--- a/TRRandomizerCore/TRVersionSupport.cs
+++ b/TRRandomizerCore/TRVersionSupport.cs
@@ -68,6 +68,7 @@ internal class TRVersionSupport
         TRRandomizerType.GlitchedSecrets,
         TRRandomizerType.HardSecrets,
         TRRandomizerType.HiddenEnemies,
+        TRRandomizerType.HideDeadTrexes,
         TRRandomizerType.Item,
         TRRandomizerType.KeyItems,
         TRRandomizerType.Secret,

--- a/TRRandomizerView/Model/ControllerOptions.cs
+++ b/TRRandomizerView/Model/ControllerOptions.cs
@@ -38,7 +38,7 @@ public class ControllerOptions : INotifyPropertyChanged
     private bool _useRewardRoomCameras;
     private uint _minSecretCount, _maxSecretCount;
     private BoolItemControlClass _includeKeyItems, _allowReturnPathLocations, _includeExtraPickups, _randomizeItemTypes, _randomizeItemLocations, _allowEnemyKeyDrops, _maintainKeyContinuity, _oneItemDifficulty;
-    private BoolItemControlClass _crossLevelEnemies, _protectMonks, _docileWillard, _swapEnemyAppearance, _allowEmptyEggs, _hideEnemies, _removeLevelEndingLarson, _giveUnarmedItems, _relocateAwkwardEnemies, _unrestrictedEnemyDifficulty;
+    private BoolItemControlClass _crossLevelEnemies, _protectMonks, _docileWillard, _swapEnemyAppearance, _allowEmptyEggs, _hideEnemies, _removeLevelEndingLarson, _giveUnarmedItems, _relocateAwkwardEnemies, _hideDeadTrexes, _unrestrictedEnemyDifficulty;
     private BoolItemControlClass _persistTextures, _randomizeWaterColour, _retainLevelTextures, _retainKeySpriteTextures, _retainSecretSpriteTextures, _retainEnemyTextures, _retainLaraTextures;
     private BoolItemControlClass _changeAmbientTracks, _includeBlankTracks, _changeTriggerTracks, _separateSecretTracks, _changeWeaponSFX, _changeCrashSFX, _changeEnemySFX, _changeDoorSFX, _linkCreatureSFX, _randomizeWibble;
     private BoolItemControlClass _persistOutfits, _removeRobeDagger, _allowGymOutfit;
@@ -2517,6 +2517,16 @@ public class ControllerOptions : INotifyPropertyChanged
         }
     }
 
+    public BoolItemControlClass HideDeadTrexes
+    {
+        get => _hideDeadTrexes;
+        set
+        {
+            _hideDeadTrexes = value;
+            FirePropertyChanged();
+        }
+    }
+
     public BirdMonsterBehaviour BirdMonsterBehaviour
     {
         get => _birdMonsterBehaviour;
@@ -3162,6 +3172,12 @@ public class ControllerOptions : INotifyPropertyChanged
             HelpURL = "https://github.com/LostArtefacts/TR-Rando/blob/master/Resources/Documentation/ENEMIES.md#awkward-enemies",
         };
         BindingOperations.SetBinding(RelocateAwkwardEnemies, BoolItemControlClass.IsActiveProperty, randomizeEnemiesBinding);
+        HideDeadTrexes = new()
+        {
+            Title = "Hide dead T-rexes",
+            Description = "T-rexes retain collision on death in TR1R, so this option will move them out of the way when killed.",
+        };
+        BindingOperations.SetBinding(HideDeadTrexes, BoolItemControlClass.IsActiveProperty, randomizeEnemiesBinding);
         ProtectMonks = new BoolItemControlClass()
         {
             Title = "Avoid having to kill allies",
@@ -3467,7 +3483,7 @@ public class ControllerOptions : INotifyPropertyChanged
         };
         EnemyBoolItemControls = new()
         {
-            _crossLevelEnemies, _docileWillard, _protectMonks, _swapEnemyAppearance, _allowEmptyEggs, _hideEnemies, _relocateAwkwardEnemies, _removeLevelEndingLarson, _giveUnarmedItems,_allowEnemyKeyDrops, _unrestrictedEnemyDifficulty
+            _crossLevelEnemies, _docileWillard, _protectMonks, _swapEnemyAppearance, _allowEmptyEggs, _hideEnemies, _relocateAwkwardEnemies, _hideDeadTrexes, _removeLevelEndingLarson, _giveUnarmedItems,_allowEnemyKeyDrops, _unrestrictedEnemyDifficulty
         };
         TextureBoolItemControls = new()
         {
@@ -3565,6 +3581,7 @@ public class ControllerOptions : INotifyPropertyChanged
 
         _protectMonks.IsAvailable = !IsTR1;
         _docileWillard.IsAvailable = IsTR3;
+        _hideDeadTrexes.IsAvailable = IsHideDeadTrexesTypeSupported;
 
         _includeKeyItems.IsAvailable = IsKeyItemTypeSupported;
         _maintainKeyContinuity.IsAvailable = IsKeyContinuityTypeSupported;
@@ -3694,6 +3711,7 @@ public class ControllerOptions : INotifyPropertyChanged
         ProtectMonks.Value = _controller.ProtectMonks;
         DocileWillard.Value = _controller.DocileWillard;
         RelocateAwkwardEnemies.Value = _controller.RelocateAwkwardEnemies;
+        HideDeadTrexes.Value = _controller.HideDeadTrexes;
         BirdMonsterBehaviours = Enum.GetValues<BirdMonsterBehaviour>();
         BirdMonsterBehaviour = _controller.BirdMonsterBehaviour;
         DragonSpawnTypes = Enum.GetValues<DragonSpawnType>();
@@ -4010,6 +4028,7 @@ public class ControllerOptions : INotifyPropertyChanged
         _controller.ProtectMonks = ProtectMonks.Value;
         _controller.DocileWillard = DocileWillard.Value;
         _controller.RelocateAwkwardEnemies = RelocateAwkwardEnemies.Value;
+        _controller.HideDeadTrexes = HideDeadTrexes.Value;
         _controller.BirdMonsterBehaviour = BirdMonsterBehaviour;
         _controller.DragonSpawnType = DragonSpawnType;
         _controller.SwapEnemyAppearance = SwapEnemyAppearance.Value;
@@ -4257,6 +4276,7 @@ public class ControllerOptions : INotifyPropertyChanged
     public bool IsKeyItemTexturesTypeSupported => IsRandomizationSupported(TRRandomizerType.KeyItemTextures);
     public bool IsWaterColourTypeSupported => IsRandomizationSupported(TRRandomizerType.WaterColour);
     public bool IsAtlanteanEggBehaviourTypeSupported => IsRandomizationSupported(TRRandomizerType.AtlanteanEggBehaviour);
+    public bool IsHideDeadTrexesTypeSupported => IsRandomizationSupported(TRRandomizerType.HideDeadTrexes);
     public bool IsHiddenEnemiesTypeSupported => IsRandomizationSupported(TRRandomizerType.HiddenEnemies);
     public bool IsLarsonBehaviourTypeSupported => IsRandomizationSupported(TRRandomizerType.LarsonBehaviour);
     public bool IsClonedEnemiesTypeSupported => IsRandomizationSupported(TRRandomizerType.ClonedEnemies);


### PR DESCRIPTION
Resolves #708.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Quite the hack, but it gets the T-rex out of the way to avoid problems with pickups and blocking levers, entrances etc.

Added a few additional awkward T-rex locations in Midas too, plus fixed the scion in Atlantis if you have T-rex or Adam as it has to become shootable in that instance.
