### PR TITLE
Fix shuffled item mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR-Rando/compare/V1.9.1...master) - xxxx-xx-xx
-- fixed key item softlocks in TR1R New Game+ (#732)
+- fixed key item softlocks in remastered New Game+ when using shuffled item mode (#732, #734)
 - fixed wireframe mode potentially exceeding texture limits and preventing levels from loading (#722)
 - fixed docile bird monsters causing multiple Laras to spawn in remastered levels (#723)
 - fixed the incomplete skidoo model in TR2R when it appears anywhere other than Tibetan Foothills (#721)

--- a/TRRandomizerCore/Randomizers/Shared/LocationPicker.cs
+++ b/TRRandomizerCore/Randomizers/Shared/LocationPicker.cs
@@ -224,10 +224,12 @@ public class LocationPicker : IRouteManager
         return roomPool;
     }
 
-    public bool IsValidKeyItemLocation(int keyItemID, Location location)
+    public bool IsValidKeyItemLocation(int keyItemID, Location location, bool hasPickupTrigger)
     {
-        return GetRoomPool(keyItemID).Contains(location.Room)
-            && _locations.Any(l => l.IsEquivalent(location));
+        List<short> roomPool = GetRoomPool(keyItemID);
+        return roomPool.Contains(location.Room)
+            && _locations.Any(l => l.IsEquivalent(location))
+            && (KeyItemTestAction == null || KeyItemTestAction(location, hasPickupTrigger, roomPool));
     }
 
     private bool TestLocation(Location location, KeyMode keyTestMode, int keyItemID)

--- a/TRRandomizerCore/Randomizers/TR1/Remastered/TR1RItemRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Remastered/TR1RItemRandomizer.cs
@@ -52,7 +52,6 @@ public class TR1RItemRandomizer : BaseTR1RRandomizer
                 if (Settings.ItemMode == ItemMode.Shuffled)
                 {
                     _allocator.ApplyItemSwaps(_levelInstance.Name, _levelInstance.Data.Entities);
-                    AdjustNGPlusItems(_levelInstance);
                 }
                 else
                 {
@@ -78,30 +77,5 @@ public class TR1RItemRandomizer : BaseTR1RRandomizer
         }
 
         level.Data.Entities.AddRange(TR1ItemAllocator.TihocanEndItems);
-    }
-
-    private void AdjustNGPlusItems(TR1RCombinedLevel level)
-    {
-        // If keys have ended up as OG medi-packs, NG+ will convert them to ammo and hence softlock-city.
-        // Duplicate the items so the game doesn't know their indices, and hide the originals.
-        List<TR1Entity> keyItems = level.Data.Entities.FindAll(e => TR1TypeUtilities.IsKeyItemType(e.TypeID));
-        TR1Level ogLevel = _levelControl.Read(Path.Combine(BackupPath, level.Name));
-        foreach (TR1Entity item in keyItems)
-        {
-            int currentIndex = level.Data.Entities.IndexOf(item);
-            if (currentIndex < ogLevel.Entities.Count
-                && TR1TypeUtilities.IsMediType(ogLevel.Entities[currentIndex].TypeID))
-            {
-                level.Data.Entities.Add((TR1Entity)item.Clone());
-                item.TypeID = TR1Type.CameraTarget_N;
-                ItemUtilities.HideEntity(item);
-
-                // Any triggers will need to match the new index
-                short newIndex = (short)(level.Data.Entities.Count - 1);
-                level.Data.FloorData.GetEntityTriggers(currentIndex)
-                    .SelectMany(t => t.Actions.Where(a => a.Action == FDTrigAction.Object && a.Parameter == currentIndex))
-                    .ToList().ForEach(a => a.Parameter = newIndex);
-            }
-        }
     }
 }

--- a/TRRandomizerCore/Randomizers/TR1/Shared/TR1ItemAllocator.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Shared/TR1ItemAllocator.cs
@@ -97,7 +97,8 @@ public class TR1ItemAllocator : ItemAllocator<TR1Type, TR1Entity>
         }
         else
         {
-            ShuffleItems(levelName, level.Entities, isUnarmed, GetKeyItemLevelSequence(levelName, originalSequence));
+            ShuffleItems(levelName, level.Entities, isUnarmed, GetKeyItemLevelSequence(levelName, originalSequence),
+                e => LocationUtilities.HasPickupTriger(e, level.Entities.IndexOf(e), level));
         }
         
         RandomizeSprites(level);
@@ -125,9 +126,7 @@ public class TR1ItemAllocator : ItemAllocator<TR1Type, TR1Entity>
 
     private void InitialisePicker(string levelName, TR1Level level, LocationMode locationMode)
     {
-        _picker.TriggerTestAction = locationMode == LocationMode.KeyItems
-            ? location => LocationUtilities.HasAnyTrigger(location, level)
-            : null;
+        _picker.TriggerTestAction = location => LocationUtilities.HasAnyTrigger(location, level);
         _picker.RoomInfos = new(level.Rooms.Select(r => new ExtRoomInfo(r)));
 
         List<Location> pool = GetItemLocationPool(levelName, level, locationMode != LocationMode.Default);

--- a/TRRandomizerCore/Randomizers/TR2/Shared/TR2ItemAllocator.cs
+++ b/TRRandomizerCore/Randomizers/TR2/Shared/TR2ItemAllocator.cs
@@ -55,7 +55,8 @@ public class TR2ItemAllocator : ItemAllocator<TR2Type, TR2Entity>
         }
         else
         {
-            ShuffleItems(levelName, level.Entities, scriptedLevel.RemovesWeapons, scriptedLevel.OriginalSequence);
+            ShuffleItems(levelName, level.Entities, scriptedLevel.RemovesWeapons, scriptedLevel.OriginalSequence,
+                e => LocationUtilities.HasPickupTriger(e, level.Entities.IndexOf(e), level));
         }
     }
 
