### PR TITLE
Update TR2X guids

### DIFF
--- a/TRLevelControl/Helpers/TRXGuid.cs
+++ b/TRLevelControl/Helpers/TRXGuid.cs
@@ -478,6 +478,9 @@ public static class TRXGuid
             [(int)TR2Type.LaraCutscenePlacement_N]  = new("604407b7-fce9-4042-9268-9269a191f615"),
             [(int)TR2Type.ShotgunShowerAnimation_H] = new("c3c56053-16cd-4bff-9892-dc2f816d8897"),
             [(int)TR2Type.DragonExplosionEmitter_N] = new("78bde34c-13f0-4fb0-8407-c7dfc3c2e3fb"),
+            [(int)TR2Type.Bear]                     = new("fbf6c19f-80aa-4790-baba-9dadb09d4f82"),
+            [(int)TR2Type.Wolf]                     = new("6b3b8413-7ac3-4728-9e4b-e15e64e1e40c"),
+            [(int)TR2Type.MonkWithNoShadow]         = new("28271d92-b65b-44a2-9156-24ab1a7c41b2"),
         },
     };
 }

--- a/TRLevelControl/Model/TR2/Enums/TR2Type.cs
+++ b/TRLevelControl/Model/TR2/Enums/TR2Type.cs
@@ -275,10 +275,15 @@ public enum TR2Type : uint
     ShotgunShowerAnimation_H = 263,
     DragonExplosionEmitter_N = 264,
 
-    // Scenery
-    Plant0                   = 265,
-    Plant1                   = 266,
-    Plant2                   = 267,
+    // TRX
+    Bear                     = 265,
+    Wolf                     = 266,
+    MonkWithNoShadow         = 267,
+
+    // Scenery - TODO: get rid of defined statics
+    Plant0                   = Bear,
+    Plant1                   = Wolf,
+    Plant2                   = MonkWithNoShadow,
     Plant3                   = 268,
     Plant4                   = 269,
     Plant5                   = 270,
@@ -326,7 +331,7 @@ public enum TR2Type : uint
     Debris7                  = 312,
     Debris8                  = 313,
     Debris9                  = 314,
-    SceneryBase              = Plant0,
+    SceneryBase              = Bear,
 
     // Alias entries
     BengalTiger                   = 1000,


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

This adds guids for the bear and wolf in TR2 Golden Mask (matching the equivalent in TR1) and creates a new guid for the monk type in GM that has no shadow.

I will get rid of defined static IDs in the future from the TR1-3 type enums as they don't make sense, they are simple slots in-game with no behaviour attached.

Ref: https://github.com/LostArtefacts/TRXInjectionTool/pull/79
