### PR TITLE
Update IO library for TRR

### DIFF
--- a/TRLevelControl/Build/TRFDBuilder.cs
+++ b/TRLevelControl/Build/TRFDBuilder.cs
@@ -17,6 +17,7 @@ public class TRFDBuilder
     {
         uint numFloorData = reader.ReadUInt32();
         ushort[] data = reader.ReadUInt16s(numFloorData);
+        _observer?.OnFloorDataRead(data);
 
         FDControl floorData = new(_version, _observer, data.Length == 0 ? (ushort)0 : data[0]);
         if (_observer?.UseOriginalFloorData ?? false)

--- a/TRLevelControl/Build/TRModelBuilder.cs
+++ b/TRLevelControl/Build/TRModelBuilder.cs
@@ -10,6 +10,8 @@ public class TRModelBuilder<T>
     private readonly TRGameVersion _version;
     private readonly TRModelDataType _dataType;
     private readonly ITRLevelObserver _observer;
+    private readonly bool _remastered;
+         
 
     private List<TRAnimation> _animations;
     private List<TRAnimDispatch> _dispatches;
@@ -24,11 +26,12 @@ public class TRModelBuilder<T>
     private Dictionary<TRAnimDispatch, short> _dispatchToAnimMap;
     private Dictionary<TRAnimDispatch, short> _dispatchFrameBase;
 
-    public TRModelBuilder(TRGameVersion version, TRModelDataType dataType, ITRLevelObserver observer = null)
+    public TRModelBuilder(TRGameVersion version, TRModelDataType dataType, ITRLevelObserver observer = null, bool remastered = false)
     {
         _version = version;
         _dataType = dataType;
         _observer = observer;
+        _remastered = remastered;
     }
 
     public TRDictionary<T, TRModel> ReadModelData(TRLevelReader reader, IMeshProvider meshProvider)
@@ -197,7 +200,7 @@ public class TRModelBuilder<T>
                 Animation = reader.ReadUInt16()
             });
 
-            if (_version == TRGameVersion.TR5)
+            if (_version == TRGameVersion.TR5 && !_remastered)
             {
                 reader.ReadUInt16(); // Skip padding
             }
@@ -882,7 +885,7 @@ public class TRModelBuilder<T>
             writer.Write(placeholderModel.FrameOffset);
             writer.Write(placeholderModel.Animation);
 
-            if (_version == TRGameVersion.TR5)
+            if (_version == TRGameVersion.TR5 && !_remastered)
             {
                 writer.Write(_tr5ModelPadding);
             }

--- a/TRLevelControl/Build/TRSpriteBuilder.cs
+++ b/TRLevelControl/Build/TRSpriteBuilder.cs
@@ -16,13 +16,13 @@ public class TRSpriteBuilder<T> : ISpriteProvider<T>
         _version = version;
     }
 
