### PR TITLE
Make FD writing stricter

### DIFF
--- a/TRDataControlTests/Environment/Surfaces/LadderTests.cs
+++ b/TRDataControlTests/Environment/Surfaces/LadderTests.cs
@@ -1,0 +1,137 @@
+﻿using TRDataControl.Environment;
+using TRLevelControl.Model;
+using TRLevelControlTests;
+
+namespace TRDataControlTests.Environment.Entities;
+
+[TestClass]
+[TestCategory("Environment")]
+public class LadderTests : TestBase
+{
+    [TestMethod]
+    public void TestNewLadder()
+    {
+        var (level, location, sector) = Setup();
+        Assert.AreEqual(0, sector.FDIndex);
+
+        new EMLadderFunction
+        {
+            TextureMap = [],
+            Location = location,
+            IsNegativeX = true,
+            IsPositiveZ = true,
+        }.ApplyToLevel(level);
+
+        Assert.AreNotEqual(0, sector.FDIndex);
+        var ladder = level.FloorData[sector.FDIndex].OfType<FDClimbEntry>().FirstOrDefault();
+        Assert.IsNotNull(ladder);
+
+        Assert.IsTrue(ladder.IsNegativeX);
+        Assert.IsTrue(ladder.IsPositiveZ);
+        Assert.IsFalse(ladder.IsPositiveX);
+        Assert.IsFalse(ladder.IsNegativeZ);
+    }
+
+    [TestMethod]
+    public void TestAlteredLadder()
+    {
+        var (level, location, sector) = Setup();
+
+        new EMLadderFunction
+        {
+            TextureMap = [],
+            Location = location,
+            IsNegativeX = true,
+            IsPositiveZ = true,
+        }.ApplyToLevel(level);
+
+        new EMLadderFunction
+        {
+            TextureMap = [],
+            Location = location,
+            IsPositiveX = true,
+            IsNegativeZ = true,
+        }.ApplyToLevel(level);
+
+        var ladders = level.FloorData[sector.FDIndex].OfType<FDClimbEntry>();
+        Assert.AreEqual(1, ladders.Count());
+
+        var ladder = ladders.First();
+        Assert.IsFalse(ladder.IsNegativeX);
+        Assert.IsFalse(ladder.IsPositiveZ);
+        Assert.IsTrue(ladder.IsPositiveX);
+        Assert.IsTrue(ladder.IsNegativeZ);
+    }
+
+    [TestMethod]
+    public void TestRemovedLadder()
+    {
+        var (level, location, sector) = Setup();
+
+        new EMLadderFunction
+        {
+            TextureMap = [],
+            Location = location,
+            IsNegativeX = true,
+            IsPositiveZ = true,
+        }.ApplyToLevel(level);
+
+        var ladder = level.FloorData[sector.FDIndex].OfType<FDClimbEntry>().FirstOrDefault();
+        Assert.IsNotNull(ladder);
+
+        new EMLadderFunction
+        {
+            TextureMap = [],
+            Location = location,
+        }.ApplyToLevel(level);
+
+        ladder = level.FloorData[sector.FDIndex].OfType<FDClimbEntry>().FirstOrDefault();
+        Assert.IsNull(ladder);
+    }
+
+    [TestMethod]
+    public void TestMultipleLadders()
+    {
+        var (level, location, sector) = Setup();
+
+        level.FloorData.CreateFloorData(sector);
+        level.FloorData[sector.FDIndex].Add(new FDClimbEntry { IsPositiveX = true });
+        level.FloorData[sector.FDIndex].Add(new FDClimbEntry { IsNegativeZ = true });
+
+        level = WriteReadTempLevel(level);
+        sector = level.GetRoomSector(location);
+
+        var ladders = level.FloorData[sector.FDIndex].OfType<FDClimbEntry>();
+        Assert.AreEqual(1, ladders.Count());
+
+        var ladder = ladders.First();
+        Assert.IsTrue(ladder.IsPositiveX);
+        Assert.IsTrue(ladder.IsNegativeZ);
+        Assert.IsFalse(ladder.IsNegativeX);
+        Assert.IsFalse(ladder.IsPositiveZ);
+    }
+
+    [TestMethod]
+    public void TestNullLadder()
+    {
+        var (level, location, sector) = Setup();
+
+        level.FloorData.CreateFloorData(sector);
+        level.FloorData[sector.FDIndex].Add(new FDClimbEntry());
+
+        level = WriteReadTempLevel(level);
+        sector = level.GetRoomSector(location);
+        Assert.AreEqual(0, sector.FDIndex);
+    }
+
+    private static (TR2Level, EMLocation, TRRoomSector) Setup()
+    {
+        var level = GetTR2TestLevel();
+        var location = new EMLocation
+        {
+            X = 3584,
+            Z = 10752,
+        };
+        return (level, location, level.GetRoomSector(location));
+    }
+}

