### PR TITLE
Add sprite texture position mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - fixed uncontrolled SFX in TR2 and TR3 causing an error message during randomization (#827)
 - fixed cloned enemies in TR1X being left behind if a room is flooded and the original enemy is moved on land (#842)
 - fixed Lara potentially starting beyond initial enemy triggers in The Great Wall if the first area is flooded
+- fixed flame sprites in some TR2 levels not being targeted for texture randomization (#844)
 
 ## [V1.10.2](https://github.com/LostArtefacts/TR-Rando/compare/V1.10.1...V1.10.2) - 2024-12-06
 - added support for TR1X 4.6 (#796)


### PR DESCRIPTION
Resolves #844.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

On data import, object texture positions are mapped so texture monitoring can reference the positions, but sprite textures were missed in this logic. This meant that sprites such as the flames couldn't be targeted for texture randomization in levels such as Venice where they don't already exist.
