### PR TITLE
Adjust TR2R Diving Area ending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased](https://github.com/LostArtefacts/TR-Rando/compare/V1.10.2...master) - xxxx-xx-xx
 - added Spanish translations for TR1 (#800)
+- fixed a crash at the end of Diving Area in TR2R (#814)
 
 ## [V1.10.2](https://github.com/LostArtefacts/TR-Rando/compare/V1.10.1...V1.10.2) - 2024-12-06
 - added support for TR1X 4.6 (#796)

--- a/TRRandomizerCore/Randomizers/TR2/Remastered/TR2REnemyRandomizer.cs
+++ b/TRRandomizerCore/Randomizers/TR2/Remastered/TR2REnemyRandomizer.cs
@@ -140,9 +140,23 @@ public class TR2REnemyRandomizer : BaseTR2RRandomizer
 
     private void ApplyPostRandomization(TR2RCombinedLevel level)
     {
+        AdjustDivingAreaEnd(level);
         RestoreHSHDog(level);
         MakeChickensUnconditional(level);
         AddUnarmedItems(level);
+    }
+
+    private static void AdjustDivingAreaEnd(TR2RCombinedLevel level)
+    {
+        if (!level.Is(TR2LevelNames.DA))
+        {
+            return;
+        }
+
+        // TR2R crashes at the end of DA in some cases because of presumably hard-coded dying monk
+        // checks. Change the monk's type to allow environment mods to detect the change and make
+        // further adjustments.
+        level.Data.Entities[117].TypeID = TR2Type.PushButtonSwitch;
     }
 
     private static void RestoreHSHDog(TR2RCombinedLevel level)

--- a/TRRandomizerCore/Resources/TR2/Environment/PLATFORM.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR2/Environment/PLATFORM.TR2-Environment.json
@@ -2587,6 +2587,77 @@
           }
         }
       ]
+    },
+    {
+      "Condition": {
+        "Comments": "If the end monk is no longer of that type, it's been done to avoid TR2R crashing. Add further tweaks to end the level.",
+        "ConditionType": 0,
+        "EntityIndex": 117,
+        "EntityType": 256
+      },
+      "OnFalse": [
+        {
+          "EMType": 71,
+          "Tags": [
+            13
+          ],
+          "Locations": [
+            {
+              "X": 54784,
+              "Y": 3072,
+              "Z": 61952,
+              "Room": 5
+            }
+          ],
+          "ActionItem": {
+            "Parameter": 117
+          }
+        },
+        {
+          "EMType": 45,
+          "EntityIndex": 117,
+          "NewEntityType": 103
+        },
+        {
+          "EMType": 45,
+          "EntityIndex": 116,
+          "NewEntityType": 67
+        },
+        {
+          "EMType": 44,
+          "EntityIndex": 117,
+          "TargetLocation": {
+            "X": 55808,
+            "Y": 4608,
+            "Z": 61952,
+            "Room": 77
+          }
+        },
+        {
+          "EMType": 44,
+          "EntityIndex": 116,
+          "TargetLocation": {
+            "X": 57856,
+            "Y": 5632,
+            "Z": 61952,
+            "Room": 77
+          }
+        },
+        {
+          "EMType": 61,
+          "EntityLocation": 117,
+          "Trigger": {
+            "TrigType": 2,
+            "Mask": 31,
+            "SwitchOrKeyRef": 117,
+            "Actions": [
+              {
+                "Action": 7
+              }
+            ]
+          }
+        }
+      ]
     }
   ],
   "ConditionalOneOf": [],


### PR DESCRIPTION
Resolves #814.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Enforces a different way to end Diving Area in TR2R if enemies are randomized.