--- a/TRLevelControlTests/Base/Observers/TR3Observer.cs
+++ b/TRLevelControlTests/Base/Observers/TR3Observer.cs
@@ -3,7 +3,24 @@
 public class TR3Observer : TR2Observer
 {
     private readonly Dictionary<int, Tuple<ushort, ushort>> _animLinks = new();
+    private readonly bool _useOriginalFloorData;
     private ushort? _badOverlap;
+    private ushort[] _floorData;
+
+    public TR3Observer(bool useOriginalFD = false)
+    {
+        _useOriginalFloorData = useOriginalFD;
+    }
+
+    public override bool UseOriginalFloorData => _useOriginalFloorData;
+
+    public override void OnFloorDataRead(ushort[] data)
+    {
+        _floorData = data;
+    }
+
+    public override ushort[] GetFloorData() =>
+        _useOriginalFloorData ? _floorData : null;
 
     public override void OnBadAnimLinkRead(int animIndex, ushort animLink, ushort frameLink)
     {

--- a/TRLevelControlTests/Base/Observers/TR4Observer.cs
+++ b/TRLevelControlTests/Base/Observers/TR4Observer.cs
@@ -14,22 +14,9 @@ public class TR4Observer : TR3Observer
     private readonly Dictionary<byte, List<byte>> _flybyIndices = new();
 
     private uint[] _sampleIndices;
-    protected readonly bool _remastered;
-    private ushort[] _floorData;
 
-    public TR4Observer(bool remastered)
-    {
-        _remastered = remastered;
-    }
-
-    public override bool UseOriginalFloorData => _remastered;
-
-    public override void OnFloorDataRead(ushort[] data)
-    {
-        _floorData = data;
-    }
-
-    public override ushort[] GetFloorData() => _floorData;
+    public TR4Observer(bool useOriginalFloorData)
+        : base(useOriginalFloorData) { }
 
     public override void TestOutput(byte[] input, byte[] output)
     {

--- a/TRLevelControlTests/Base/TestBase.cs
+++ b/TRLevelControlTests/Base/TestBase.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text;
 using TRLevelControl;
+using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 
 namespace TRLevelControlTests;
@@ -100,7 +101,8 @@ public class TestBase
                 control2.Write(level2, outputStream);
                 break;
             case TRGameVersion.TR3:
-                observer = new TR3Observer();
+                bool originalFD = UseOriginalTR3FD(levelName, remastered);
+                observer = new TR3Observer(originalFD);
                 TR3LevelControl control3 = new(observer);
                 TR3Level level3 = control3.Read(pathI);
                 control3.Write(level3, outputStream);
@@ -122,6 +124,12 @@ public class TestBase
         }
 
         observer.TestOutput(inputData, outputStream.ToArray());
+    }
+
+    private static bool UseOriginalTR3FD(string levelName, bool remastered)
+    {
+        return levelName == TR3LevelNames.ANTARC
+            || (remastered && (levelName == TR3LevelNames.JUNGLE_CUT || levelName == TR3LevelNames.MADUBU));
     }
 
     public static TR1Level WriteReadTempLevel(TR1Level level)


### PR DESCRIPTION
Resolves #850.

#### Checklist

- [x] I have read the [coding conventions](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have read the [testing guidelines](https://github.com/LostArtefacts/TR-Rando/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] I have added a changelog entry about what my pull request accomplishes, or it is an internal change

#### Description

Ensures FD functions are written in the correct order at write time rather than manually having to manage lists elsewhere. There are three entries in TR3 that fail the tests, where ceiling triangulation comes before floor. We just ignore those.
Also improves ladder handling by ensuring multiple entries are squashed into one, and that null ladders are omitted.
