### PR TITLE
Add SFX fallback reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - fixed the raptor spawns in Crash Site when enemies are randomized to guarantee that some appear when using the turrent (#818)
 - fixed enemy 211 in Area 51 potentially being untriggerable, and hence a potential softlock if carrying a key item (#816)
 - fixed an unreachable secret in TR3R Madubu Gorge (#819)
+- fixed uncontrolled SFX in TR2 and TR3 causing an error message during randomization (#827)
 
 ## [V1.10.2](https://github.com/LostArtefacts/TR-Rando/compare/V1.10.1...V1.10.2) - 2024-12-06
 - added support for TR1X 4.6 (#796)

--- a/TRLevelControl/Build/TRSFXBuilder.cs
+++ b/TRLevelControl/Build/TRSFXBuilder.cs
@@ -4,8 +4,13 @@ namespace TRLevelControl.Build;
 
 public static class TRSFXBuilder
 {
-    public static List<short> ReadSoundMap(TRLevelReader reader)
+    public static List<short> ReadSoundMap(TRLevelReader reader, int length)
     {
+        if (length > 0)
+        {
+            return [.. reader.ReadInt16s(length)];
+        }
+
         List<short> map = new();
         while (reader.PeekUInt() >= ushort.MaxValue)
         {

--- a/TRLevelControl/Control/TR1/TR1LevelControl.cs
+++ b/TRLevelControl/Control/TR1/TR1LevelControl.cs
@@ -302,7 +302,21 @@ public class TR1LevelControl : TRLevelControlBase<TR1Level>
 
     private void ReadSoundEffects(TRLevelReader reader)
     {
-        List<short> soundMap = TRSFXBuilder.ReadSoundMap(reader);
+        long startPos = reader.BaseStream.Position;
+        try
+        {
+            ReadSoundEffects(reader, -1);
+        }
+        catch
+        {
+            reader.BaseStream.Position = startPos;
+            ReadSoundEffects(reader, Enum.GetValues<TR1SFX>().Length);
+        }
+    }
+
+    private void ReadSoundEffects(TRLevelReader reader, int mapLength)
+    {
+        List<short> soundMap = TRSFXBuilder.ReadSoundMap(reader, mapLength);
 
         uint numSoundDetails = reader.ReadUInt32();
         List<TR1SoundEffect> sfx = new();

--- a/TRLevelControl/Control/TR2/TR2LevelControl.cs
+++ b/TRLevelControl/Control/TR2/TR2LevelControl.cs
@@ -308,7 +308,21 @@ public class TR2LevelControl : TRLevelControlBase<TR2Level>
 
     private void ReadSoundEffects(TRLevelReader reader)
     {
-        List<short> soundMap = TRSFXBuilder.ReadSoundMap(reader);
+        long startPos = reader.BaseStream.Position;
+        try
+        {
+            ReadSoundEffects(reader, -1);
+        }
+        catch
+        {
+            reader.BaseStream.Position = startPos;
+            ReadSoundEffects(reader, Enum.GetValues<TR2SFX>().Length);
+        }
+    }
+
+    private void ReadSoundEffects(TRLevelReader reader, int mapLength)
+    {
+        List<short> soundMap = TRSFXBuilder.ReadSoundMap(reader, mapLength);
 
         uint numSoundDetails = reader.ReadUInt32();
         List<TR2SoundEffect> sfx = new();

--- a/TRLevelControl/Control/TR3/TR3LevelControl.cs
+++ b/TRLevelControl/Control/TR3/TR3LevelControl.cs
@@ -308,7 +308,21 @@ public class TR3LevelControl : TRLevelControlBase<TR3Level>
 
     private void ReadSoundEffects(TRLevelReader reader)
     {
-        List<short> soundMap = TRSFXBuilder.ReadSoundMap(reader);
+        long startPos = reader.BaseStream.Position;
+        try
+        {
+            ReadSoundEffects(reader, -1);
+        }
+        catch
+        {
+            reader.BaseStream.Position = startPos;
+            ReadSoundEffects(reader, Enum.GetValues<TR3SFX>().Length);
+        }
+    }
+
+    private void ReadSoundEffects(TRLevelReader reader, int mapLength)
+    {
+        List<short> soundMap = TRSFXBuilder.ReadSoundMap(reader, mapLength);
 
         uint numSoundDetails = reader.ReadUInt32();
         List<TR3SoundEffect> sfx = new();

--- a/TRLevelControl/Control/TR4/TR4LevelControl.cs
+++ b/TRLevelControl/Control/TR4/TR4LevelControl.cs
@@ -372,7 +372,21 @@ public class TR4LevelControl : TRLevelControlBase<TR4Level>
 
     private void ReadSoundEffects(TRLevelReader reader)
     {
-        List<short> soundMap = TRSFXBuilder.ReadSoundMap(reader);
+        long startPos = reader.BaseStream.Position;
+        try
+        {
+            ReadSoundEffects(reader, -1);
+        }
+        catch
+        {
+            reader.BaseStream.Position = startPos;
+            ReadSoundEffects(reader, Enum.GetValues<TR4SFX>().Length);
+        }
+    }
+
+    private void ReadSoundEffects(TRLevelReader reader, int mapLength)
+    {
+        List<short> soundMap = TRSFXBuilder.ReadSoundMap(reader, mapLength);
 
         uint numSoundDetails = reader.ReadUInt32();
         List<TR4SoundEffect> sfx = new();

--- a/TRLevelControl/Control/TR5/TR5LevelControl.cs
+++ b/TRLevelControl/Control/TR5/TR5LevelControl.cs
@@ -431,7 +431,21 @@ public class TR5LevelControl : TRLevelControlBase<TR5Level>
 
     private void ReadSoundEffects(TRLevelReader reader)
     {
-        List<short> soundMap = TRSFXBuilder.ReadSoundMap(reader);
+        long startPos = reader.BaseStream.Position;
+        try
+        {
+            ReadSoundEffects(reader, -1);
+        }
+        catch
+        {
+            reader.BaseStream.Position = startPos;
+            ReadSoundEffects(reader, Enum.GetValues<TR5SFX>().Length);
+        }
+    }
+
+    private void ReadSoundEffects(TRLevelReader reader, int mapLength)
+    {
+        List<short> soundMap = TRSFXBuilder.ReadSoundMap(reader, mapLength);
 
         uint numSoundDetails = reader.ReadUInt32();
         List<TR4SoundEffect> sfx = new();

--- a/TRLevelControlTests/TR2/SoundTests.cs
+++ b/TRLevelControlTests/TR2/SoundTests.cs
@@ -1,0 +1,30 @@
+﻿using TRLevelControl.Model;
+
+namespace TRLevelControlTests.TR2;
+
+[TestClass]
+[TestCategory("Sound")]
+public class SoundTests : TestBase
+{
+    [TestMethod]
+    [Description("Test sample ID order.")]
+    public void TestSampleOrder()
+    {
+        var level = GetTR2TestLevel();
+
+        var feet = level.SoundEffects[TR2SFX.LaraFeet];
+        var breath = level.SoundEffects[TR2SFX.LaraBreath];
+        Assert.IsGreaterThan(feet.SampleID, breath.SampleID);
+
+        (breath.SampleID, feet.SampleID) = (feet.SampleID, breath.SampleID);
+
+        try
+        {
+            WriteReadTempLevel(level);
+        }
+        catch
+        {
+            Assert.Fail();
+        }
+    }
+}


### PR DESCRIPTION
Resolves #827.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Adds an approach to fall back to reading the expected sound map length per game length if reading it dynamically fails. Only happens when the sample ID order is not consecutive, which is limited to TR2 and TR3, but I've added the fallback to all games as a guard.
