### PR TITLE
Remove birds from droppable creature lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - fixed being unable to shoot the scion in Atlantis if using the skip, without backtracking for its trigger when the T-rex or Adam is present (#746)
 - fixed an awkwardly positioned egg in Sanctuary of the Scion that could prevent being able to reach a switch (#748)
 - improved data integrity checks when opening a folder and prior to randomization (#719)
+- removed birds from the list of enemies that can drop items in TR2 and TR3 (#752)
 
 ## [V1.9.1](https://github.com/LostArtefacts/TR-Rando/compare/V1.9.0...V1.9.1) - 2024-06-23
 - fixed a missing reference related to Willard, which would cause enemy randomization to fail if he was selected (#712)

--- a/TRLevelControl/Helpers/TR2TypeUtilities.cs
+++ b/TRLevelControl/Helpers/TR2TypeUtilities.cs
@@ -233,9 +233,7 @@ public static class TR2TypeUtilities
         List<TR2Type> types = new()
         {
             TR2Type.BengalTiger,
-            TR2Type.Crow,
             TR2Type.Doberman,
-            TR2Type.Eagle,
             TR2Type.FlamethrowerGoonOG,
             TR2Type.FlamethrowerGoonTopixtor,
             TR2Type.GiantSpider,

--- a/TRLevelControl/Helpers/TR3TypeUtilities.cs
+++ b/TRLevelControl/Helpers/TR3TypeUtilities.cs
@@ -507,7 +507,6 @@ public static class TR3TypeUtilities
             TR3Type.SophiaLee,
             TR3Type.Tiger,
             TR3Type.TinnosMonster,
-            TR3Type.TinnosWasp,
             TR3Type.TonyFirehands,
             TR3Type.TribesmanAxe,
             TR3Type.TribesmanDart,

--- a/TRLevelControl/Helpers/TR3TypeUtilities.cs
+++ b/TRLevelControl/Helpers/TR3TypeUtilities.cs
@@ -486,7 +486,6 @@ public static class TR3TypeUtilities
             TR3Type.Cobra,
             TR3Type.Compsognathus,
             TR3Type.Crawler,
-            TR3Type.Crow,
             TR3Type.DamGuard,
             TR3Type.DogAntarc,
             TR3Type.DogLondon,
@@ -513,7 +512,6 @@ public static class TR3TypeUtilities
             TR3Type.TribesmanAxe,
             TR3Type.TribesmanDart,
             TR3Type.Tyrannosaur,
-            TR3Type.Vulture
         };
 
         if (!protectFriendlyEnemies)


### PR DESCRIPTION
Resolves #752.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Items carried by birds killed with grenades would spawn in mid-air. This has gone unnoticed for a very long time. TR1 is fine as there are no explosives, and besides in TR1X there is specific handling for items to fall to the floor; we also can't assign drops in TR1R.
