### PR TITLE
Read and write TR1 SFX environment

### DIFF
--- a/TRLevelControl/Build/TRModelBuilder.cs
+++ b/TRLevelControl/Build/TRModelBuilder.cs
@@ -416,7 +416,7 @@ public class TRModelBuilder<T>
                         {
                             FrameNumber = sfxFrame,
                             SoundID = (short)(sfxID & 0x3FFF),
-                            Environment = _version == TRGameVersion.TR1 ? TRSFXEnvironment.Any : (TRSFXEnvironment)(sfxID & 0xC000)
+                            Environment = (TRSFXEnvironment)(sfxID & 0xC000)
                         };
                         break;
                     case TRAnimCommandType.FlipEffect:
@@ -721,11 +721,7 @@ public class TRModelBuilder<T>
                     break;
                 case TRSFXCommand sfxCmd:
                     {
-                        short soundID = sfxCmd.SoundID;
-                        if (_version > TRGameVersion.TR1)
-                        {
-                            soundID = (short)((int)soundID | (int)sfxCmd.Environment);
-                        }
+                        short soundID = (short)((int)sfxCmd.SoundID | (int)sfxCmd.Environment);
                         values.Add((short)(sfxCmd.FrameNumber + placeholderAnimation.RelFrameStart));
                         values.Add(soundID);
                         break;


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

TR1X supports the environment flag on SFX anim commands, so this adds IO support for that. If writing a level for TRR, TombATI or otherwise, leave the environment as Any,