@@ -80,12 +81,9 @@ public class TR2ItemAllocator : ItemAllocator<TR2Type, TR2Entity>
 
     private void InitialisePicker(string levelName, TR2Level level, LocationMode locationMode)
     {
-        _picker.TriggerTestAction = locationMode == LocationMode.KeyItems
-            ? location => LocationUtilities.HasAnyTrigger(location, level)
-            : null;
-        _picker.KeyItemTestAction = locationMode == LocationMode.KeyItems
-            ? (location, hasPickupTrigger, roomPool) => TestKeyItemLocation(location, hasPickupTrigger, roomPool, levelName, level)
-            : null;
+        _picker.TriggerTestAction = location => LocationUtilities.HasAnyTrigger(location, level);
+        _picker.KeyItemTestAction = (location, hasPickupTrigger, roomPool)
+            => TestKeyItemLocation(location, hasPickupTrigger, roomPool, levelName, level);
         _picker.RoomInfos = new(level.Rooms.Select(r => new ExtRoomInfo(r)));
 
         List<Location> pool = GetItemLocationPool(levelName, level, locationMode != LocationMode.Default);

--- a/TRRandomizerCore/Randomizers/TR3/Shared/TR3ItemAllocator.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Shared/TR3ItemAllocator.cs
@@ -50,7 +50,8 @@ public class TR3ItemAllocator : ItemAllocator<TR3Type, TR3Entity>
         }
         else
         {
-            ShuffleItems(levelName, level.Entities, isUnarmed, originalSequence);
+            ShuffleItems(levelName, level.Entities, isUnarmed, originalSequence,
+                e => LocationUtilities.HasPickupTriger(e, level.Entities.IndexOf(e), level));
         }
     }
 
@@ -75,12 +76,9 @@ public class TR3ItemAllocator : ItemAllocator<TR3Type, TR3Entity>
 
     private void InitialisePicker(string levelName, TR3Level level, LocationMode locationMode, bool isCold)
     {
-        _picker.TriggerTestAction = locationMode == LocationMode.KeyItems
-            ? location => LocationUtilities.HasAnyTrigger(location, level)
-            : null;
-        _picker.KeyItemTestAction = locationMode == LocationMode.KeyItems
-            ? (location, hasPickupTrigger, roomPool) => TestKeyItemLocation(location, hasPickupTrigger, roomPool, levelName, level)
-            : null;
+        _picker.TriggerTestAction = location => LocationUtilities.HasAnyTrigger(location, level);
+        _picker.KeyItemTestAction = (location, hasPickupTrigger, roomPool)
+            => TestKeyItemLocation(location, hasPickupTrigger, roomPool, levelName, level);
         _picker.RoomInfos = new(level.Rooms.Select(r => new ExtRoomInfo(r)));
 
         List<Location> pool = GetItemLocationPool(levelName, level, locationMode != LocationMode.Default, isCold);

--- a/TRRandomizerView/Model/ControllerOptions.cs
+++ b/TRRandomizerView/Model/ControllerOptions.cs
@@ -1037,7 +1037,7 @@ public class ControllerOptions : INotifyPropertyChanged
         MaintainKeyContinuity.IsActive = defaultMode;
 
         AllowReturnPathLocations.IsActive = !defaultMode || IncludeKeyItems.Value;
-        AllowEnemyKeyDrops.IsActive = defaultMode && IncludeKeyItems.Value;
+        AllowEnemyKeyDrops.IsActive = !defaultMode || IncludeKeyItems.Value;
 
         FirePropertyChanged(nameof(WeaponDifficultyAvailable));
         FirePropertyChanged(nameof(IncludeKeyItemsImplied));
@@ -3559,7 +3559,7 @@ public class ControllerOptions : INotifyPropertyChanged
     {
         bool defaultMode = ItemMode == ItemMode.Default;
         AllowReturnPathLocations.IsActive = !defaultMode || IncludeKeyItems.Value;
-        AllowEnemyKeyDrops.IsActive = defaultMode && IncludeKeyItems.Value;
+        AllowEnemyKeyDrops.IsActive = !defaultMode || IncludeKeyItems.Value;
         FirePropertyChanged(nameof(IncludeKeyItemsImplied));
     }
 


### PR DESCRIPTION
Resolves #734.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This replaces #733 as a proper fix for shuffled item mode. We use a more standard approach of swapping locations rather than types so that indices match up with OG and so to prevent TRR NG+ changing the wrong things.

This change also means triggers under keys will be shifted and so it means it's more consistent with normal item rando. That itself fixes a potential softlock in Catacombs - consider picking up whatever is in the mask's place at the start, which triggers the flipmap, but then dropping down into the drained pool without picking up the mask.

The option for allowing keys under enemies is available too, and when it's off, if there isn't a suitable location for a key it won't be moved. We do this rather than moving the key to the enemy's position and nudging the enemy off it, because that relies on the player knowing the spawn points and still having to kill the enemy most likely. One instance (at least) where this isn't the case is the yellow key in Rig - there are only 2 potential locations for it, both under an enemy, so in that case we _do_ nudge the enemy and leave the key in the original spot. If allow-enemy-keys is enabled, it will end up under the other enemy.
