### PR TITLE
Reuse tex infos in wireframe mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR-Rando/compare/V1.9.1...master) - xxxx-xx-xx
+- fixed wireframe mode potentially exceeding texture limits and preventing levels from loading (#722)
 - fixed docile bird monsters causing multiple Laras to spawn in remastered levels (#723)
 - fixed the incomplete skidoo model in TR2R when it appears anywhere other than Tibetan Foothills (#721)
 - fixed secrets on triangle portals not triggering in TR3 (#727)


### PR DESCRIPTION
Resolves #722.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Although we only need a handful of textures for wireframe mode, it can creep over the maximum available depending on what else has been imported into the level. After deleting all unnecessary textures, we now reuse those slots.
