### PR TITLE
Fix TR3 enemy logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - fixed a crash at the end of Diving Area in TR2R (#814)
 - fixed a potential key softlock in City of Khamoon if "large" range is selected and either return paths are disabled in classic, or playing remastered (#820)
 - fixed the raptor spawns in Crash Site when enemies are randomized to guarantee that some appear when using the turrent (#818)
+- fixed enemy 211 in Area 51 potentially being untriggerable, and hence a potential softlock if carrying a key item (#816)
 
 ## [V1.10.2](https://github.com/LostArtefacts/TR-Rando/compare/V1.10.1...V1.10.2) - 2024-12-06
 - added support for TR1X 4.6 (#796)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - added Spanish translations for TR1 (#800)
 - fixed a crash at the end of Diving Area in TR2R (#814)
 - fixed a potential key softlock in City of Khamoon if "large" range is selected and either return paths are disabled in classic, or playing remastered (#820)
+- fixed the raptor spawns in Crash Site when enemies are randomized to guarantee that some appear when using the turrent (#818)
 
 ## [V1.10.2](https://github.com/LostArtefacts/TR-Rando/compare/V1.10.1...V1.10.2) - 2024-12-06
 - added support for TR1X 4.6 (#796)

--- a/TRRandomizerCore/Resources/TR3/Environment/AREA51.TR2-Environment.json
+++ b/TRRandomizerCore/Resources/TR3/Environment/AREA51.TR2-Environment.json
@@ -450,6 +450,25 @@
               120
             ]
           }
+        },
+        {
+          "Comments": "Ensure enemy 211 is still triggered.",
+          "EMType": 68,
+          "LocationExpander": {
+            "Location": {
+              "X": 40448,
+              "Y": -2048,
+              "Z": 41472,
+              "Room": 103
+            },
+            "ExpandX": 1,
+            "ExpandZ": 3
+          },
+          "Actions": [
+            {
+              "Parameter": 211
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
Resolves #816.
Resolves #818.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

- Keeps raptors in place in room 15 in Crash Site if they are present as a model, otherwise swaps out the spawn and AI points with actual enemies.
- If enemy 211 in Area 51 is no longer triggered by the nearby heavy trigger, regular triggers will be added to avoid softlock if he's carrying a key.
