### PR TITLE
Fix TR2R sprite issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR-Rando/compare/V1.9.2...master) - xxxx-xx-xx
+- fixed dark pickup sprites in TR2R OG graphics (#760)
+- fixed gun pickup sprites not showing properly in TR2R Floating Islands and Dragon's Lair OG graphics (#760)
 
 ## [V1.9.2](https://github.com/LostArtefacts/TR-Rando/compare/V1.9.1...V1.9.2) - 2024-08-20
 - added support for level sequence randomization in TR1R and TR2R (#756)

--- a/TRRandomizerCore/Randomizers/TR2/Classic/TR2ItemRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR2/Classic/TR2ItemRandomizer.cs
@@ -34,6 +34,7 @@ public class TR2ItemRandomizer : BaseTR2Randomizer
             Generator = _generator,
             Settings = Settings,
             ItemFactory = ItemFactory,
+            DefaultItemShade = -1,
         };
 
         _allocator.AllocateWeapons(Levels.Where(l => !l.Is(TR2LevelNames.ASSAULT)));

--- a/TRRandomizerCore/Randomizers/TR2/Classic/TR2SecretRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR2/Classic/TR2SecretRandomizer.cs
@@ -28,6 +28,7 @@ public class TR2SecretRandomizer : BaseTR2Randomizer
             Settings = Settings,
             Mirrorer = Mirrorer,
             ItemFactory = ItemFactory,
+            DefaultItemShade = -1,
         };
 
         foreach (TR2ScriptedLevel lvl in Levels)

--- a/TRRandomizerCore/Randomizers/TR2/Shared/TR2ItemAllocator.cs
+++ b/TRRandomizerCore/Randomizers/TR2/Shared/TR2ItemAllocator.cs
@@ -8,6 +8,8 @@ namespace TRRandomizerCore.Randomizers;
 
 public class TR2ItemAllocator : ItemAllocator<TR2Type, TR2Entity>
 {
+    public short DefaultItemShade { get; set; }
+
     public TR2ItemAllocator()
         : base(TRGameVersion.TR2) { }
 
@@ -33,7 +35,7 @@ public class TR2ItemAllocator : ItemAllocator<TR2Type, TR2Entity>
         => false;
 
     protected override void ItemMoved(TR2Entity item)
-        => item.Intensity1 = item.Intensity2 = -1;
+        => item.Intensity1 = item.Intensity2 = DefaultItemShade;
 
     public void RandomizeItems(string levelName, TR2Level level, AbstractTRScriptedLevel scriptedLevel)
     {

--- a/TRRandomizerCore/Randomizers/TR2/Shared/TR2SecretAllocator.cs
+++ b/TRRandomizerCore/Randomizers/TR2/Shared/TR2SecretAllocator.cs
@@ -19,6 +19,7 @@ public class TR2SecretAllocator : ISecretRandomizer
     public Random Generator { get; set; }
     public IMirrorControl Mirrorer { get; set; }
     public ItemFactory<TR2Entity> ItemFactory { get; set; }
+    public short DefaultItemShade { get; set; }
 
     public TR2SecretAllocator()
     {
@@ -141,8 +142,8 @@ public class TR2SecretAllocator : ISecretRandomizer
     {
         _routePicker.SetLocation(entity, location);
         entity.TypeID = type;
-        entity.Intensity1 = -1;
-        entity.Intensity2 = -1;
+        entity.Intensity1 = DefaultItemShade;
+        entity.Intensity2 = DefaultItemShade;
         entity.Flags = 0;
     }
 }


### PR DESCRIPTION
Resolves #760.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

- TR2R seems to need 0 for the brightest shade, whereas classic uses -1.
- The TRGE update takes care of injecting the weapons into Floater and Lair, the same way it does for classic. It was being skipped as it's all handled a little differently there.