-    public TRDictionary<T, TRSpriteSequence> ReadSprites(TRLevelReader reader)
+    public TRDictionary<T, TRSpriteSequence> ReadSprites(TRLevelReader reader, bool remastered = false)
     {
         if (_version >= TRGameVersion.TR4)
         {
             string sprMarker = new(reader.ReadChars(_sprMarker.Length));
             Debug.Assert(sprMarker == _sprMarker);
-            if (_version == TRGameVersion.TR5)
+            if (_version == TRGameVersion.TR5 && !remastered)
             {
                 byte end = reader.ReadByte();
                 Debug.Assert(end == 0);
@@ -55,12 +55,12 @@ public class TRSpriteBuilder<T> : ISpriteProvider<T>
         return sprites;
     }
 
-    public void WriteSprites(TRLevelWriter writer, TRDictionary<T, TRSpriteSequence> sprites)
+    public void WriteSprites(TRLevelWriter writer, TRDictionary<T, TRSpriteSequence> sprites, bool remastered = false)
     {
         if (_version >= TRGameVersion.TR4)
         {
             writer.Write(_sprMarker.ToCharArray());
-            if (_version == TRGameVersion.TR5)
+            if (_version == TRGameVersion.TR5 && !remastered)
             {
                 writer.Write((byte)0);
             }

--- a/TRLevelControl/IO/TRLevelReader.cs
+++ b/TRLevelControl/IO/TRLevelReader.cs
@@ -200,6 +200,17 @@ public class TRLevelReader : BinaryReader
         return colours;
     }
 
+    public TRColour4 ReadRGBA()
+    {
+        return new()
+        {
+            Red = ReadByte(),
+            Green = ReadByte(),
+            Blue = ReadByte(),
+            Alpha = ReadByte()
+        };
+    }
+
     public TR5Colour ReadTR5Colour()
     {
         return new()

--- a/TRLevelControl/IO/TRLevelReader.cs
+++ b/TRLevelControl/IO/TRLevelReader.cs
@@ -20,11 +20,7 @@ public class TRLevelReader : BinaryReader
         uint expectedLength = ReadUInt32();
         uint compressedLength = ReadUInt32();
 
-        byte[] data = new byte[compressedLength];
-        for (uint i = 0; i < compressedLength; i++)
-        {
-            data[i] = ReadByte();
-        }
+        byte[] data = ReadUInt8s(compressedLength);
 
         MemoryStream inflatedStream = new();
         using MemoryStream ms = new(data);

--- a/TRLevelControl/ITRLevelObserver.cs
+++ b/TRLevelControl/ITRLevelObserver.cs
@@ -8,6 +8,8 @@ public interface ITRLevelObserver
     void OnChunkWritten(long startPosition, long endPosition, TRChunkType chunkType, byte[] data);
     bool UseTR5RawRooms { get; }
     bool UseOriginalFloorData { get; }
+    void OnFloorDataRead(ushort[] data);
+    ushort[] GetFloorData();
     void OnRawTR5RoomsRead(List<byte> data);
     List<byte> GetTR5Rooms();
     void OnMeshPaddingRead(uint meshPointer, List<byte> values);

--- a/TRLevelControl/Model/Common/Enums/TRFileVersion.cs
+++ b/TRLevelControl/Model/Common/Enums/TRFileVersion.cs
@@ -7,5 +7,6 @@ public enum TRFileVersion : uint
     TR2     = 0x0000002D,
     TR3a    = 0xFF080038,
     TR3b    = 0xFF180038,
-    TR45    = 0x00345254,
+    TR45    = 0x00345254, // classic
+    TRR4    = 0x34585254, // remastered
 }

--- a/TRLevelControl/Model/Common/Enums/TRFileVersion.cs
+++ b/TRLevelControl/Model/Common/Enums/TRFileVersion.cs
@@ -9,4 +9,5 @@ public enum TRFileVersion : uint
     TR3b    = 0xFF180038,
     TR45    = 0x00345254, // classic
     TRR4    = 0x34585254, // remastered
+    TRR5    = 0x35585254,
 }

--- a/TRLevelControl/Model/Common/FloorData/FDControl.cs
+++ b/TRLevelControl/Model/Common/FloorData/FDControl.cs
@@ -69,6 +69,12 @@ public class FDControl : IEnumerable<KeyValuePair<int, List<FDEntry>>>
 
     public List<ushort> Flatten(IEnumerable<TRRoomSector> sectors)
     {
+        ushort[] oldData = _observer?.GetFloorData();
+        if (oldData != null)
+        {
+            return new(oldData);
+        }
+
         List<ushort> data = new()
         {
             _dummyEntry

--- a/TRLevelControl/Model/Common/TRRoomMesh.cs
+++ b/TRLevelControl/Model/Common/TRRoomMesh.cs
@@ -4,10 +4,10 @@ public class TRRoomMesh<T, V> : ICloneable
     where T : Enum
     where V : TRRoomVertex
 {
-    public List<V> Vertices { get; set; }
-    public List<TRFace> Rectangles { get; set; }
-    public List<TRFace> Triangles { get; set; }
-    public List<TRRoomSprite<T>> Sprites { get; set; }
+    public List<V> Vertices { get; set; } = new();
+    public List<TRFace> Rectangles { get; set; } = new();
+    public List<TRFace> Triangles { get; set; } = new();
+    public List<TRRoomSprite<T>> Sprites { get; set; } = new();
 
     public IEnumerable<TRFace> Faces => Rectangles.Concat(Triangles);
 

--- a/TRLevelControl/Model/TR5/TR5Room.cs
+++ b/TRLevelControl/Model/TR5/TR5Room.cs
@@ -2,7 +2,7 @@
 
 public class TR5Room : TRRoom
 {
-    public TRRoomMesh<TR5Type, TR5RoomVertex> Mesh { get; set; }
+    public TRRoomMesh<TR5Type, TR5RoomVertex> Mesh { get; set; } = new();
     public TRColour4 Colour { get; set; }
     public List<TR5RoomLight> Lights { get; set; }
     public List<TR5RoomStaticMesh> StaticMeshes { get; set; }

--- a/TRLevelControlTests/Base/Observers/ObserverBase.cs
+++ b/TRLevelControlTests/Base/Observers/ObserverBase.cs
@@ -20,6 +20,11 @@ public class ObserverBase : ITRLevelObserver
     public virtual bool UseOriginalFloorData => true;
     public virtual bool UseTR5RawRooms => false;
 
+    public virtual void OnFloorDataRead(ushort[] data)
+    { }
+
+    public virtual ushort[] GetFloorData() => null;
+
     public virtual void OnRawTR5RoomsRead(List<byte> data)
     { }
 

--- a/TRLevelControlTests/Base/Observers/TR4Observer.cs
+++ b/TRLevelControlTests/Base/Observers/TR4Observer.cs
@@ -15,6 +15,22 @@ public class TR4Observer : TR3Observer
     private readonly Dictionary<byte, List<byte>> _flybyIndices = new();
 
     private uint[] _sampleIndices;
+    protected readonly bool _remastered;
+    private ushort[] _floorData;
+
+    public TR4Observer(bool remastered)
+    {
+        _remastered = remastered;
+    }
+
+    public override bool UseOriginalFloorData => _remastered;
+
+    public override void OnFloorDataRead(ushort[] data)
+    {
+        _floorData = data;
+    }
+
+    public override ushort[] GetFloorData() => _floorData;
 
     public override void TestOutput(byte[] input, byte[] output)
     {

--- a/TRLevelControlTests/Base/Observers/TR5Observer.cs
+++ b/TRLevelControlTests/Base/Observers/TR5Observer.cs
@@ -6,6 +6,9 @@ public class TR5Observer : TR4Observer
     private short? _animCommandPadding;
     private List<byte> _rawRooms;
 
+    public TR5Observer(bool remastered)
+        : base(remastered) { }
+
     public override bool UseTR5RawRooms => true;
 
     public override void OnRawTR5RoomsRead(List<byte> data)

--- a/TRLevelControlTests/Base/TestBase.cs
+++ b/TRLevelControlTests/Base/TestBase.cs
@@ -107,13 +107,13 @@ public class TestBase
                 control3.Write(level3, outputStream);
                 break;
             case TRGameVersion.TR4:
-                observer = new TR4Observer();
+                observer = new TR4Observer(remastered);
                 TR4LevelControl control4 = new(observer);
                 TR4Level level4 = control4.Read(pathI);
                 control4.Write(level4, outputStream);
                 break;
             case TRGameVersion.TR5:
-                observer = new TR5Observer();
+                observer = new TR5Observer(remastered);
                 TR5LevelControl control5 = new(observer);
                 TR5Level level5 = control5.Read(pathI);
                 control5.Write(level5, outputStream);

--- a/TRLevelControlTests/Base/TestBase.cs
+++ b/TRLevelControlTests/Base/TestBase.cs
@@ -68,10 +68,10 @@ public class TestBase
         return control.Read(GetReadPath(level, TRGameVersion.TR4));
     }
 
-    public static TR5Level GetTR5Level(string level)
+    public static TR5Level GetTR5Level(string level, bool remastered = false)
     {
         TR5LevelControl control = new();
-        return control.Read(GetReadPath(level, TRGameVersion.TR5));
+        return control.Read(GetReadPath(level, TRGameVersion.TR5, remastered));
     }
 
     public static void ReadWriteLevel(string levelName, TRGameVersion version, bool remastered)

--- a/TRLevelControlTests/TR4/IOTests.cs
+++ b/TRLevelControlTests/TR4/IOTests.cs
@@ -19,6 +19,13 @@ public class IOTests : TestBase
 
     [TestMethod]
     [DynamicData(nameof(GetAllLevels), DynamicDataSourceType.Method)]
+    public void TestRemasteredReadWrite(string levelName)
+    {
+        ReadWriteLevel(levelName, TRGameVersion.TR4, true);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(GetAllLevels), DynamicDataSourceType.Method)]
     public void TestAgressiveFloorData(string levelName)
     {
         TR4Level level = GetTR4Level(levelName);

--- a/TRLevelControlTests/TR5/IOTests.cs
+++ b/TRLevelControlTests/TR5/IOTests.cs
@@ -19,6 +19,13 @@ public class IOTests : TestBase
 
     [TestMethod]
     [DynamicData(nameof(GetAllLevels), DynamicDataSourceType.Method)]
+    public void TestRemasteredReadWrite(string levelName)
+    {
+        ReadWriteLevel(levelName, TRGameVersion.TR5, true);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(GetAllLevels), DynamicDataSourceType.Method)]
     public void TestAgressiveFloorData(string levelName)
     {
         TR5Level level = GetTR5Level(levelName);

--- a/TRLevelControlTests/TR5/RoomTests.cs
+++ b/TRLevelControlTests/TR5/RoomTests.cs
@@ -31,16 +31,27 @@ public class RoomTests : TestBase
     [TestMethod]
     [DynamicData(nameof(GetAllLevels), DynamicDataSourceType.Method)]
     [Description("Compare each room in each level before and after writing to ensure identical properties.")]
-    public void TestRoomIO(string levelName)
+    public void TestRoomIOClassic(string levelName)
     {
-        TestRoomIO(levelName, _roomCounts[levelName]);
+        TR5Level level = GetTR5Level(levelName, false);
+        TestRoomIO(level, _roomCounts[levelName]);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(GetAllLevels), DynamicDataSourceType.Method)]
+    public void TestRoomIORemastered(string levelName)
+    {
+        TR5Level level = GetTR5Level(levelName, true);
+        TestRoomIO(level, _roomCounts[levelName]);
     }
 
     [TestMethod]
     [Description("Add a room to test roomlet expansion and squashing.")]
-    public void TestRoomToRoomlet()
+    [DataRow(true)]
+    [DataRow(false)]
+    public void TestRoomToRoomlet(bool remastered)
     {
-        TR5Level level = GetTR5Level(TR5LevelNames.ROME);
+        TR5Level level = GetTR5Level(TR5LevelNames.ROME, remastered);
         TR5Room room = new()
         {
             AlternateGroup = 2,
@@ -185,9 +196,8 @@ public class RoomTests : TestBase
         CompareRooms(room, newRoom);
     }
 
-    private static void TestRoomIO(string levelName, int expectedRoomCount)
+    private static void TestRoomIO(TR5Level level, int expectedRoomCount)
     {
-        TR5Level level = GetTR5Level(levelName);
         Assert.AreEqual(expectedRoomCount, level.Rooms.Count);
         List<TR5Room> rooms = new(level.Rooms);
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

The file formats for TRR 4 and 5 are different compared to classic, so this updates the level control library to support those. We don't do anything with these games yet, this is purely to keep the reader up to date. Thanks @chreden for sharing investigation notes on this.

I'll look at PDP, MAP and TRG in the future; MAP will need quite a bit of effort to get all the aliases in place, so it seems unnecessary at the moment as we don't even target the games.

Offline test results for the record:
![image](https://github.com/user-attachments/assets/eae7081f-baf5-4803-a660-d2c2c2d21f6e)
