### PR TITLE
Restore TR1R extra pickups option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - fixed a crash in Palace Midas when randomizing enemies natively (#746)
 - fixed being unable to shoot the scion in Atlantis if using the skip, without backtracking for its trigger when the T-rex or Adam is present (#746)
 - fixed an awkwardly positioned egg in Sanctuary of the Scion that could prevent being able to reach a switch (#748)
+- fixed the missing UI option to control adding extra pickups in TR1R (#754)
 - improved data integrity checks when opening a folder and prior to randomization (#719)
 
 ## [V1.9.1](https://github.com/LostArtefacts/TR-Rando/compare/V1.9.0...V1.9.1) - 2024-06-23

--- a/TRRandomizerCore/TRVersionSupport.cs
+++ b/TRRandomizerCore/TRVersionSupport.cs
@@ -65,6 +65,7 @@ internal class TRVersionSupport
         TRRandomizerType.AtlanteanEggBehaviour,
         TRRandomizerType.Audio,
         TRRandomizerType.Enemy,
+        TRRandomizerType.ExtraPickups,
         TRRandomizerType.GlitchedSecrets,
         TRRandomizerType.HardSecrets,
         TRRandomizerType.HiddenEnemies,


### PR DESCRIPTION
Resolves #754.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

A missing UI option for TR1R meant the corresponding setting to add extra pickups was enabled by default and the player couldn't control it.
