### PR TITLE
Restore TR2R skidoo belt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR-Rando/compare/V1.9.1...master) - xxxx-xx-xx
 - fixed docile bird monsters causing multiple Laras to spawn in remastered levels (#723)
+- fixed the incomplete skidoo model in TR2R when it appears anywhere other than Tibetan Foothills (#721)
 - improved data integrity checks when opening a folder and prior to randomization (#719)
 
 ## [V1.9.1](https://github.com/LostArtefacts/TR-Rando/compare/V1.9.0...V1.9.1) - 2024-06-23

--- a/TRDataControl/Data/Remastered/BaseTRRDataCache.cs
+++ b/TRDataControl/Data/Remastered/BaseTRRDataCache.cs
@@ -72,6 +72,15 @@ public abstract class BaseTRRDataCache<TKey, TAlias>
     public void SetMapData(Dictionary<TKey, TAlias> mapData, TKey sourceType, TKey destinationType)
     {
         TAlias alias = GetAlias(sourceType);
+        Dictionary<TKey, TAlias> dependencies = GetMapDependencies(sourceType);
+        if (dependencies != null)
+        {
+            foreach (var (depKey, depAlias) in dependencies)
+            {
+                mapData[depKey] = depAlias;
+            }
+        }
+
         if (EqualityComparer<TAlias>.Default.Equals(alias, default))
         {
             return;
@@ -86,4 +95,6 @@ public abstract class BaseTRRDataCache<TKey, TAlias>
     public abstract TKey TranslateKey(TKey key);
     public abstract TKey TranslateAlias(TKey alias);
     public abstract TAlias GetAlias(TKey key);
+    protected virtual Dictionary<TKey, TAlias> GetMapDependencies(TKey key)
+        => null;
 }

--- a/TRDataControl/Data/Remastered/TR2RDataCache.cs
+++ b/TRDataControl/Data/Remastered/TR2RDataCache.cs
@@ -24,6 +24,16 @@ public class TR2RDataCache : BaseTRRDataCache<TR2Type, TR2RAlias>
     public override TR2RAlias GetAlias(TR2Type key)
         => _mapAliases.ContainsKey(key) ? _mapAliases[key] : default;
 
+    protected override Dictionary<TR2Type, TR2RAlias> GetMapDependencies(TR2Type key)
+        => key == TR2Type.RedSnowmobile ? _skidooDependencies : null;
+
+    private static readonly Dictionary<TR2Type, TR2RAlias> _skidooDependencies = new()
+    {
+        [TR2Type.CutsceneActor4] = TR2RAlias.SKIDOO_TRACK_1,
+        [TR2Type.CutsceneActor5] = TR2RAlias.SKIDOO_TRACK_2,
+        [TR2Type.CutsceneActor6] = TR2RAlias.SKIDOO_TRACK_3,
+    };
+
     private static readonly Dictionary<TR2Type, string> _sourceLevels = new()
     {
         [TR2Type.Crow] = TR2LevelNames.GW,


### PR DESCRIPTION
Resolves #721.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This adds some `.MAP` entries for the skidoo as TRR seems to use three different models for the belt. Classic just has one, which is already handled in `TRDataControl.TR2DataProvider`. The change covers both skidoo types: the black skidoo cannot exist without the red, so that's guaranteed to be present.
