### PR TITLE
Retain prisoners in TR3R

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - fixed secrets in 40 Fathoms all generally appearing too close to the start of the level (#729)
 - fixed the Jade secret appearing before the Stone in TR2R Floating Islands (#729)
 - fixed being unable to collect secret artefacts in TR3R High Security Compound (#737)
+- fixed (the lack of) prisoners in Area51 crashing the game when loading a save (#739)
 - improved data integrity checks when opening a folder and prior to randomization (#719)
 
 ## [V1.9.1](https://github.com/LostArtefacts/TR-Rando/compare/V1.9.0...V1.9.1) - 2024-06-23

--- a/TRRandomizerCore/Randomizers/TR3/Classic/TR3EnemyRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Classic/TR3EnemyRandomizer.cs
@@ -142,7 +142,7 @@ public class TR3EnemyRandomizer : BaseTR3Randomizer
             List<TR3CombinedLevel> levels = new(_enemyMapping.Keys);
             foreach (TR3CombinedLevel level in levels)
             {
-                _enemyMapping[level] = _outer._allocator.SelectCrossLevelEnemies(level.Name, level.Data, level.Sequence);
+                _enemyMapping[level] = _outer._allocator.SelectCrossLevelEnemies(level.Name, level.Data, level.Sequence, false);
             }
         }
 

--- a/TRRandomizerCore/Randomizers/TR3/Remastered/TR3REnemyRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Remastered/TR3REnemyRandomizer.cs
@@ -152,7 +152,7 @@ public class TR3REnemyRandomizer : BaseTR3RRandomizer
             List<TR3RCombinedLevel> levels = new(_enemyMapping.Keys);
             foreach (TR3RCombinedLevel level in levels)
             {
-                _enemyMapping[level] = _outer._allocator.SelectCrossLevelEnemies(level.Name, level.Data, level.Sequence);
+                _enemyMapping[level] = _outer._allocator.SelectCrossLevelEnemies(level.Name, level.Data, level.Sequence, true);
             }
         }
 

--- a/TRRandomizerCore/Randomizers/TR3/Shared/TR3EnemyAllocator.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Shared/TR3EnemyAllocator.cs
@@ -41,7 +41,7 @@ public class TR3EnemyAllocator : EnemyAllocator<TR3Type>
     protected override bool IsOneShotType(TR3Type type)
         => _oneShotEnemies.Contains(type);
 
-    public EnemyTransportCollection<TR3Type> SelectCrossLevelEnemies(string levelName, TR3Level level, int levelSequence)
+    public EnemyTransportCollection<TR3Type> SelectCrossLevelEnemies(string levelName, TR3Level level, int levelSequence, bool remastered)
     {
         if (levelName == TR3LevelNames.ASSAULT)
         {
@@ -74,6 +74,18 @@ public class TR3EnemyAllocator : EnemyAllocator<TR3Type>
             {
                 newTypes.Add(type);
             }
+        }
+
+        if (remastered && (levelName == TR3LevelNames.HSC || levelName == TR3LevelNames.AREA51))
+        {
+            // TRR prisoners have to remain because of (presumably) the way the game fixes them not being friendly.
+            if (!newTypes.Contains(TR3Type.Prisoner))
+            {
+                newTypes.Add(TR3Type.Prisoner);
+            }
+
+            level.Entities.FindAll(e => e.TypeID == TR3Type.Prisoner)
+                .ForEach(e => ItemFactory.LockItem(levelName, level.Entities.IndexOf(e)));
         }
 
         foreach (int itemIndex in ItemFactory.GetLockedItems(levelName))


### PR DESCRIPTION
Resolves #739.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This avoids TR3R crashing when loading a save and no prisoners are present in HSC/Area51.
