### PR TITLE
Remove quest types as secret pickup models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - fixed being unable to collect secret artefacts in TR3R High Security Compound (#737)
 - fixed (the lack of) prisoners in Area51 crashing the game when loading a save (#739)
 - fixed some enemies in TR3 causing triggers for other objects to break e.g. Crash Site room 72 (#742)
+- fixed secret models in TR3R Aldwych appearing offset from their actual location (#744)
 - improved data integrity checks when opening a folder and prior to randomization (#719)
 
 ## [V1.9.1](https://github.com/LostArtefacts/TR-Rando/compare/V1.9.0...V1.9.1) - 2024-06-23

--- a/TRRandomizerCore/Randomizers/TR3/Remastered/TR3RSecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Remastered/TR3RSecretRandomizer.cs
@@ -241,6 +241,9 @@ public class TR3RSecretRandomizer : BaseTR3RRandomizer, ISecretRandomizer
                 allocation.AvailablePickupModels.AddRange(_artefactReplacements.Keys
                     .Where(a => !level.Data.Models.ContainsKey(a)));
 
+                allocation.AvailablePickupModels.Remove(TR3Type.Quest1_P);
+                allocation.AvailablePickupModels.Remove(TR3Type.Quest2_P);
+
                 List<TR3Type> artefactTypes = _artefactPickups.Keys.ToList();
                 artefactTypes.RemoveAll(a => level.Data.Models.ContainsKey(a));
 


### PR DESCRIPTION
Resolves #744.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

It seems that allocating quest pickup types in TRR doesn't work, no matter what we add to the `.map` files. We now prevent these from being used as pickup types. In TRR (with the lack of level sequencing) they would only appear in Aldwych anyway as keys and puzzles are used first, so here instead you will just get 5 `key4` pickups as secrets instead of a variety of models.

The game text calls it Solomon's Key but there is no workaround for that.
