### PR TITLE
Fix TR2R HSH pickups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-## [Unreleased](https://github.com/LostArtefacts/TR-Rando/compare/V1.9.3...master) - xxxx-xx-xx
+## [Unreleased](https://github.com/LostArtefacts/TR-Rando/compare/V1.10.0...master) - xxxx-xx-xx
+- fixed too many pickups on the same tile in TR2R patch 4 causing a crash (#793)
 
 ## [V1.10.0](https://github.com/LostArtefacts/TR-Rando/compare/V1.9.3...V1.10.0) - 2024-11-05
 - added (experimental) support for Linux (#143)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## [Unreleased](https://github.com/LostArtefacts/TR-Rando/compare/V1.10.0...master) - xxxx-xx-xx
+## [Unreleased](https://github.com/LostArtefacts/TR-Rando/compare/V1.10.1...master) - xxxx-xx-xx
+
+## [Unreleased](https://github.com/LostArtefacts/TR-Rando/compare/V1.10.0...V1.10.1) - 2024-12-01
 - fixed too many pickups on the same tile in TR2R patch 4 causing a crash (#793)
 
 ## [V1.10.0](https://github.com/LostArtefacts/TR-Rando/compare/V1.9.3...V1.10.0) - 2024-11-05

--- a/TRRandomizerCore/Randomizers/TR2/Remastered/TR2REnemyRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR2/Remastered/TR2REnemyRandomizer.cs
@@ -30,6 +30,9 @@ public class TR2REnemyRandomizer : BaseTR2RRandomizer
         new() { X = 31232, Y = 256, Z = 66048, Room = 57 },
         new() { X = 31232, Y = 256, Z = 65024, Room = 57 },
         new() { X = 31232, Y = 256, Z = 64000, Room = 52 },
+        new() { X = 31232, Y = 256, Z = 62976, Room = 52 },
+        new() { X = 31232, Y = 256, Z = 61952, Room = 52 },
+        new() { X = 31232, Y = 256, Z = 60928, Room = 52 },
     };
 
     private Dictionary<string, List<Location>> _pistolLocations;

--- a/TRRandomizerView/TRRandomizerView.csproj
+++ b/TRRandomizerView/TRRandomizerView.csproj
@@ -20,7 +20,7 @@
     <SelfContained>false</SelfContained>
     <ApplicationIcon>Resources\rando.ico</ApplicationIcon>
 
-    <Version>1.10.0</Version>
+    <Version>1.10.1</Version>
     <Product>Tomb Raider Randomizer</Product>
     <Copyright>Copyright © Tomb Raider Community 2024</Copyright>
   </PropertyGroup>


### PR DESCRIPTION
Resolves #793.
Resolves #794.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Patch 4 reduced the maximum pickups per tile (or in a single pickup rather, I'm assuming it's an HUD limit). Added more locations in HSH to spread extra ammo around to avoid a crash. With the most difficult enemy rating, the maximum we would now add per tile is 12, which doesn't crash.

Will release as a hotfix as V1.10.1.
