### PR TITLE
Lock HSC armoury items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR-Rando/compare/V1.9.3...master) - xxxx-xx-xx
 - added (experimental) support for Linux (#143)
 - changed the number of secrets in TR3R Coastal Village to four to match the statistics (#775)
+- fixed being unable to pick-up some items in TR3R High Security Compound (#783)
 - fixed unreachable item locations in Coastal Village (#774)
 
 ## [V1.9.3](https://github.com/LostArtefacts/TR-Rando/compare/V1.9.2...V1.9.3) - 2024-09-29

--- a/TRRandomizerCore/Randomizers/TR3/Remastered/TR3RItemRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR3/Remastered/TR3RItemRandomizer.cs
@@ -33,6 +33,14 @@ public class TR3RItemRandomizer : BaseTR3RRandomizer
                 continue;
             }
 
+            if (lvl.Is(TR3LevelNames.HSC))
+            {
+                // These can't be picked up if they are moved out of these rooms.
+                _levelInstance.Data.Entities.Where(e => TR3TypeUtilities.IsAnyPickupType(e.TypeID) && (e.Room == 167 || e.Room == 168))
+                    .ToList()
+                    .ForEach(e => ItemFactory.LockItem(_levelInstance.Name, _levelInstance.Data.Entities.IndexOf(e)));
+            }
+
             _allocator.RandomizeItems(_levelInstance.Name, _levelInstance.Data,
                 _levelInstance.Script.RemovesWeapons, _levelInstance.Script.OriginalSequence, _levelInstance.HasExposureMeter);
 


### PR DESCRIPTION
Resolves #783.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The game must reset the room numbers on the armoury items (maybe to do with the fact they added more pickups here), so while we can move the positions, the game will put them back into the original rooms but XYZ won't match. It is a guess ultimately, so the safest thing is not to randomize these items in the first place.
