### PR TITLE
Remove one shot enemy flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - fixed the Jade secret appearing before the Stone in TR2R Floating Islands (#729)
 - fixed being unable to collect secret artefacts in TR3R High Security Compound (#737)
 - fixed (the lack of) prisoners in Area51 crashing the game when loading a save (#739)
-- fixed some enemies causing triggers for other objects to break e.g. Crash Site room 72 (#742)
+- fixed some enemies in TR3 causing triggers for other objects to break e.g. Crash Site room 72 (#742)
 - improved data integrity checks when opening a folder and prior to randomization (#719)
 
 ## [V1.9.1](https://github.com/LostArtefacts/TR-Rando/compare/V1.9.0...V1.9.1) - 2024-06-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - fixed the Jade secret appearing before the Stone in TR2R Floating Islands (#729)
 - fixed being unable to collect secret artefacts in TR3R High Security Compound (#737)
 - fixed (the lack of) prisoners in Area51 crashing the game when loading a save (#739)
+- fixed some enemies causing triggers for other objects to break e.g. Crash Site room 72 (#742)
 - improved data integrity checks when opening a folder and prior to randomization (#719)
 
 ## [V1.9.1](https://github.com/LostArtefacts/TR-Rando/compare/V1.9.0...V1.9.1) - 2024-06-23

--- a/TRRandomizerCore/Randomizers/TR3/Shared/TR3EnemyAllocator.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Shared/TR3EnemyAllocator.cs
@@ -11,14 +11,6 @@ public class TR3EnemyAllocator : EnemyAllocator<TR3Type>
 {
     private const int _willardSequence = 19;
 
-    private static readonly List<TR3Type> _oneShotEnemies = new()
-    {
-        TR3Type.Croc,
-        TR3Type.KillerWhale,
-        TR3Type.Raptor,
-        TR3Type.Rat,
-    };
-
     private readonly Dictionary<string, List<Location>> _pistolLocations;
 
     public ItemFactory<TR3Entity> ItemFactory { get; set; }
@@ -39,7 +31,7 @@ public class TR3EnemyAllocator : EnemyAllocator<TR3Type>
         => TR3EnemyUtilities.GetRestrictedEnemyRooms(levelName, difficulty);
 
     protected override bool IsOneShotType(TR3Type type)
-        => _oneShotEnemies.Contains(type);
+        => false;
 
     public EnemyTransportCollection<TR3Type> SelectCrossLevelEnemies(string levelName, TR3Level level, int levelSequence, bool remastered)
     {


### PR DESCRIPTION
Resolves #742.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

When TR3 enemy randomisation was originally implemented, it was shortly after TR2 cross-level enemies were introduced and that brought to light the need for the dragon to have one shot triggers to avoid crashes (#151). As a pre-caution, we added these TR3 one-shot enemies for any in the OG that had this flag on any trigger. This isn't actually required, they work with the flag off and indeed there are also non-oneshot triggers for these in OG. The killer whale is the exception but I've checked and there are no issues with it set to false.
