### PR TITLE
Exclude TRR monkey item drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - fixed dark pickup sprites in TR2R OG graphics (#760)
 - fixed gun pickup sprites not showing properly in TR2R Floating Islands and Dragon's Lair OG graphics (#760)
 - fixed all placement issues with underwater corner secrets in TR1-3 (#763)
+- fixed monkey item drops causing crashes in TR3R (#768)
 - removed support for 32-bit (#759)
 
 ## [V1.9.2](https://github.com/LostArtefacts/TR-Rando/compare/V1.9.1...V1.9.2) - 2024-08-20

--- a/TRRandomizerCore/Randomizers/TR3/Classic/TR3EnvironmentRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Classic/TR3EnvironmentRandomizer.cs
@@ -5,6 +5,7 @@ using TRLevelControl.Model;
 using TRRandomizerCore.Helpers;
 using TRRandomizerCore.Levels;
 using TRRandomizerCore.Textures;
+using TRRandomizerCore.Utilities;
 
 namespace TRRandomizerCore.Randomizers;
 
@@ -192,35 +193,6 @@ public class TR3EnvironmentRandomizer : BaseTR3Randomizer, IMirrorControl
             monitor.UseMirroring = true;
         }
 
-        CheckMonkeyPickups(level);
-    }
-
-    private static void CheckMonkeyPickups(TR3CombinedLevel level)
-    {
-        // Do a global check for monkeys that may be sitting on more than one pickup.
-        // This has to happen after item, enemy and environment rando to account for
-        // any shifted, converted and added items.
-        List<TR3Entity> monkeys = level.Data.Entities.FindAll(e => e.TypeID == TR3Type.Monkey);
-        foreach (TR3Entity monkey in monkeys)
-        {
-            List<TR3Entity> pickups = level.Data.Entities.FindAll(e =>
-                    e.X == monkey.X &&
-                    e.Y == monkey.Y &&
-                    e.Z == monkey.Z &&
-                    TR3TypeUtilities.IsAnyPickupType(e.TypeID)).ToList();
-
-            if (pickups.Count == 1)
-            {
-                continue;
-            }
-
-            // Leave one item to drop, favouring key items. The others will be shifted
-            // slightly so the monkey doesn't pick them up.
-            pickups.Sort((e1, e2) => TR3TypeUtilities.IsKeyItemType(e1.TypeID) ? 1 : -1);
-            for (int i = 0; i < pickups.Count - 1; i++)
-            {
-                ++pickups[i].X;
-            }
-        }
+        TR3EnemyUtilities.CheckMonkeyPickups(level.Data, false);
     }
 }

--- a/TRRandomizerCore/Randomizers/TR3/Remastered/TR3REnvironmentRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Remastered/TR3REnvironmentRandomizer.cs
@@ -1,6 +1,7 @@
 ﻿using TRDataControl.Environment;
 using TRGE.Core;
 using TRRandomizerCore.Levels;
+using TRRandomizerCore.Utilities;
 
 namespace TRRandomizerCore.Randomizers;
 
@@ -75,5 +76,7 @@ public class TR3REnvironmentRandomizer : BaseTR3RRandomizer
                 mod.ApplyToLevel(level.Data, picker.Options);
             }
         }
+
+        TR3EnemyUtilities.CheckMonkeyPickups(level.Data, true);
     }
 }


### PR DESCRIPTION
Resolves #768.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

I had omitted to do any sort of monkey item drop check per classic for TRR, but this issue is exclusive to TRR anyway. When there is more than one monkey with a drop item, it can crash on save/load. We do the check at the very end of randomization, similar to classic (for >1 item pickups); this is easier than excluding monkeys outright from being able to drop items earlier in randomization, because that would involve a lot of additional classic/TRR checks.
