### PR TITLE
Duplicate key items for NG+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR-Rando/compare/V1.9.1...master) - xxxx-xx-xx
+- fixed key item softlocks in TR1R New Game+ (#732)
 - fixed wireframe mode potentially exceeding texture limits and preventing levels from loading (#722)
 - fixed docile bird monsters causing multiple Laras to spawn in remastered levels (#723)
 - fixed the incomplete skidoo model in TR2R when it appears anywhere other than Tibetan Foothills (#721)

--- a/TRLevelControl/Helpers/TR1TypeUtilities.cs
+++ b/TRLevelControl/Helpers/TR1TypeUtilities.cs
@@ -254,6 +254,11 @@ public static class TR1TypeUtilities
         return GetStandardPickupTypes().Contains(type);
     }
 
+    public static bool IsMediType(TR1Type type)
+    {
+        return type == TR1Type.SmallMed_S_P || type == TR1Type.LargeMed_S_P;
+    }
+
     public static bool IsWeaponPickup(TR1Type type)
     {
         return GetWeaponPickups().Contains(type);


### PR DESCRIPTION
Resolves #732.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

In TR1R NG+, anything that is _originally_ a medipack will be converted into ammo, so in shuffled item mode, key items that end up in a medipack's slot will also become ammo. The game seems to do this by index rather than type. So we duplicate the key to make an index the game doesn't know about and hide the old one. The heaviest rando'ed level sits at just under 200 items so we're OK in terms of the 256 item limit.

This NG+ mode doesn't apply to TR2R/TR3R so no changes needed there.
