### PR TITLE
Fix Khamoon second key range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - added support for TR1X 4.14 (now the minimum version supported) (#803)
 - added Spanish translations for TR1 (#800)
 - fixed a crash at the end of Diving Area in TR2R (#814)
+- fixed a potential key softlock in City of Khamoon if "large" range is selected and either return paths are disabled in classic, or playing remastered (#820)
 
 ## [V1.10.2](https://github.com/LostArtefacts/TR-Rando/compare/V1.10.1...V1.10.2) - 2024-12-06
 - added support for TR1X 4.6 (#796)

--- a/TRRandomizerCore/Resources/TR1/Locations/routes.json
+++ b/TRRandomizerCore/Resources/TR1/Locations/routes.json
@@ -4815,7 +4815,7 @@
       "Y": 1216,
       "Z": 15872,
       "Room": 2,
-      "KeyItemsLow": "19217,19193",
+      "KeyItemsLow": "19217",
       "Range": "Large"
     },
     {
@@ -5090,6 +5090,14 @@
       "Room": 52,
       "KeyItemsLow": "19193",
       "Range": "Medium"
+    },
+    {
+      "X": 56064,
+      "Y": 1024,
+      "Z": 25088,
+      "Room": 52,
+      "KeyItemsLow": "19193",
+      "Range": "Large"
     },
     {
       "X": 56832,


### PR DESCRIPTION
Resolves #820.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Restricts the second key's range in City of Khamoon if return paths are disabled/not feasible.
