### PR TITLE
Add native enemy dependencies in TR1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - fixed (the lack of) prisoners in Area51 crashing the game when loading a save (#739)
 - fixed some enemies in TR3 causing triggers for other objects to break e.g. Crash Site room 72 (#742)
 - fixed secret models in TR3R Aldwych appearing offset from their actual location (#744)
+- fixed a crash in Palace Midas when randomizing enemies natively (#746)
 - improved data integrity checks when opening a folder and prior to randomization (#719)
 
 ## [V1.9.1](https://github.com/LostArtefacts/TR-Rando/compare/V1.9.0...V1.9.1) - 2024-06-23

--- a/TRRandomizerCore/Randomizers/TR1/Classic/TR1EnemyRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Classic/TR1EnemyRandomizer.cs
@@ -443,9 +443,6 @@ public class TR1EnemyRandomizer : BaseTR1Randomizer
         importer.LevelName = level.Name;
         importer.DataFolder = GetResourcePath(@"TR1\Objects");
 
-        importer.Data.TextureObjectLimit = RandoConsts.TRRTexLimit;
-        importer.Data.TextureTileLimit = RandoConsts.TRRTileLimit;
-
         string remapPath = $@"TR1\Textures\Deduplication\{level.Name}-TextureRemap.json";
         if (ResourceExists(remapPath))
         {

--- a/TRRandomizerCore/Randomizers/TR1/Remastered/TR1RItemRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Remastered/TR1RItemRandomizer.cs
@@ -3,7 +3,6 @@ using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRRandomizerCore.Helpers;
 using TRRandomizerCore.Levels;
-using TRRandomizerCore.Utilities;
 
 namespace TRRandomizerCore.Randomizers;
 

--- a/TRRandomizerCore/Randomizers/TR1/Shared/TR1EnemyAllocator.cs
+++ b/TRRandomizerCore/Randomizers/TR1/Shared/TR1EnemyAllocator.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using System.Numerics;
+using TRDataControl;
 using TRDataControl.Environment;
 using TRLevelControl;
 using TRLevelControl.Helpers;
@@ -284,6 +285,15 @@ public class TR1EnemyAllocator : EnemyAllocator<TR1Type>
         RandomizeEnemies(levelName, level, enemies);
 
         return enemies;
+    }
+
+    public static IEnumerable<TR1Type> GetMissingDependencies(TR1Level level, List<TR1Type> enemyTypes)
+    {
+        TR1DataProvider data = new();
+        return enemyTypes
+            .SelectMany(t => data.GetCyclicDependencies(t))
+            .Except(level.Models.Keys)
+            .Distinct();
     }
 
     public void RandomizeEnemies(string levelName, TR1Level level, EnemyRandomizationCollection<TR1Type> enemies)


### PR DESCRIPTION
Resolves #746.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This ensures that the land rat model is present in Midas regardless of randomizing natively or cross-level. This is the only case where this can happen, so there is no need to add equivalent handling to TR2/3. I've moved some of the import code around to avoid too much duplication.

Thanks to @Topixtor for finding this issue and the cause.
